### PR TITLE
Install headers with autotools

### DIFF
--- a/eosknowledge/Makefile.am.inc
+++ b/eosknowledge/Makefile.am.inc
@@ -68,6 +68,6 @@ libeosknowledge_@EKN_API_VERSION@_la_LDFLAGS = \
 # Public header files
 publicincludedir = $(includedir)/@EKN_API_NAME@
 nobase_publicinclude_HEADERS = \
-	$(endless_public_installed_headers) \
-	$(endless_private_installed_headers) \
+	$(eosknowledge_public_installed_headers) \
+	$(eosknowledge_private_installed_headers) \
 	$(NULL)


### PR DESCRIPTION
A couple of variables were misnamed in a makefile and no headers
were being installed
[endlessm/eos-sdk#825]
