### PR TITLE
Symlink system override file to pkgdatadir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,7 +7,6 @@
 /docs/reference/eosknowledge/version.xml
 /eosknowledge-0.pc
 /eosknowledge/ekn-resource*.[ch]
-/overrides/EosKnowledge.js
 /overrides/config.js
 
 # Autotools/Gettext droppings

--- a/Makefile.am
+++ b/Makefile.am
@@ -46,16 +46,6 @@ distdir:
 	@false
 endif
 
-# General-purpose sed script for replacing installed directory locations. Use
-# this to replace $datadir and friends inside a script, as suggested by the
-# Autoconf manual; because $datadir and friends only work inside Makefiles.
-# If referenced from configure.ac, they may be incorrect or not fully expanded.
-replace_dirs = sed \
-	-e 's|@datadir[@]|$(datadir)|g' \
-	-e 's|@pkgdatadir[@]|$(pkgdatadir)|g' \
-	-e 's|@pkglibdir[@]|$(pkglibdir)|g' \
-	$(NULL)
-
 # # # LIBRARY # # #
 
 # Main library

--- a/configure.ac
+++ b/configure.ac
@@ -92,6 +92,9 @@ AS_ALL_LINGUAS
 # --------------------
 # Make sure we can create directory hierarchies
 AC_PROG_MKDIR_P
+# Make sure we can symlink
+AC_PROG_LN_S
+AS_IF([test "$LN_S" = "ln -s"], [], [AC_MSG_ERROR([Symlink support required.])])
 # C compiler
 AC_PROG_CC
 AC_PROG_CC_C99

--- a/overrides/EosKnowledge.js
+++ b/overrides/EosKnowledge.js
@@ -1,10 +1,11 @@
 const Gio = imports.gi.Gio;
 const Lang = imports.lang;
+const Endless = imports.gi.Endless;
 
 let EosKnowledge;
 
 let _oldSearchPath = imports.searchPath;
-imports.searchPath.unshift('@pkgdatadir@/overrides');
+imports.searchPath.unshift(Endless.getCurrentFileDir());
 
 const Hello = imports.hello;
 const Card = imports.card;

--- a/overrides/Makefile.am.inc
+++ b/overrides/Makefile.am.inc
@@ -3,20 +3,18 @@
 
 overridesdir = $(datadir)/gjs-1.0/overrides
 pkgoverridesdir = $(pkgdatadir)/overrides
-overrides_DATA = overrides/EosKnowledge.js
 dist_pkgoverrides_DATA = \
+	overrides/EosKnowledge.js \
 	overrides/config.js \
 	overrides/hello.js \
 	overrides/card.js \
 	overrides/composite_button.js \
 	$(NULL)
 
-overrides/EosKnowledge.js: overrides/EosKnowledge.js.in
-	$(AM_V_GEN)mkdir -p $(@D) && \
-	rm -f $@ $@.tmp && \
-	$(replace_dirs) $< >$@.tmp && \
-	chmod a-w $@.tmp && \
-	mv $@.tmp $@ \
-	$(NULL)
-CLEANFILES += overrides/EosKnowledge.js
-EXTRA_DIST += overrides/EosKnowledge.js.in
+install-data-hook:
+	rm -f $(overridesdir)/EosKnowledge.js
+	ln -s $(pkgoverridesdir)/EosKnowledge.js \
+		$(overridesdir)/EosKnowledge.js
+
+uninstall-hook:
+	rm -f $(overridesdir)/EosKnowledge.js


### PR DESCRIPTION
This lets us not need to configure our import path, things the js
files locally have the same structure as when they are installed.
And solves a problem where our tests would import the installed
js and not the local js
[endlessm/eos-sdk#873]

So here's my vote for how to handle this. Taking a page out of our updater architecture for apps--All files in a common directory, symlinks from system space to that directory. This lets us keep the same structure in the src tree as the installed tree, and keeps things nice and simple.

Requires https://github.com/endlessm/eos-sdk/pull/876 to work.
