### PR TITLE
Rename source package eos-knowledge-lib

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,4 @@
-eos-knowledge (0.0.0) eos; urgency=low
+eos-knowledge-lib (0.0.0) eos; urgency=low
 
   * Initial release
 

--- a/debian/control
+++ b/debian/control
@@ -1,4 +1,4 @@
-Source: eos-knowledge
+Source: eos-knowledge-lib
 Priority: standard
 Maintainer: Philip Chimento <philip@endlessm.com>
 Build-Depends: autotools-dev,


### PR DESCRIPTION
To make source package name agree with github repo name and jenkins
job name, and fix the jenkins jobs inferred package name
[endlessm/eos-sdk#826]
