### PR TITLE
Symlink to the eventual install location of EosKnowledge.js

### DIFF
--- a/overrides/Makefile.am.inc
+++ b/overrides/Makefile.am.inc
@@ -14,7 +14,7 @@ dist_pkgoverrides_DATA = \
 install-data-hook:
 	$(MKDIR_P) $(DESTDIR)$(overridesdir)
 	rm -f $(DESTDIR)$(overridesdir)/EosKnowledge.js
-	ln -s $(DESTDIR)$(pkgoverridesdir)/EosKnowledge.js \
+	ln -s $(pkgoverridesdir)/EosKnowledge.js \
 		$(DESTDIR)$(overridesdir)/EosKnowledge.js
 
 uninstall-hook:


### PR DESCRIPTION
We were symlinking to the location in DESTDIR, which does not work
for debian packaging tools. I'll get these autotools eventually...
[endlessm/eos-sdk#827]
