### PR TITLE
History model

### DIFF
--- a/docs/reference/eosknowledge/eosknowledge-docs.xml
+++ b/docs/reference/eosknowledge/eosknowledge-docs.xml
@@ -22,6 +22,7 @@
 
   <chapter>
     <title>Model API Reference</title>
+    <xi:include href="xml/history-model.xml"/>
     <xi:include href="xml/history-item-model.xml"/>
   </chapter>
 
@@ -45,6 +46,5 @@
     <xi:include href="xml/api-index-deprecated.xml"><xi:fallback /></xi:include>
   </index>
 
-  <!-- Uncomment when there are annotations used -->
-  <!--<xi:include href="xml/annotation-glossary.xml"><xi:fallback /></xi:include>-->
+  <xi:include href="xml/annotation-glossary.xml"><xi:fallback /></xi:include>
 </book>

--- a/docs/reference/eosknowledge/eosknowledge-sections.txt
+++ b/docs/reference/eosknowledge/eosknowledge-sections.txt
@@ -9,6 +9,34 @@ EKN_ENUM_VALUE
 </SECTION>
 
 <SECTION>
+<FILE>history-model</FILE>
+EknHistoryModel
+EknHistoryModelClass
+ekn_history_model_new
+<SUBSECTION Methods>
+ekn_history_model_clear
+ekn_history_model_get_item
+ekn_history_model_go_back
+ekn_history_model_go_forward
+<SUBSECTION Getters>
+ekn_history_model_get_back_list
+ekn_history_model_get_can_go_back
+ekn_history_model_get_can_go_forward
+ekn_history_model_get_current_item
+ekn_history_model_get_forward_list
+<SUBSECTION Setters>
+ekn_history_model_set_current_item
+<SUBSECTION Standard>
+EKN_HISTORY_MODEL
+EKN_HISTORY_MODEL_CLASS
+EKN_HISTORY_MODEL_GET_CLASS
+EKN_IS_HISTORY_MODEL
+EKN_IS_HISTORY_MODEL_CLASS
+EKN_TYPE_HISTORY_MODEL
+ekn_history_model_get_type
+</SECTION>
+
+<SECTION>
 <FILE>history-item-model</FILE>
 EknHistoryItemModel
 EknHistoryItemModelInterface

--- a/eosknowledge/Makefile.am.inc
+++ b/eosknowledge/Makefile.am.inc
@@ -30,6 +30,7 @@ eosknowledge_private_installed_headers = \
 	eosknowledge/ekn-enums.h \
 	eosknowledge/ekn-hello.h \
 	eosknowledge/ekn-history-item-model.h \
+	eosknowledge/ekn-history-model.h \
 	eosknowledge/ekn-macros.h \
 	eosknowledge/ekn-types.h \
 	eosknowledge/ekn-version.h \
@@ -38,6 +39,7 @@ eosknowledge_private_installed_headers = \
 eosknowledge_library_sources = \
 	eosknowledge/ekn-hello.c \
 	eosknowledge/ekn-history-item-model.c \
+	eosknowledge/ekn-history-model.c \
 	eosknowledge/ekn-init.c eosknowledge/ekn-init-private.h \
 	eosknowledge/ekn-resource.c eosknowledge/ekn-resource-private.h \
 	$(NULL)

--- a/eosknowledge/ekn-history-model.c
+++ b/eosknowledge/ekn-history-model.c
@@ -1,0 +1,582 @@
+/* -*- mode: C; c-file-style: "gnu"; indent-tabs-mode: nil; -*- */
+
+/* Copyright 2014 Endless Mobile, Inc. */
+
+#include "ekn-history-model.h"
+#include "ekn-history-item-model.h"
+
+#include <glib.h>
+
+/**
+ * SECTION:history-model
+ * @short_description: List of pages that a history control keeps track of
+ * @title: History model
+ * @include: eosknowledge/eosknowledge.h
+ *
+ * This model keeps track of "pages" or items that a user visits, in order to
+ * populate a history control such as a browser's back button, or a breadcrumb.
+ *
+ * The most important operation is to set the #EknHistoryModel:current-item
+ * property.
+ * This is used to navigate to a new page.
+ * If the new page's #EknHistoryItemModel is identical to an item model already
+ * in the history model, then it navigates back or forward through the list
+ * instead.
+ * (Note, that means the objects are the same, rather than having their
+ * properties equal.)
+ */
+
+typedef struct
+{
+  GSList *back_list;
+  GSList *forward_list;
+
+  EknHistoryItemModel *current;
+} EknHistoryModelPrivate;
+
+G_DEFINE_TYPE_WITH_PRIVATE (EknHistoryModel, ekn_history_model, G_TYPE_OBJECT);
+
+enum {
+  PROP_0,
+  PROP_CAN_GO_BACK,
+  PROP_CAN_GO_FORWARD,
+  PROP_CURRENT_ITEM,
+  PROP_BACK_LIST,
+  PROP_FORWARD_LIST,
+  NPROPS
+};
+
+static GParamSpec *ekn_history_model_props[NPROPS] = { NULL, };
+
+static void
+ekn_history_model_get_property (GObject    *object,
+                                guint       property_id,
+                                GValue     *value,
+                                GParamSpec *pspec)
+{
+  EknHistoryModel *self = EKN_HISTORY_MODEL (object);
+  switch (property_id)
+    {
+    case PROP_CAN_GO_BACK:
+      g_value_set_boolean (value, ekn_history_model_get_can_go_back (self));
+      break;
+
+    case PROP_CAN_GO_FORWARD:
+      g_value_set_boolean (value, ekn_history_model_get_can_go_forward (self));
+      break;
+
+    case PROP_CURRENT_ITEM:
+      g_value_set_object (value, ekn_history_model_get_current_item (self));
+      break;
+
+    case PROP_BACK_LIST:
+      g_value_set_pointer (value, ekn_history_model_get_back_list (self));
+      break;
+
+    case PROP_FORWARD_LIST:
+      g_value_set_pointer (value, ekn_history_model_get_forward_list (self));
+      break;
+
+    default:
+      G_OBJECT_WARN_INVALID_PROPERTY_ID (object, property_id, pspec);
+    }
+}
+
+static void
+ekn_history_model_set_property (GObject      *object,
+                                guint         property_id,
+                                const GValue *value,
+                                GParamSpec   *pspec)
+{
+  EknHistoryModel *self = EKN_HISTORY_MODEL (object);
+  switch (property_id)
+    {
+    case PROP_CURRENT_ITEM:
+      ekn_history_model_set_current_item (self, g_value_get_object (value));
+      break;
+
+    default:
+      G_OBJECT_WARN_INVALID_PROPERTY_ID (object, property_id, pspec);
+    }
+}
+
+/* Unref a list of GObjects and make it NULL (the empty list) */
+static void
+clear_list (GSList **listp)
+{
+  g_slist_free_full (*listp, g_object_unref);
+  *listp = NULL;
+}
+
+static void
+ekn_history_model_dispose (GObject *object)
+{
+  EknHistoryModel *self = EKN_HISTORY_MODEL (object);
+  EknHistoryModelPrivate *priv = ekn_history_model_get_instance_private (self);
+
+  g_clear_object (&priv->current);
+  clear_list (&priv->back_list);
+  clear_list (&priv->forward_list);
+
+  G_OBJECT_CLASS (ekn_history_model_parent_class)->dispose (object);
+}
+
+static void
+ekn_history_model_class_init (EknHistoryModelClass *klass)
+{
+  GObjectClass *object_class = G_OBJECT_CLASS (klass);
+  object_class->get_property = ekn_history_model_get_property;
+  object_class->set_property = ekn_history_model_set_property;
+  object_class->dispose = ekn_history_model_dispose;
+
+  /**
+   * EknHistoryModel:can-go-back:
+   *
+   * %TRUE if there are any pages to go back to.
+   * This property and #EknHistoryModel:can-go-forward can be bound to the
+   * #GtkWidget:sensitive property of a back or forward button, for example.
+   */
+  ekn_history_model_props[PROP_CAN_GO_BACK] =
+    g_param_spec_boolean ("can-go-back", "Can go back",
+                          "Whether there is a previous item to navigate backwards to",
+                          FALSE,
+                          G_PARAM_READABLE | G_PARAM_STATIC_STRINGS);
+
+  /**
+   * EknHistoryModel:can-go-forward:
+   *
+   * %TRUE if there are any pages to go forward to.
+   * See also #EknHistoryModel:can-go-back.
+   */
+  ekn_history_model_props[PROP_CAN_GO_FORWARD] =
+    g_param_spec_boolean ("can-go-forward", "Can go forward",
+                          "Whether there is a next item to navigate forwards to",
+                          FALSE,
+                          G_PARAM_READABLE | G_PARAM_STATIC_STRINGS);
+
+  /**
+   * EknHistoryModel:current-item:
+   *
+   * The #EknHistoryItemModel for the page currently displaying.
+   * Users of this API can listen to changes on this property using
+   * #GObject::notify and update their views accordingly.
+   *
+   * Setting this property navigates to a new page.
+   * If the given item model is in the back or forward list (that is, the same
+   * object), navigates back or forward until that item is the current item.
+   * If the given item model is not in the back or forward list (even if another
+   * item model with the same content is!), this sets the given item model to be
+   * the current item, moves the old value of the current item to the back list,
+   * and clears the forward list.
+   *
+   * Although %NULL is the initial value as with all object-type properties, it
+   * is not valid to set this property to %NULL.
+   * It is up to you to determine what a %NULL value for this property means, in
+   * terms of user interface.
+   */
+  ekn_history_model_props[PROP_CURRENT_ITEM] =
+    g_param_spec_object ("current-item", "Current item",
+                         "The current item that has been navigated to",
+                         G_TYPE_OBJECT,
+                         G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS);
+
+  /* This doc comment won't show up in the documentation, because Gtk-Doc
+  doesn't parse the annotation. Instead you will see the property blurb. See
+  bug: https://bugzilla.gnome.org/show_bug.cgi?id=727778 */
+  /**
+   * EknHistoryModel:back-list: (type GSList(EknHistoryItemModel)):
+   *
+   * List of #EknHistoryItemModel objects representing pages that can be
+   * navigated backwards to.
+   *
+   * > ## Note ##
+   * > This property has a pointer type, but it refers to a #GList with
+   * > #EknHistoryItemModel objects in its @data fields.
+   */
+  ekn_history_model_props[PROP_BACK_LIST] =
+    g_param_spec_pointer ("back-list", "Back list",
+                          "List of items that can be navigated backwards to",
+                          G_PARAM_READABLE | G_PARAM_STATIC_STRINGS);
+
+  /* See comment on :back-list above */
+  /**
+   * EknHistoryModel:forward-list: (type GSList(EknHistoryItemModel)):
+   *
+   * List of #EknHistoryItemModel objects representing pages that can be
+   * navigated forwards to.
+   *
+   * > ## Note ##
+   * > This property has a pointer type, but it refers to a #GList with
+   * > #EknHistoryItemModel objects in its @data fields.
+   */
+  ekn_history_model_props[PROP_FORWARD_LIST] =
+    g_param_spec_pointer ("forward-list", "Forward list",
+                          "List of items that can be navigated forwards to",
+                          G_PARAM_READABLE | G_PARAM_STATIC_STRINGS);
+
+  g_object_class_install_properties (object_class, NPROPS,
+                                     ekn_history_model_props);
+}
+
+static void
+ekn_history_model_init (EknHistoryModel *self)
+{
+}
+
+/* Helper function: navigate backwards by n steps, used internally in both
+go_back() and set_current_item() */
+static void
+go_back_n_steps (EknHistoryModel *self,
+                 gint             nsteps)
+{
+  EknHistoryModelPrivate *priv = ekn_history_model_get_instance_private (self);
+  gboolean could_go_forward = ekn_history_model_get_can_go_forward (self);
+
+  priv->forward_list = g_slist_prepend (priv->forward_list, priv->current);
+  for (; nsteps > 1; nsteps--)
+    {
+      EknHistoryItemModel *to_move = priv->back_list->data;
+      priv->back_list = g_slist_remove_link (priv->back_list, priv->back_list);
+      priv->forward_list = g_slist_prepend (priv->forward_list, to_move);
+    }
+  priv->current = priv->back_list->data;
+  priv->back_list = g_slist_remove_link (priv->back_list, priv->back_list);
+
+  if (!ekn_history_model_get_can_go_back (self))
+    g_object_notify (G_OBJECT (self), "can-go-back");
+  if (!could_go_forward)
+    g_object_notify (G_OBJECT (self), "can-go-forward");
+  g_object_notify (G_OBJECT (self), "back-list");
+  g_object_notify (G_OBJECT (self), "forward-list");
+  g_object_notify (G_OBJECT (self), "current-item");
+}
+
+/* Helper function: navigate forwards by n steps, used internally in both
+go_forward() and set_current_item() */
+static void
+go_forward_n_steps (EknHistoryModel *self,
+                    gint             nsteps)
+{
+  EknHistoryModelPrivate *priv = ekn_history_model_get_instance_private (self);
+  gboolean could_go_back = ekn_history_model_get_can_go_back (self);
+
+  priv->back_list = g_slist_prepend (priv->back_list, priv->current);
+  for (; nsteps > 1; nsteps--)
+    {
+      EknHistoryItemModel *to_move = priv->forward_list->data;
+      priv->forward_list = g_slist_remove_link (priv->forward_list,
+                                                priv->forward_list);
+      priv->back_list = g_slist_prepend (priv->back_list, to_move);
+    }
+  priv->current = priv->forward_list->data;
+  priv->forward_list = g_slist_remove_link (priv->forward_list,
+                                            priv->forward_list);
+
+  if (!could_go_back)
+    g_object_notify (G_OBJECT (self), "can-go-back");
+  if (!ekn_history_model_get_can_go_forward (self))
+    g_object_notify (G_OBJECT (self), "can-go-forward");
+  g_object_notify (G_OBJECT (self), "back-list");
+  g_object_notify (G_OBJECT (self), "forward-list");
+  g_object_notify (G_OBJECT (self), "current-item");
+}
+
+/* PUBLIC API */
+
+/**
+ * ekn_history_model_new:
+ *
+ * Convenience API for creating a new #EknHistoryModel in C.
+ * The new object's state is equal to just having called
+ * ekn_history_model_clear() on an existing #EknHistoryModel.
+ *
+ * Returns: (transfer full): the newly created history model.
+ */
+EknHistoryModel *
+ekn_history_model_new (void)
+{
+  return g_object_new (EKN_TYPE_HISTORY_MODEL, NULL);
+}
+
+/**
+ * ekn_history_model_clear:
+ * @self: the history model
+ *
+ * Removes all item models from the history model, and sets the
+ * #EknHistoryModel:current-item to %NULL.
+ */
+void
+ekn_history_model_clear (EknHistoryModel *self)
+{
+  g_return_if_fail (self != NULL && EKN_IS_HISTORY_MODEL (self));
+
+  EknHistoryModelPrivate *priv = ekn_history_model_get_instance_private (self);
+
+  if (priv->current == NULL)
+    return;
+
+  gboolean could_go_back = ekn_history_model_get_can_go_back (self);
+  gboolean could_go_forward = ekn_history_model_get_can_go_forward (self);
+
+  clear_list (&priv->back_list);
+  clear_list (&priv->forward_list);
+  g_clear_object (&priv->current);
+
+  if (could_go_back)
+    {
+      g_object_notify (G_OBJECT (self), "can-go-back");
+      g_object_notify (G_OBJECT (self), "back-list");
+    }
+  if (could_go_forward)
+    {
+      g_object_notify (G_OBJECT (self), "can-go-forward");
+      g_object_notify (G_OBJECT (self), "forward-list");
+    }
+  g_object_notify (G_OBJECT (self), "current-item");
+}
+
+/**
+ * ekn_history_model_go_back:
+ * @self: the history model
+ *
+ * Navigates backwards by one step, to the previous page in the history.
+ * That is, the most recent item from the #EknHistoryModel:back-list becomes the
+ * #EknHistoryModel:current-item, and the #EknHistoryModel:current-item is added
+ * to the #EknHistoryModel:forward-list.
+ *
+ * It is an error to call this method if the value of
+ * #EknHistoryModel:can-go-back is %FALSE.
+ * It is also an error to call this method if the #EknHistoryModel:current-item
+ * is set to %NULL.
+ */
+void
+ekn_history_model_go_back (EknHistoryModel *self)
+{
+  g_return_if_fail (self != NULL && EKN_IS_HISTORY_MODEL (self));
+  g_return_if_fail (ekn_history_model_get_can_go_back (self));
+
+  EknHistoryModelPrivate *priv = ekn_history_model_get_instance_private (self);
+
+  g_return_if_fail (priv->current != NULL);
+
+  go_back_n_steps (self, 1);
+}
+
+/**
+ * ekn_history_model_go_forward:
+ * @self: the history model
+ *
+ * Navigates forwards by one step, to the previous page in the history.
+ * That is, the earliest item from the #EknHistoryModel:forward-list becomes the
+ * #EknHistoryModel:current-item, and the #EknHistoryModel:current-item is added
+ * to the #EknHistoryModel:back-list.
+ *
+ * It is an error to call this method if the value of
+ * #EknHistoryModel:can-go-forward is %FALSE.
+ * It is also an error to call this method if the #EknHistoryModel:current-item
+ * is set to %NULL.
+ */
+void
+ekn_history_model_go_forward (EknHistoryModel *self)
+{
+  g_return_if_fail (self != NULL && EKN_IS_HISTORY_MODEL (self));
+  g_return_if_fail (ekn_history_model_get_can_go_forward (self));
+
+  EknHistoryModelPrivate *priv = ekn_history_model_get_instance_private (self);
+
+  g_return_if_fail (priv->current != NULL);
+
+  go_forward_n_steps (self, 1);
+}
+
+/**
+ * ekn_history_model_get_item:
+ * @self: the history model
+ * @index: index of the item to get; 0 for current, negative for back, or
+ * positive for forward.
+ *
+ * Retrieves a history model item from the history model.
+ * The @index is relative to the current item; negative for going backwards, or
+ * positive for going forwards.
+ *
+ * You can set the #EknHistoryModel:current-item property to the item retrieved
+ * with this function in order to navigate forwards or backwards by more than
+ * one step.
+ *
+ * Returns: (transfer none): the requested #EknHistoryItemModel.
+ * This object is owned by the #EknHistoryModel and should not be freed.
+ */
+EknHistoryItemModel *
+ekn_history_model_get_item (EknHistoryModel *self,
+                            gint             index)
+{
+  g_return_val_if_fail (self != NULL && EKN_IS_HISTORY_MODEL (self), NULL);
+
+  EknHistoryModelPrivate *priv = ekn_history_model_get_instance_private (self);
+
+  /* g_slist_nth_data() returns NULL if the index is off the end of the list, so
+  we don't need to check that here */
+
+  if (index == 0)
+    return priv->current;
+  if (index < 0)
+    return g_slist_nth_data (priv->back_list, -index - 1);
+  return g_slist_nth_data (priv->forward_list, index - 1);
+}
+
+/**
+ * ekn_history_model_get_back_list:
+ * @self: the history model
+ *
+ * Retrieves the list of pages that can be navigated backwards to.
+ * See #EknHistoryModel:back-list.
+ *
+ * The list may be empty, which for a #GSList is equivalent to returning %NULL.
+ *
+ * Returns: (transfer container) (element-type EknHistoryItemModel): a list of
+ * #EknHistoryItemModel objects.
+ * The item models are owned by #EknHistoryModel.
+ * Do not free them.
+ */
+GSList *
+ekn_history_model_get_back_list (EknHistoryModel *self)
+{
+  g_return_val_if_fail (self != NULL && EKN_IS_HISTORY_MODEL (self), NULL);
+
+  EknHistoryModelPrivate *priv = ekn_history_model_get_instance_private (self);
+  return g_slist_copy (priv->back_list);
+}
+
+/**
+ * ekn_history_model_get_forward_list:
+ * @self: the history model
+ *
+ * Retrieves the list of pages that can be navigated forwards to.
+ * See #EknHistoryModel:forward-list.
+ *
+ * The list may be empty, which for a #GSList is equivalent to returning %NULL.
+ *
+ * Returns: (transfer container) (element-type EknHistoryItemModel): a list of
+ * #EknHistoryItemModel objects.
+ * The item models are owned by #EknHistoryModel.
+ * Do not free them.
+ */
+GSList *
+ekn_history_model_get_forward_list (EknHistoryModel *self)
+{
+  g_return_val_if_fail (self != NULL && EKN_IS_HISTORY_MODEL (self), NULL);
+
+  EknHistoryModelPrivate *priv = ekn_history_model_get_instance_private (self);
+  return g_slist_copy (priv->forward_list);
+}
+
+/**
+ * ekn_history_model_get_can_go_back:
+ * @self: the history model
+ *
+ * See #EknHistoryModel:can-go-back.
+ *
+ * Returns: %TRUE if there are any pages to go back to, %FALSE otherwise.
+ */
+gboolean
+ekn_history_model_get_can_go_back (EknHistoryModel *self)
+{
+  g_return_val_if_fail (self != NULL && EKN_IS_HISTORY_MODEL (self), FALSE);
+
+  EknHistoryModelPrivate *priv = ekn_history_model_get_instance_private (self);
+  return priv->back_list != NULL;
+}
+
+/**
+ * ekn_history_model_get_can_go_forward:
+ * @self: the history model
+ *
+ * See #EknHistoryModel:can-go-forward.
+ *
+ * Returns: %TRUE if there are any pages to go forward to, %FALSE otherwise.
+ */
+gboolean
+ekn_history_model_get_can_go_forward (EknHistoryModel *self)
+{
+  g_return_val_if_fail (self != NULL && EKN_IS_HISTORY_MODEL (self), FALSE);
+
+  EknHistoryModelPrivate *priv = ekn_history_model_get_instance_private (self);
+  return priv->forward_list != NULL;
+}
+
+/**
+ * ekn_history_model_get_current_item:
+ * @self: the history model
+ *
+ * See #EknHistoryModel:current-item.
+ *
+ * Returns: (allow-none) (transfer none): the #EknHistoryItemModel object
+ * representing the page that is currently being viewed, or %NULL if there is
+ * none.
+ */
+EknHistoryItemModel *
+ekn_history_model_get_current_item (EknHistoryModel *self)
+{
+  g_return_val_if_fail (self != NULL && EKN_IS_HISTORY_MODEL (self), NULL);
+
+  EknHistoryModelPrivate *priv = ekn_history_model_get_instance_private (self);
+  return priv->current;
+}
+
+/**
+ * ekn_history_model_set_current_item:
+ * @self: the history model
+ * @item: an #EknHistoryItemModel object representing a page to navigate to.
+ *
+ * See #EknHistoryModel:current-item.
+ */
+void
+ekn_history_model_set_current_item (EknHistoryModel     *self,
+                                    EknHistoryItemModel *item)
+{
+  g_return_if_fail (self != NULL && EKN_IS_HISTORY_MODEL (self));
+  g_return_if_fail (item != NULL && EKN_IS_HISTORY_ITEM_MODEL (item));
+
+  EknHistoryModelPrivate *priv = ekn_history_model_get_instance_private (self);
+
+  if (item == priv->current)
+    return;
+
+  gboolean could_go_back = ekn_history_model_get_can_go_back (self);
+  gboolean could_go_forward = ekn_history_model_get_can_go_forward (self);
+  gint index;
+
+  /* If the item model is already in the back list, jump backwards */
+  if (could_go_back && (index = g_slist_index (priv->back_list, item)) != -1)
+    {
+      go_back_n_steps (self, index + 1);
+      return;
+    }
+
+  /* If the item model is already in the forward list, jump forwards */
+  if (could_go_forward
+      && (index = g_slist_index (priv->forward_list, item)) != -1)
+    {
+      go_forward_n_steps (self, index + 1);
+      return;
+    }
+
+  /* It's a new item model, so navigate to it and clear the forward list */
+  if (priv->current != NULL)
+    {
+      priv->back_list = g_slist_prepend (priv->back_list, priv->current);
+      if (!could_go_back)
+        g_object_notify (G_OBJECT (self), "can-go-back");
+      g_object_notify (G_OBJECT (self), "back-list");
+    }
+  priv->current = g_object_ref (item);
+
+  clear_list (&priv->forward_list);
+  if (could_go_forward)
+    {
+      g_object_notify (G_OBJECT (self), "can-go-forward");
+      g_object_notify (G_OBJECT (self), "forward-list");
+    }
+
+  g_object_notify (G_OBJECT (self), "current-item");
+}

--- a/eosknowledge/ekn-history-model.h
+++ b/eosknowledge/ekn-history-model.h
@@ -1,0 +1,107 @@
+/* -*- mode: C; c-file-style: "gnu"; indent-tabs-mode: nil; -*- */
+
+/* Copyright 2014 Endless Mobile, Inc. */
+
+#ifndef EKN_HISTORY_MODEL_H
+#define EKN_HISTORY_MODEL_H
+
+#if !(defined(_EKN_INSIDE_EOSKNOWLEDGE_H) || defined(COMPILING_EOS_KNOWLEDGE))
+#error "Please do not include this header file directly."
+#endif
+
+#include "ekn-types.h"
+#include "ekn-history-item-model.h"
+
+#include <glib-object.h>
+#include <gio/gio.h>
+
+G_BEGIN_DECLS
+
+#define EKN_TYPE_HISTORY_MODEL ekn_history_model_get_type()
+
+#define EKN_HISTORY_MODEL(obj) \
+  (G_TYPE_CHECK_INSTANCE_CAST ((obj), \
+  EKN_TYPE_HISTORY_MODEL, EknHistoryModel))
+
+#define EKN_HISTORY_MODEL_CLASS(klass) \
+  (G_TYPE_CHECK_CLASS_CAST ((klass), \
+  EKN_TYPE_HISTORY_MODEL, EknHistoryModelClass))
+
+#define EKN_IS_HISTORY_MODEL(obj) \
+  (G_TYPE_CHECK_INSTANCE_TYPE ((obj), \
+  EKN_TYPE_HISTORY_MODEL))
+
+#define EKN_IS_HISTORY_MODEL_CLASS(klass) \
+  (G_TYPE_CHECK_CLASS_TYPE ((klass), \
+  EKN_TYPE_HISTORY_MODEL))
+
+#define EKN_HISTORY_MODEL_GET_CLASS(obj) \
+  (G_TYPE_INSTANCE_GET_CLASS ((obj), \
+  EKN_TYPE_HISTORY_MODEL, EknHistoryModelClass))
+
+/**
+ * EknHistoryModel:
+ *
+ * This instance structure contains no public members.
+ */
+typedef struct _EknHistoryModel EknHistoryModel;
+/**
+ * EknHistoryModelClass:
+ *
+ * This class structure contains no public members.
+ */
+typedef struct _EknHistoryModelClass EknHistoryModelClass;
+
+struct _EknHistoryModel
+{
+  /*< private >*/
+  GObject parent;
+};
+
+struct _EknHistoryModelClass
+{
+  /*< private >*/
+  GObjectClass parent_class;
+};
+
+EKN_ALL_API_VERSIONS
+GType                ekn_history_model_get_type           (void) G_GNUC_CONST;
+
+EKN_ALL_API_VERSIONS
+EknHistoryModel     *ekn_history_model_new                (void);
+
+EKN_ALL_API_VERSIONS
+void                 ekn_history_model_clear              (EknHistoryModel     *self);
+
+EKN_ALL_API_VERSIONS
+void                 ekn_history_model_go_back            (EknHistoryModel     *self);
+
+EKN_ALL_API_VERSIONS
+void                 ekn_history_model_go_forward         (EknHistoryModel     *self);
+
+EKN_ALL_API_VERSIONS
+EknHistoryItemModel *ekn_history_model_get_item           (EknHistoryModel     *self,
+                                                           gint                 index);
+
+EKN_ALL_API_VERSIONS
+GSList              *ekn_history_model_get_back_list      (EknHistoryModel     *self);
+
+EKN_ALL_API_VERSIONS
+GSList              *ekn_history_model_get_forward_list   (EknHistoryModel     *self);
+
+EKN_ALL_API_VERSIONS
+gboolean             ekn_history_model_get_can_go_back    (EknHistoryModel     *self);
+
+EKN_ALL_API_VERSIONS
+gboolean             ekn_history_model_get_can_go_forward (EknHistoryModel     *self);
+
+EKN_ALL_API_VERSIONS
+EknHistoryItemModel *ekn_history_model_get_current_item   (EknHistoryModel     *self);
+
+EKN_ALL_API_VERSIONS
+void                 ekn_history_model_set_current_item   (EknHistoryModel     *self,
+                                                           EknHistoryItemModel *item);
+
+G_END_DECLS
+
+#endif /* EKN_HISTORY_MODEL_H */

--- a/overrides/EosKnowledge.js
+++ b/overrides/EosKnowledge.js
@@ -23,6 +23,34 @@ function _init() {
     // here we force the C lib to be initialized along with it its gresource
     this.hello_c;
 
+    // More hackzors. Work around bug where GList-type properties aren't
+    // converted properly into JS values.
+    // https://bugzilla.gnome.org/show_bug.cgi?id=727787
+    Object.defineProperties(EosKnowledge.HistoryModel.prototype, {
+        'back-list': {
+            get: EosKnowledge.HistoryModel.prototype.get_back_list
+        },
+        'forward-list': {
+            get: EosKnowledge.HistoryModel.prototype.get_forward_list
+        },
+        // Once again with underscores, because that's the most used name to
+        // access properties with
+        'back_list': {
+            get: EosKnowledge.HistoryModel.prototype.get_back_list
+        },
+        'forward_list': {
+            get: EosKnowledge.HistoryModel.prototype.get_forward_list
+        },
+        // Once again in camelCaps, because GJS supports that notation too for
+        // properties
+        'backList': {
+            get: EosKnowledge.HistoryModel.prototype.get_back_list
+        },
+        'forwardList': {
+            get: EosKnowledge.HistoryModel.prototype.get_forward_list
+        }
+    });
+
     let modulesToImport = [ArticleCard, Card, LessonCard, ListCard];
     modulesToImport.forEach(function (module) {
         // Inject the EosKnowledge module into the module being imported, to

--- a/tests/Makefile.am.inc
+++ b/tests/Makefile.am.inc
@@ -6,6 +6,7 @@ javascript_tests = \
 	tests/eosknowledge/testCard.js \
 	tests/eosknowledge/testHello.js \
 	tests/eosknowledge/testHistoryItemModel.js \
+	tests/eosknowledge/testHistoryModel.js \
 	tests/eosknowledge/testLessonCard.js \
 	tests/eosknowledge/testListCard.js \
 	$(NULL)

--- a/tests/eosknowledge/testHistoryModel.js
+++ b/tests/eosknowledge/testHistoryModel.js
@@ -1,0 +1,350 @@
+// Copyright 2014 Endless Mobile, Inc.
+
+const GObject = imports.gi.GObject;
+const Lang = imports.lang;
+
+const EosKnowledge = imports.gi.EosKnowledge;
+
+GObject.ParamFlags.READWRITE = GObject.ParamFlags.READABLE | GObject.ParamFlags.WRITABLE;
+
+const MockItemModel = new Lang.Class({
+    Name: 'MockItemModel',
+    Extends: GObject.Object,
+    Implements: [ EosKnowledge.HistoryItemModel ],
+    Properties: {
+        // FIXME this property should not be here, but it is required because
+        // you cannot override interface-defined properties in GJS (yet).
+        // https://bugzilla.gnome.org/show_bug.cgi?id=727368
+        'title': GObject.ParamSpec.string('title', 'override', 'override',
+            GObject.ParamFlags.READWRITE | GObject.ParamFlags.CONSTRUCT_ONLY,
+            '')
+    },
+
+    // for debugging test results
+    toString: function () {
+        return '[Mock item model: "' + this.title + '"]';
+    }
+});
+
+describe('History model', function () {
+    let model, notify;
+
+    let SOUR_CREAM = { title: 'Sour Cream '};
+    let POTATOES = { title: 'Potatoes' };
+    let CHIVES = { title: 'Chives' };
+    let BUTTER = { title: 'Butter' };
+    let BACON = { title: 'Bacon' };
+    let SALT = { title: 'Salt' };
+    let ANY = jasmine.any(Object);
+
+    beforeEach(function () {
+        model = new EosKnowledge.HistoryModel();
+
+        notify = jasmine.createSpy('notify');
+        model.connect('notify', function (object, pspec) {
+            notify(pspec.name, object[pspec.name]);
+        });
+    });
+
+    it('navigates to a page', function () {
+        model.current_item = new MockItemModel(POTATOES);
+        expect(model.current_item).toEqual(jasmine.objectContaining(POTATOES));
+    });
+
+    it('notifies when navigating to a page from empty', function () {
+        model.current_item = new MockItemModel(SOUR_CREAM);
+
+        expect(notify).toHaveBeenCalledWith('current-item',
+            jasmine.objectContaining(SOUR_CREAM));
+        expect(notify).not.toHaveBeenCalledWith('can-go-back', ANY);
+        expect(notify).not.toHaveBeenCalledWith('can-go-forward', ANY);
+        expect(notify).not.toHaveBeenCalledWith('back-list', ANY);
+        expect(notify).not.toHaveBeenCalledWith('forward-list', ANY);
+    });
+
+    it('notifies when navigating to a page from another page', function () {
+        model.current_item = new MockItemModel(SOUR_CREAM);
+        notify.calls.reset();
+        model.current_item = new MockItemModel(POTATOES);
+
+        expect(notify).toHaveBeenCalledWith('current-item',
+            jasmine.objectContaining(POTATOES));
+        expect(notify).toHaveBeenCalledWith('can-go-back', true);
+        expect(notify).not.toHaveBeenCalledWith('can-go-forward', ANY);
+        expect(notify).toHaveBeenCalledWith('back-list', [
+            jasmine.objectContaining(SOUR_CREAM)
+        ]);
+        expect(notify).not.toHaveBeenCalledWith('forward-list', ANY);
+    });
+
+    describe('with items', function () {
+        beforeEach(function () {
+            // Populate model
+            [SOUR_CREAM, POTATOES, CHIVES, BUTTER, BACON].forEach(function (item) {
+                model.current_item = new MockItemModel(item);
+            });
+            // Go back to the middle
+            model.current_item = model.get_item(-2);
+            notify.calls.reset();
+        });
+
+        it('has the correct state', function () {
+            expect(model.current_item).toEqual(jasmine.objectContaining(CHIVES));
+            expect(model.back_list).toEqual([
+                jasmine.objectContaining(POTATOES),
+                jasmine.objectContaining(SOUR_CREAM)
+            ]);
+            expect(model.forward_list).toEqual([
+                jasmine.objectContaining(BUTTER),
+                jasmine.objectContaining(BACON)
+            ]);
+        });
+
+        it('clears to an empty state', function () {
+            model.clear();
+
+            expect(model.current_item).toBeNull();
+            expect(model.back_list).toEqual([]);
+            expect(model.forward_list).toEqual([]);
+        });
+
+        it('notifies when clearing', function () {
+            model.clear();
+
+            expect(notify).toHaveBeenCalledWith('current-item', null);
+            expect(notify).toHaveBeenCalledWith('can-go-back', false);
+            expect(notify).toHaveBeenCalledWith('can-go-forward', false);
+            expect(notify).toHaveBeenCalledWith('back-list', []);
+            expect(notify).toHaveBeenCalledWith('forward-list', []);
+        });
+
+        it('does not notify when clearing from empty state', function () {
+            model.clear();
+            notify.calls.reset();
+            model.clear();
+
+            expect(notify).not.toHaveBeenCalled();
+        });
+
+        it('navigates to the correct state', function () {
+            model.current_item = new MockItemModel(SALT);
+
+            expect(model.current_item).toEqual(jasmine.objectContaining(SALT));
+            expect(model.back_list).toEqual([
+                jasmine.objectContaining(CHIVES),
+                jasmine.objectContaining(POTATOES),
+                jasmine.objectContaining(SOUR_CREAM)
+            ]);
+            expect(model.forward_list).toEqual([]);
+        });
+
+        it('notifies when navigating', function () {
+            model.current_item = new MockItemModel(SALT);
+
+            expect(notify).toHaveBeenCalledWith('current-item', ANY);
+            expect(notify).not.toHaveBeenCalledWith('can-go-back', ANY);
+            expect(notify).toHaveBeenCalledWith('can-go-forward', false);
+            expect(notify).toHaveBeenCalledWith('back-list', ANY);
+            expect(notify).toHaveBeenCalledWith('forward-list', ANY);
+        });
+
+        it('navigates backwards to the correct state', function () {
+            model.go_back();
+
+            expect(model.current_item).toEqual(jasmine.objectContaining(POTATOES));
+            expect(model.back_list).toEqual([
+                jasmine.objectContaining(SOUR_CREAM)
+            ]);
+            expect(model.forward_list).toEqual([
+                jasmine.objectContaining(CHIVES),
+                jasmine.objectContaining(BUTTER),
+                jasmine.objectContaining(BACON)
+            ]);
+        });
+
+        it('notifies when navigating backwards', function () {
+            model.go_back();
+
+            // In all the notify tests, the values of the current-item,
+            // back-list and forward-list properties have already been checked
+            // in the corresponding functionality test
+            expect(notify).toHaveBeenCalledWith('current-item', ANY);
+            expect(notify).not.toHaveBeenCalledWith('can-go-back', ANY);
+            expect(notify).not.toHaveBeenCalledWith('can-go-forward', ANY);
+            expect(notify).toHaveBeenCalledWith('back-list', ANY);
+            expect(notify).toHaveBeenCalledWith('forward-list', ANY);
+        });
+
+        it('navigates forwards to the correct state', function () {
+            model.go_forward();
+            expect(model.current_item).toEqual(jasmine.objectContaining(BUTTER));
+            expect(model.back_list).toEqual([
+                jasmine.objectContaining(CHIVES),
+                jasmine.objectContaining(POTATOES),
+                jasmine.objectContaining(SOUR_CREAM)
+            ]);
+            expect(model.forward_list).toEqual([
+                jasmine.objectContaining(BACON)
+            ]);
+        });
+
+        it('notifies when navigating forwards', function () {
+            model.go_forward();
+
+            expect(notify).toHaveBeenCalledWith('current-item', ANY);
+            expect(notify).not.toHaveBeenCalledWith('can-go-back', ANY);
+            expect(notify).not.toHaveBeenCalledWith('can-go-forward', ANY);
+            expect(notify).toHaveBeenCalledWith('back-list', ANY);
+            expect(notify).toHaveBeenCalledWith('forward-list', ANY);
+        });
+
+        it('jumps to what is already the current item', function () {
+            let current_item = model.current_item;
+            let back_list = model.back_list;
+            let forward_list = model.forward_list;
+
+            model.current_item = model.get_item(0);
+
+            expect(model.current_item).toEqual(current_item);
+            expect(model.back_list).toEqual(back_list);
+            expect(model.forward_list).toEqual(forward_list);
+        });
+
+        it('does not notify when jumping to the current item', function () {
+            // use the C setter function here, because GJS throws in an extra
+            // 'notify' for good measure when you use the property setter.
+            model.set_current_item(model.get_item(0));
+            expect(notify).not.toHaveBeenCalled();
+        });
+
+        it('jumps backwards one step to the correct state', function () {
+            model.current_item = model.get_item(-1);
+
+            expect(model.current_item).toEqual(jasmine.objectContaining(POTATOES));
+            expect(model.back_list).toEqual([
+                jasmine.objectContaining(SOUR_CREAM)
+            ]);
+            expect(model.forward_list).toEqual([
+                jasmine.objectContaining(CHIVES),
+                jasmine.objectContaining(BUTTER),
+                jasmine.objectContaining(BACON)
+            ]);
+        });
+
+        it('notifies when jumping backwards one step', function () {
+            model.current_item = model.get_item(-1);
+
+            expect(notify).toHaveBeenCalledWith('current-item', ANY);
+            expect(notify).not.toHaveBeenCalledWith('can-go-back', ANY);
+            expect(notify).not.toHaveBeenCalledWith('can-go-forward', ANY);
+            expect(notify).toHaveBeenCalledWith('back-list', ANY);
+            expect(notify).toHaveBeenCalledWith('forward-list', ANY);
+        });
+
+        it('jumps backwards more than one step to the correct state', function () {
+            model.current_item = model.get_item(-2);
+
+            expect(model.current_item).toEqual(jasmine.objectContaining(SOUR_CREAM));
+            expect(model.back_list).toEqual([]);
+            expect(model.forward_list).toEqual([
+                jasmine.objectContaining(POTATOES),
+                jasmine.objectContaining(CHIVES),
+                jasmine.objectContaining(BUTTER),
+                jasmine.objectContaining(BACON)
+            ]);
+        });
+
+        it('notifies when jumping backwards more than one step', function () {
+            model.current_item = model.get_item(-2);
+
+            expect(notify).toHaveBeenCalledWith('current-item', ANY);
+            expect(notify).toHaveBeenCalledWith('back-list', ANY);
+            expect(notify).toHaveBeenCalledWith('forward-list', ANY);
+        });
+
+        it('jumps forwards one step to the correct state', function () {
+            model.current_item = model.get_item(+1);
+
+            expect(model.current_item).toEqual(jasmine.objectContaining(BUTTER));
+            expect(model.back_list).toEqual([
+                jasmine.objectContaining(CHIVES),
+                jasmine.objectContaining(POTATOES),
+                jasmine.objectContaining(SOUR_CREAM)
+            ]);
+            expect(model.forward_list).toEqual([
+                jasmine.objectContaining(BACON)
+            ]);
+        });
+
+        it('notifies when jumping forwards one step', function () {
+            model.current_item = model.get_item(+1);
+
+            expect(notify).toHaveBeenCalledWith('current-item', ANY);
+            expect(notify).not.toHaveBeenCalledWith('can-go-back', ANY);
+            expect(notify).not.toHaveBeenCalledWith('can-go-forward', ANY);
+            expect(notify).toHaveBeenCalledWith('back-list', ANY);
+            expect(notify).toHaveBeenCalledWith('forward-list', ANY);
+        });
+
+        it('jumps forwards more than one step to the correct state', function () {
+            model.current_item = model.get_item(+2);
+
+            expect(model.current_item).toEqual(jasmine.objectContaining(BACON));
+            expect(model.back_list).toEqual([
+                jasmine.objectContaining(BUTTER),
+                jasmine.objectContaining(CHIVES),
+                jasmine.objectContaining(POTATOES),
+                jasmine.objectContaining(SOUR_CREAM)
+            ]);
+            expect(model.forward_list).toEqual([]);
+        });
+
+        it('notifies when jumping forwards more than one step', function () {
+            model.current_item = model.get_item(+2);
+
+            expect(notify).toHaveBeenCalledWith('current-item', ANY);
+            expect(notify).toHaveBeenCalledWith('back-list', ANY);
+            expect(notify).toHaveBeenCalledWith('forward-list', ANY);
+        });
+
+        it('notifies when navigating backwards from the most recent', function () {
+            model.current_item = model.get_item(+2);
+            notify.calls.reset();
+            model.go_back();
+
+            expect(notify).not.toHaveBeenCalledWith('can-go-back', ANY);
+            expect(notify).toHaveBeenCalledWith('can-go-forward', true);
+        });
+
+        it('notifies when navigating backwards to the earliest', function () {
+            model.current_item = model.get_item(-2);
+
+            expect(notify).toHaveBeenCalledWith('can-go-back', false);
+            expect(notify).not.toHaveBeenCalledWith('can-go-forward', ANY);
+        });
+
+        it('notifies when navigating forwards to the most recent', function () {
+            model.current_item = model.get_item(+2);
+
+            expect(notify).not.toHaveBeenCalledWith('can-go-back', ANY);
+            expect(notify).toHaveBeenCalledWith('can-go-forward', false);
+        });
+
+        it('notifies when navigating forwards from the earliest', function () {
+            model.current_item = model.get_item(-2);
+            notify.calls.reset();
+            model.go_forward();
+
+            expect(notify).toHaveBeenCalledWith('can-go-back', true);
+            expect(notify).not.toHaveBeenCalledWith('can-go-forward', ANY);
+        });
+
+        it('gracefully handles requesting an index that is too low', function () {
+            expect(model.get_item(-5)).toBeNull();
+        });
+
+        it('gracefully handles requesting an index that is too high', function () {
+            expect(model.get_item(+5)).toBeNull();
+        });
+    });
+});


### PR DESCRIPTION
This represents a list of pages that have been navigated to during a
given run of the program. Just like a browser, they keep track of where
you have visited so far; if you navigate back, then you can also
navigate forwards again. However, trees are not possible - if you
navigate back then visit a new page, your forward history is lost.

[endlessm/eos-sdk#829]
