### PR TITLE
Copy override properties manually into EosKnowledge

### DIFF
--- a/overrides/EosKnowledge.js
+++ b/overrides/EosKnowledge.js
@@ -51,13 +51,8 @@ function _init() {
         }
     });
 
-    let modulesToImport = [ArticleCard, Card, LessonCard, ListCard];
-    modulesToImport.forEach(function (module) {
-        // Inject the EosKnowledge module into the module being imported, to
-        // avoid recursive imports
-        module._EosKnowledge = EosKnowledge;
-        // Copy the module's public properties into the EosKnowledge module --
-        // remember to make all toplevel non-public symbols private with _
-        Lang.copyPublicProperties(module, EosKnowledge);
-    });
+    EosKnowledge.Card = Card.Card;
+    EosKnowledge.ArticleCard = ArticleCard.ArticleCard;
+    EosKnowledge.LessonCard = LessonCard.LessonCard;
+    EosKnowledge.ListCard = ListCard.ListCard;
 }

--- a/overrides/articleCard.js
+++ b/overrides/articleCard.js
@@ -1,8 +1,8 @@
 // Copyright 2014 Endless Mobile, Inc.
 
-const _Lang = imports.lang;
+const Lang = imports.lang;
 
-const _Card = imports.card;
+const Card = imports.card;
 
 /**
  * Class: ArticleCard
@@ -13,10 +13,10 @@ const _Card = imports.card;
  * Extends:
  *   <Card>
  */
-const ArticleCard = new _Lang.Class({
+const ArticleCard = new Lang.Class({
     Name: 'ArticleCard',
     GTypeName: 'EknArticleCard',
-    Extends: _Card.Card,
+    Extends: Card.Card,
 
     _init: function (props) {
         this.parent(props);

--- a/overrides/card.js
+++ b/overrides/card.js
@@ -1,14 +1,11 @@
 // Copyright 2014 Endless Mobile, Inc.
 
-/* global _EosKnowledge */
+const EosKnowledge = imports.gi.EosKnowledge;
+const Gtk = imports.gi.Gtk;
+const GObject = imports.gi.GObject;
+const Lang = imports.lang;
 
-const _Gtk = imports.gi.Gtk;
-const _GObject = imports.gi.GObject;
-const _Gio = imports.gi.Gio;
-const _Gdk = imports.gi.Gdk;
-const _Lang = imports.lang;
-
-const _CompositeButton = imports.compositeButton;
+const CompositeButton = imports.compositeButton;
 
 /**
  * Class: Card
@@ -24,46 +21,46 @@ const _CompositeButton = imports.compositeButton;
  * Signal generated when user clicked the card.
  * > card.connect("clicked", function (widget) { print("Clicked!"); });
  */
-const Card = new _Lang.Class({
+const Card = new Lang.Class({
     Name: 'Card',
     GTypeName: 'EknCard',
-    Extends: _CompositeButton.CompositeButton,
+    Extends: CompositeButton.CompositeButton,
     Properties: {
         /**
          * Property: title
          * A string with the title of the card. Defaults to an empty string.
          */
-        'title': _GObject.ParamSpec.string('title', 'Card Title',
+        'title': GObject.ParamSpec.string('title', 'Card Title',
             'Title of the card',
-            _GObject.ParamFlags.READABLE | _GObject.ParamFlags.WRITABLE, ''),
+            GObject.ParamFlags.READABLE | GObject.ParamFlags.WRITABLE, ''),
         /**
          * Property: subtitle
          * A string with the subtitle of the card. Defaults to an empty string.
          */
-        'subtitle': _GObject.ParamSpec.string('subtitle', 'Card Description',
+        'subtitle': GObject.ParamSpec.string('subtitle', 'Card Description',
             'Subtitle of the card',
-            _GObject.ParamFlags.READABLE | _GObject.ParamFlags.WRITABLE, ''),
+            GObject.ParamFlags.READABLE | GObject.ParamFlags.WRITABLE, ''),
         /**
          * Property: thumbnail-uri
          * A string with the URI of the thumbnail image. An empty string means
          * no thumbnail should be visible. Defaults to an empty string.
          */
-        'thumbnail-uri': _GObject.ParamSpec.string('thumbnail-uri', 'Thumbnail URI',
+        'thumbnail-uri': GObject.ParamSpec.string('thumbnail-uri', 'Thumbnail URI',
             'URI of the background image',
-            _GObject.ParamFlags.READABLE | _GObject.ParamFlags.WRITABLE, '')
+            GObject.ParamFlags.READABLE | GObject.ParamFlags.WRITABLE, '')
     },
 
     _init: function(params) {
-        this._title_label = new _Gtk.Label();
-        this._subtitle_label = new _Gtk.Label();
-        this._frame = new _Gtk.Frame();
-        this._background_provider = new _Gtk.CssProvider();
+        this._title_label = new Gtk.Label();
+        this._subtitle_label = new Gtk.Label();
+        this._frame = new Gtk.Frame();
+        this._background_provider = new Gtk.CssProvider();
         this._thumbnail_uri = null;
 
         this.parent(params);
 
-        let grid = new _Gtk.Grid({
-            orientation: _Gtk.Orientation.VERTICAL
+        let grid = new Gtk.Grid({
+            orientation: Gtk.Orientation.VERTICAL
         });
         grid.add(this._frame);
         grid.add(this._title_label);
@@ -73,10 +70,10 @@ const Card = new _Lang.Class({
 
         this.setSensitiveChildren([this._title_label, this._subtitle_label, this._frame]);
 
-        this.get_style_context().add_class(_EosKnowledge.STYLE_CLASS_CARD);
-        this._title_label.get_style_context().add_class(_EosKnowledge.STYLE_CLASS_TITLE);
-        this._subtitle_label.get_style_context().add_class(_EosKnowledge.STYLE_CLASS_SUBTITLE);
-        this._frame.get_style_context().add_class(_EosKnowledge.STYLE_CLASS_THUMBNAIL);
+        this.get_style_context().add_class(EosKnowledge.STYLE_CLASS_CARD);
+        this._title_label.get_style_context().add_class(EosKnowledge.STYLE_CLASS_TITLE);
+        this._subtitle_label.get_style_context().add_class(EosKnowledge.STYLE_CLASS_SUBTITLE);
+        this._frame.get_style_context().add_class(EosKnowledge.STYLE_CLASS_THUMBNAIL);
     },
 
     set title (v) {
@@ -110,7 +107,7 @@ const Card = new _Lang.Class({
             let frame_css = '* { background-image: url("' + this._thumbnail_uri + '"); }';
             this._background_provider.load_from_data(frame_css);
             let context = this._frame.get_style_context();
-            context.add_provider(this._background_provider, _Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION);
+            context.add_provider(this._background_provider, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION);
         }
         this.notify('thumbnail-uri');
     },

--- a/overrides/lessonCard.js
+++ b/overrides/lessonCard.js
@@ -1,20 +1,19 @@
 // Copyright 2014 Endless Mobile, Inc.
 
-/* global _EosKnowledge */
+const EosKnowledge = imports.gi.EosKnowledge;
+const Format = imports.format;
+const Gettext = imports.gettext;
+const GLib = imports.gi.GLib;
+const GObject = imports.gi.GObject;
+const Gtk = imports.gi.Gtk;
+const Lang = imports.lang;
 
-const _Format = imports.format;
-const _Gettext = imports.gettext;
-const _GLib = imports.gi.GLib;
-const _GObject = imports.gi.GObject;
-const _Gtk = imports.gi.Gtk;
-const _Lang = imports.lang;
+const Card = imports.card;
+const Config = imports.config;
 
-const _Card = imports.card;
-const _Config = imports.config;
-
-String.prototype.format = _Format.format;
-let _ = _Gettext.dgettext.bind(null, _Config.GETTEXT_PACKAGE);
-_GObject.ParamFlags.READWRITE = _GObject.ParamFlags.READABLE | _GObject.ParamFlags.WRITABLE;
+String.prototype.format = Format.format;
+let _ = Gettext.dgettext.bind(null, Config.GETTEXT_PACKAGE);
+GObject.ParamFlags.READWRITE = GObject.ParamFlags.READABLE | GObject.ParamFlags.WRITABLE;
 
 /**
  * Class: LessonCard
@@ -28,10 +27,10 @@ _GObject.ParamFlags.READWRITE = _GObject.ParamFlags.READABLE | _GObject.ParamFla
  * Extends:
  *   <Card>
  */
-const LessonCard = new _Lang.Class({
+const LessonCard = new Lang.Class({
     Name: 'LessonCard',
     GTypeName: 'EknLessonCard',
-    Extends: _Card.Card,
+    Extends: Card.Card,
     Properties: {
         /**
          * Property: item-index
@@ -41,40 +40,40 @@ const LessonCard = new _Lang.Class({
          * If set to 0, then the lesson or step number will not be displayed.
          * (That is: the index is human-readable, and so 1-based.)
          */
-        'item-index': _GObject.ParamSpec.uint('item-index', 'Item index',
+        'item-index': GObject.ParamSpec.uint('item-index', 'Item index',
             'Number of the lesson or step this card represents',
-            _GObject.ParamFlags.READWRITE,
-            0, _GLib.MAXUINT32, 0),
+            GObject.ParamFlags.READWRITE,
+            0, GLib.MAXUINT32, 0),
         /**
          * Property: complete
          *
          * Set to *true* if this lesson has been completed or othwerise "checked
          * off."
          */
-        'complete': _GObject.ParamSpec.boolean('complete', 'Complete',
+        'complete': GObject.ParamSpec.boolean('complete', 'Complete',
             'Whether this card should be marked as completed',
-            _GObject.ParamFlags.READWRITE,
+            GObject.ParamFlags.READWRITE,
             false)
     },
 
     _init: function (props) {
         this._complete = false;
         this._index = 0;
-        this._banner = new _Gtk.Frame({
-            halign: _Gtk.Align.START,
-            valign: _Gtk.Align.START,
+        this._banner = new Gtk.Frame({
+            halign: Gtk.Align.START,
+            valign: Gtk.Align.START,
             no_show_all: true,
             margin_top: 10,  // FIXME arbitrary value, waiting on design
             margin_left: 10
         });
-        let banner_grid = new _Gtk.Grid({
-            orientation: _Gtk.Orientation.HORIZONTAL,
+        let banner_grid = new Gtk.Grid({
+            orientation: Gtk.Orientation.HORIZONTAL,
             visible: true
         });
-        this._index_label = new _Gtk.Label({
+        this._index_label = new Gtk.Label({
             visible: true
         });
-        this._checkmark_label = new _Gtk.Label({
+        this._checkmark_label = new Gtk.Label({
             label: '\u2713'  // U+2713 = Unicode check mark
         });
         banner_grid.add(this._index_label);
@@ -91,7 +90,7 @@ const LessonCard = new _Lang.Class({
         // structure the drawing. This is just a placeholder.
         let grid = this.get_child();
         this.remove(grid);
-        let overlay = new _Gtk.Overlay();
+        let overlay = new Gtk.Overlay();
         overlay.add(grid);
         this.add(overlay);
         this.setSensitiveChildren([this._title_label, this._subtitle_label,
@@ -118,9 +117,9 @@ const LessonCard = new _Lang.Class({
     set complete(value) {
         this._complete = value;
         if (this._complete)
-            this.get_style_context().add_class(_EosKnowledge.STYLE_CLASS_COMPLETE);
+            this.get_style_context().add_class(EosKnowledge.STYLE_CLASS_COMPLETE);
         else
-            this.get_style_context().remove_class(_EosKnowledge.STYLE_CLASS_COMPLETE);
+            this.get_style_context().remove_class(EosKnowledge.STYLE_CLASS_COMPLETE);
         this._update_banner();
     },
 

--- a/overrides/listCard.js
+++ b/overrides/listCard.js
@@ -1,8 +1,8 @@
 // Copyright 2014 Endless Mobile, Inc.
 
-const _Lang = imports.lang;
+const Lang = imports.lang;
 
-const _Card = imports.card;
+const Card = imports.card;
 
 /**
  * Class: ListCard
@@ -12,10 +12,10 @@ const _Card = imports.card;
  * Extends:
  *   <Card>
  */
-const ListCard = new _Lang.Class({
+const ListCard = new Lang.Class({
     Name: 'ListCard',
     GTypeName: 'EknListCard',
-    Extends: _Card.Card,
+    Extends: Card.Card,
 
     _init: function (props) {
         this.parent(props);


### PR DESCRIPTION
Instead of calling copyPublicProperties for each file import
manually copy only the properties we care about into EosKnowledge.
This saves us from a lot of bookkeeping to mark all properties
we don't want in EosKnowledge with an underscore, such as standard
library imports

[endlessm/eos-sdk#906]
