### PR TITLE
Home page only shows cards it has space for

### DIFF
--- a/data/endless_knowledge.css
+++ b/data/endless_knowledge.css
@@ -1,6 +1,7 @@
 .card {
     border-radius: 5px;
     padding: 10px;
+    margin: 30px;
     color: orange;
     background-color: white;
     transition:color 250ms ease-in-out;

--- a/overrides/Makefile.am.inc
+++ b/overrides/Makefile.am.inc
@@ -13,6 +13,7 @@ dist_pkgoverrides_DATA = \
 	overrides/lessonCard.js \
 	overrides/lightbox.js \
 	overrides/listCard.js \
+	overrides/marginButton.js \
 	overrides/progressCard.js \
 	overrides/tableOfContents.js \
 	overrides/treeNode.js \

--- a/overrides/compositeButton.js
+++ b/overrides/compositeButton.js
@@ -1,6 +1,8 @@
 const Gtk = imports.gi.Gtk;
 const Lang = imports.lang;
 
+const MarginButton = imports.marginButton;
+
 // Class for buttons whose :hover and :active CSS pseudoclass states should be
 // inherited by some of their child widgets, since as of GTK 3.10 these flags no
 // longer propagate from a widget to its children. Widgets in sensitiveChildren
@@ -10,7 +12,7 @@ const Lang = imports.lang;
 const CompositeButton = new Lang.Class({
     Name: 'CompositeButton',
     GTypeName: 'CompositeButton',
-    Extends: Gtk.Button,
+    Extends: MarginButton.MarginButton,
 
     _INHERITED_FLAGS: [Gtk.StateFlags.PRELIGHT, Gtk.StateFlags.ACTIVE],
 

--- a/overrides/marginButton.js
+++ b/overrides/marginButton.js
@@ -1,0 +1,60 @@
+const Gtk = imports.gi.Gtk;
+const Lang = imports.lang;
+
+// A button that actually supports the margin css property! Makes styling our
+// apps a lot easier.
+const MarginButton = new Lang.Class({
+    Name: 'MarginButton',
+    GTypeName: 'MarginButton',
+    Extends: Gtk.Button,
+
+    _get_margin: function () {
+        return this.get_style_context().get_margin(this.get_state_flags());
+    },
+
+    _grow_request_by_margin_width: function (request) {
+        let margin = this._get_margin();
+        let extra_width = margin.left + margin.right;
+        return [request[0] + extra_width, request[1] + extra_width];
+    },
+
+    _grow_request_by_margin_height: function (request) {
+        let margin = this._get_margin();
+        let extra_height = margin.top + margin.bottom;
+        return [request[0] + extra_height, request[1] + extra_height];
+    },
+
+    vfunc_get_preferred_width: function () {
+        return this._grow_request_by_margin_width(this.parent());
+    },
+
+    vfunc_get_preferred_height: function () {
+        return this._grow_request_by_margin_height(this.parent());
+    },
+
+    vfunc_get_preferred_width_for_height: function (height) {
+        return this._grow_request_by_margin_width(this.parent(height));
+    },
+
+    vfunc_get_preferred_height_for_width: function (width) {
+        return this._grow_request_by_margin_height(this.parent(width));
+    },
+
+    vfunc_get_preferred_height_and_baseline_for_width: function (width) {
+        let margin = this._get_margin();
+        let [height_min, height_nat, baseline_min, baseline_nat] = this.parent(width);
+        return [height_min + margin.top + margin.bottom,
+                height_nat + margin.top + margin.bottom,
+                baseline_min + margin.top,
+                baseline_nat + margin.top];
+    },
+
+    vfunc_size_allocate: function (alloc) {
+        let margin = this._get_margin();
+        alloc.x += margin.left;
+        alloc.y += margin.top;
+        alloc.width -= margin.left + margin.right;
+        alloc.height -= margin.top + margin.bottom;
+        this.parent(alloc);
+    }
+});


### PR DESCRIPTION
Required a custom container. Sizing down the home page will drop
cards out of the list, until there is only one left.
[endlessm/eos-sdk#967]

I now have margin coming in on two pull requests. I'll just rebase one over whatever gets merged first.
