### PR TITLE
Sdk/922

### DIFF
--- a/overrides/EosKnowledge.js
+++ b/overrides/EosKnowledge.js
@@ -7,6 +7,7 @@ let _oldSearchPath = imports.searchPath;
 imports.searchPath.unshift(Endless.getCurrentFileDir());
 
 const ArticleCard = imports.articleCard;
+const ArticleObjectModel = imports.articleObjectModel;
 const Card = imports.card;
 const ContentObjectModel = imports.contentObjectModel;
 const HomePageA = imports.homePageA;
@@ -58,6 +59,7 @@ function _init() {
     });
 
     EosKnowledge.ArticleCard = ArticleCard.ArticleCard;
+    EosKnowledge.ArticleObjectModel = ArticleObjectModel.ArticleObjectModel;
     EosKnowledge.Card = Card.Card;
     EosKnowledge.ContentObjectModel = ContentObjectModel.ContentObjectModel;
     EosKnowledge.HomePageA = HomePageA.HomePageA;

--- a/overrides/Makefile.am.inc
+++ b/overrides/Makefile.am.inc
@@ -6,6 +6,7 @@ pkgoverridesdir = $(pkgdatadir)/overrides
 public_overrides = \
 	overrides/EosKnowledge.js \
 	overrides/articleCard.js \
+	overrides/articleObjectModel.js \
 	overrides/card.js \
 	overrides/contentObjectModel.js \
 	overrides/homePageA.js \

--- a/overrides/articleObjectModel.js
+++ b/overrides/articleObjectModel.js
@@ -1,0 +1,114 @@
+// Copyright 2014 Endless Mobile, Inc.
+
+const Endless = imports.gi.Endless;
+const EosKnowledge = imports.gi.EosKnowledge;
+const GLib = imports.gi.GLib;
+const GObject = imports.gi.GObject;
+const Gtk = imports.gi.Gtk;
+const Lang = imports.lang;
+
+const ContentObjectModel = imports.contentObjectModel;
+
+GObject.ParamFlags.READWRITE = GObject.ParamFlags.READABLE | GObject.ParamFlags.WRITABLE;
+
+/**
+ * Class: ArticleObjectModel
+ * The model class for article objects. An article has the same 
+ * properties as a <ContentObjectModel>, plus a <article-content-uri>,
+ * <word-count>, and <table-of-contents>.
+ */
+const ArticleObjectModel = new Lang.Class({
+    Name: 'ArticleObjectModel',
+    GTypeName: 'EknArticleObjectModel',
+    Extends: ContentObjectModel.ContentObjectModel,
+    Properties: {
+        /**
+         * Property: article-content-uri
+         * The URI at which the main textual portion of the article resides. Defaults to
+         * "about:blank"
+         */
+        'article-content-uri': GObject.ParamSpec.string('article-content-uri',
+            'Article Content URI', 'URI to the main textual portion of the article',
+            GObject.ParamFlags.READWRITE | GObject.ParamFlags.CONSTRUCT,
+            'about:blank'),
+
+        /**
+         * Property: word-count
+         * Integer indicating how many words are in the article
+         */
+        'word-count': GObject.ParamSpec.uint('word-count', 'Word Count',
+            'Number of words contained in the article body',
+            GObject.ParamFlags.READWRITE | GObject.ParamFlags.CONSTRUCT,
+            0, GLib.MAXUINT32, 0),
+
+        /**
+         * Property: table-of-contents
+         * A GtkTreeStore representing the article's hierarchical
+         * table of contents
+         */
+        'table-of-contents': GObject.ParamSpec.object('table-of-contents',
+             'Table of Contents',
+             'Tree representing the article\'s table of contents',
+             GObject.ParamFlags.READWRITE,
+             Gtk.TreeStore),
+    },
+    
+    _init: function (params) {
+        this.parent(params);
+    },
+
+    get article_content_uri () {
+        return this._article_content_uri;
+    },
+
+    get word_count () {
+        return this._word_count;
+    },
+
+    get table_of_contents () {
+        return this._table_of_contents;
+    },
+
+    set article_content_uri (v) {
+        this._article_content_uri = v;
+    },
+
+    set word_count (v) {
+        this._word_count = v;
+    },
+
+    set table_of_contents (v) {
+        this._table_of_contents = v;
+    }
+});
+
+/**
+ * Constructor: new_from_json_ld
+ * Creates an ArticleObjectModel from a Knowledge Engine ArticleObject
+ * JSON-LD document
+ */
+ArticleObjectModel.new_from_json_ld = function (json_ld_data) {
+    let props = ArticleObjectModel._props_from_json_ld(json_ld_data);
+    return new ArticleObjectModel(props);
+};
+
+ArticleObjectModel._props_from_json_ld = function (json_ld_data) {
+    // Inherit properties marshalled from parent class
+    let ParentClass = ArticleObjectModel.__super__;
+    let props = ParentClass._props_from_json_ld(json_ld_data);
+
+    // Marshal properties specific to ArticleObjectModel
+    if (json_ld_data.hasOwnProperty('@id')) {
+        props.article_content_uri = json_ld_data['@id'];
+    }
+
+    if (json_ld_data.hasOwnProperty('wordCount')) {
+        props.word_count = parseInt(json_ld_data.wordCount);
+    }
+
+    if (json_ld_data.hasOwnProperty('tableOfContents')) {
+        props.table_of_contents = EosKnowledge.tree_model_from_tree_node(json_ld_data);
+    }
+
+    return props;
+}

--- a/overrides/contentObjectModel.js
+++ b/overrides/contentObjectModel.js
@@ -179,21 +179,44 @@ const ContentObjectModel = new Lang.Class({
     }
 });
 
+/**
+ * Constructor: new_from_json_ld
+ * Creates an ContentObjectModel from a Knowledge Engine ContentObject
+ * JSON-LD document
+ */
 ContentObjectModel.new_from_json_ld = function (json_ld_data) {
     let props = ContentObjectModel._props_from_json_ld(json_ld_data);
     return new EosKnowledge.ContentObjectModel(props);
 };
 
 ContentObjectModel._props_from_json_ld = function (json_ld_data) {
-    return {
-        ekn_id: json_ld_data["@id"],
-        title: json_ld_data.title,
-        thumbnail_uri : json_ld_data.thumbnail,
-        language : json_ld_data.language,
-        copyright_holder : json_ld_data.copyrightHolder,
-        source_uri : json_ld_data.sourceURL,
-        synopsis : json_ld_data.synopsis,
-        last_modified_date : json_ld_data.lastModifiedDate,
-        license : json_ld_data.license
-    };
+    let props = {};
+    if(json_ld_data.hasOwnProperty('@id'))
+        props.ekn_id = json_ld_data['@id'];
+
+    if(json_ld_data.hasOwnProperty('title'))
+        props.title = json_ld_data.title;
+
+    if(json_ld_data.hasOwnProperty('thumbnail'))
+        props.thumbnail_uri = json_ld_data.thumbnail;
+
+    if(json_ld_data.hasOwnProperty('language'))
+        props.language = json_ld_data.language;
+
+    if(json_ld_data.hasOwnProperty('copyrightHolder'))
+        props.copyright_holder = json_ld_data.copyrightHolder;
+
+    if(json_ld_data.hasOwnProperty('sourceURL'))
+        props.source_uri = json_ld_data.sourceURL;
+
+    if(json_ld_data.hasOwnProperty('synopsis'))
+        props.synopsis = json_ld_data.synopsis;
+
+    if(json_ld_data.hasOwnProperty('lastModifiedDate'))
+        props.last_modified_date = json_ld_data.lastModifiedDate;
+
+    if(json_ld_data.hasOwnProperty('license'))
+        props.license = json_ld_data.license;
+
+    return props;
 };

--- a/tests/InstanceOfMatcher.js
+++ b/tests/InstanceOfMatcher.js
@@ -1,0 +1,32 @@
+const customMatchers = {
+    toBeA: function (util, customEqualityTesters) {
+        return {
+            compare: function (widget, expectedType) {
+                let result = {
+                    pass: function () {
+                        return widget instanceof expectedType;
+                    }
+                }
+
+                let widgetTypeName;
+                if (typeof widget === 'object')
+                    widgetTypeName = widget.constructor.name;
+                else
+                    widgetTypeName = typeof widget;
+
+                let expectedTypeName;
+                if (typeof expectedType.$gtype !== 'undefined')
+                    expectedTypeName = expectedType.$gtype.name;
+                else
+                    expectedTypeName = expectedType;
+
+                if (result.pass) {
+                    result.message = 'Expected ' + widget + ' not to be a ' + expectedTypeName + ', but it was';
+                } else {
+                    result.message = 'Expected ' + widget + ' to be a ' + expectedTypeName + ', but instead it had type ' + widgetTypeName;
+                }
+                return result;
+            }
+        }
+    }
+}

--- a/tests/Makefile.am.inc
+++ b/tests/Makefile.am.inc
@@ -3,6 +3,7 @@
 
 javascript_tests = \
 	tests/eosknowledge/testArticleCard.js \
+	tests/eosknowledge/testArticleObjectModel.js \
 	tests/eosknowledge/testCard.js \
 	tests/eosknowledge/testContentObjectModel.js \
 	tests/eosknowledge/testHello.js \
@@ -17,10 +18,14 @@ javascript_tests = \
 	tests/eosknowledge/testTreeNode.js \
 	tests/eosknowledge/testWebviewSwitcher.js \
 	$(NULL)
+test_content = \
+	tests/test-content/emacs.jsonld \
+	tests/test-content/greyjoyarticle.jsonld \
 EXTRA_DIST += \
 	$(javascript_tests) \
+	$(test_content) \
 	tests/CssClassMatcher.js \
-	tests/test-content/emacs.jsonld \
+	tests/eosknowledge/utils.js \
 	$(NULL)
 
 # Run tests when running 'make check'

--- a/tests/eosknowledge/testArticleObjectModel.js
+++ b/tests/eosknowledge/testArticleObjectModel.js
@@ -1,0 +1,34 @@
+const Endless = imports.gi.Endless;
+const EosKnowledge = imports.gi.EosKnowledge;
+const Gtk = imports.gi.Gtk;
+const InstanceOfMatcher = imports.InstanceOfMatcher;
+const utils = imports.utils;
+
+const MOCK_ARTICLE_PATH = Endless.getCurrentFileDir() + '/../test-content/greyjoy-article.jsonld';
+
+describe ('Article Object Model', function () {
+    let articleObject;
+    let mockArticleData = utils.parse_object_from_path(MOCK_ARTICLE_PATH);
+
+    beforeEach(function () {
+        jasmine.addMatchers(InstanceOfMatcher.customMatchers);
+
+        articleObject = new EosKnowledge.ArticleObjectModel.new_from_json_ld(mockArticleData);
+    });
+    
+    describe ('JSON-LD marshaler', function () {
+        it ('should construct from a JSON-LD document', function () {
+            expect(articleObject).toBeDefined();
+        });
+
+        it ('should inherit properties set by parent class (ContentObjectModel)', function () {
+            print(Object.keys(EosKnowledge.ArticleObjectModel._props_from_json_ld(mockArticleData)));
+            expect(articleObject.title).toBeDefined();
+            expect(articleObject.synopsis).toBeDefined();
+        });
+
+        it ('should marshal a GtkTreeStore from JSON-LD TreeNodes', function () {
+            expect(articleObject.table_of_contents).toBeA(Gtk.TreeStore);
+        });
+    });
+});

--- a/tests/eosknowledge/testContentObjectModel.js
+++ b/tests/eosknowledge/testContentObjectModel.js
@@ -1,18 +1,12 @@
 const Endless = imports.gi.Endless;
 const EosKnowledge = imports.gi.EosKnowledge;
-const Gio = imports.gi.Gio;
+const utils = imports.utils;
 
 const CONTENT_OBJECT_EMACS = Endless.getCurrentFileDir() + '/../test-content/emacs.jsonld';
 
-function parse_object_from_file (the_file) {
-    let file = Gio.file_new_for_path(the_file);
-    let [success, data] = file.load_contents(null);
-    return JSON.parse(data);
-}
-
 describe ("Content Object Model", function () {
     let contentObject;
-    let mockContentData = parse_object_from_file(CONTENT_OBJECT_EMACS);
+    let mockContentData = utils.parse_object_from_path(CONTENT_OBJECT_EMACS);
 
     describe ("Constructor", function () {
         it ("successfully creates new object from properties", function () {
@@ -33,6 +27,15 @@ describe ("Content Object Model", function () {
 
         it ("successfully creates new object from JSON-LD data", function () {
             contentObject = EosKnowledge.ContentObjectModel.new_from_json_ld(mockContentData);
+            expect(contentObject.title).toEqual(mockContentData.title);
+        });
+
+        it ("successfully creates new object from JSON-LD with missing properties", function () {
+            let just_a_title_json_ld = {
+                "@id": mockContentData["@id"],
+                "title": mockContentData["title"]
+            };
+            contentObject = EosKnowledge.ContentObjectModel.new_from_json_ld(just_a_title_json_ld);
             expect(contentObject.title).toEqual(mockContentData.title);
         });
     });

--- a/tests/test-content/greyjoy-article.jsonld
+++ b/tests/test-content/greyjoy-article.jsonld
@@ -1,0 +1,58 @@
+{
+    "@context": [
+        "http://localhost:3000/v2/_context/ContentObject.jsonld",
+        {
+            "wordCount": "schema:Integer",
+            "articleBody": "schema:mainContentText",
+            "treeNode": "ekv:TreeNode#",
+            "hasContent": {
+                "@type": "@id",
+                "@id": "treeNode:hasContent"
+            },
+            "hasParent": "treeNode:hasParent",
+            "hasLabel": "treeNode:hasLabel",
+            "hasIndex": "treeNode:hasIndex",
+            "hasIndexLabel": "treeNode:hasIndexLabel",
+            "tableOfContents": {
+                "@container": "@list",
+                "@id": "ekv:TreeNode"
+            }
+        }
+    ],
+    "@id": "ekn:asoiaf/House_Greyjoy",
+    "@type": "ekv:ArticleObject",
+    "title": "House Greyjoy",
+    "synopsis": "We Do Not Sow",
+    "articleBody": "lame",
+    "tableOfContents": [
+        {
+            "@id": "_:1",
+            "nodeIndex": 0,
+            "nodeIndexLabel": "1",
+            "nodeLabel": "History",
+            "nodeContent": "ekn:asoiaf/House_Greyjoy#History"
+        },
+        {
+            "@id": "_:1.a",
+            "nodeIndex": 0,
+            "nodeIndexLabel": "1.a",
+            "nodeLabel": "When They Used To Be Cool",
+            "nodeParent": "_:1",
+            "nodeContent": "ekn:asoiaf/House_Greyjoy#Never"
+        },
+        {
+            "@id": "_:2",
+            "nodeIndex": 1,
+            "nodeIndexLabel": "2",
+            "nodeLabel": "Sigil",
+            "nodeContent": "ekn:asoiaf/House_Greyjoy#Literally_A_Squid"
+        },
+        {
+            "@id": "_:3",
+            "nodeIndex": 2,
+            "nodeIndexLabel": "3",
+            "nodeLabel": "Criticisms",
+            "nodeContent": "ekn:asoiaf/House_Greyjoy#Seriously"
+        } 
+    ]
+}

--- a/tests/utils.js
+++ b/tests/utils.js
@@ -1,0 +1,7 @@
+const Gio = imports.gi.Gio;
+
+function parse_object_from_path (path) {
+    let file = Gio.file_new_for_path(path);
+    let [success, data] = file.load_contents(null);
+    return JSON.parse(data);
+}


### PR DESCRIPTION
ArticleModelObject! Inherits properties from ContentObjectModel, and adds a few more.

Made some changes to ContentObjectModel's json-ld construction, since previously the json -> paramsobject conversion didn't care about whether a jsonld property existed or not. 

[endlessm/eos-sdk#922]
