### PR TITLE
Sdk/956

### DIFF
--- a/overrides/EosKnowledge.js
+++ b/overrides/EosKnowledge.js
@@ -15,6 +15,7 @@ const LessonCard = imports.lessonCard;
 const Lightbox = imports.lightbox;
 const ListCard = imports.listCard;
 const ProgressCard = imports.progressCard;
+const SearchResults = imports.searchResults;
 const SectionPageA = imports.sectionPageA;
 const TableOfContents = imports.tableOfContents;
 const TreeNode = imports.treeNode;
@@ -67,6 +68,7 @@ function _init() {
     EosKnowledge.LessonCard = LessonCard.LessonCard;
     EosKnowledge.Lightbox = Lightbox.Lightbox;
     EosKnowledge.ListCard = ListCard.ListCard;
+    EosKnowledge.list_from_search_results = SearchResults.list_from_search_results;
     EosKnowledge.ProgressCard = ProgressCard.ProgressCard;
     EosKnowledge.SectionPageA = SectionPageA.SectionPageA;
     EosKnowledge.TableOfContents = TableOfContents.TableOfContents;

--- a/overrides/Makefile.am.inc
+++ b/overrides/Makefile.am.inc
@@ -15,6 +15,7 @@ public_overrides = \
 	overrides/listCard.js \
 	overrides/marginButton.js \
 	overrides/progressCard.js \
+	overrides/searchResults.js \
 	overrides/sectionPageA.js \
 	overrides/tableOfContents.js \
 	overrides/treeNode.js \

--- a/overrides/searchResults.js
+++ b/overrides/searchResults.js
@@ -1,0 +1,31 @@
+// Copyright 2014 Endless Mobile, Inc.
+const EosKnowledge = imports.gi.EosKnowledge;
+
+const EKN_TYPE_SEARCH_RESULTS = "ekv:SearchResults";
+
+/** 
+ * Function: list_from_search_results
+ * Converts a SearchResults JSON-LD object into a list of <ContentObjectModel>s, or its
+ * subclasses (<ArticleObjectModel>, <ImageObjectModel>, or <VideoObjectModel>).
+ */
+function list_from_search_results(jsonld) {
+    if (jsonld["@type"] !== EKN_TYPE_SEARCH_RESULTS)
+        throw new Error("Cannot marshal search results list from data of type " + jsonld["@type"]);
+
+    let retval = jsonld['results'].map(function (item) {
+        switch(item['@type']) {
+            case 'ekv:ContentObject':
+                return EosKnowledge.ContentObjectModel.new_from_json_ld(item);
+            case 'ekv:ArticleObject':
+                return EosKnowledge.ArticleObjectModel.new_from_json_ld(item);
+            default:
+                throw new Error(item['@type'] + ' result not implemented'); // FIXME
+        }
+    });
+
+    // Sanity check
+    if(retval.length !== jsonld['numResults'])
+        throw new Error('Number of results did not agree in JSON-LD SearchResults object');
+
+    return retval;
+}

--- a/tests/Makefile.am.inc
+++ b/tests/Makefile.am.inc
@@ -14,12 +14,15 @@ javascript_tests = \
 	tests/eosknowledge/testLightbox.js \
 	tests/eosknowledge/testListCard.js \
 	tests/eosknowledge/testProgressCard.js \
+	tests/eosknowledge/testSearchResults.js \
 	tests/eosknowledge/testSectionPageA.js \
 	tests/eosknowledge/testTableOfContents.js \
 	tests/eosknowledge/testTreeNode.js \
 	tests/eosknowledge/testWebviewSwitcher.js \
 	$(NULL)
 test_content = \
+	tests/test-content/article-search-results.jsonld \
+	tests/test-content/content-search-results.jsonld \
 	tests/test-content/emacs.jsonld \
 	tests/test-content/greyjoy-article.jsonld \
 	$(NULL)

--- a/tests/eosknowledge/testSearchResults.js
+++ b/tests/eosknowledge/testSearchResults.js
@@ -1,0 +1,99 @@
+const Endless = imports.gi.Endless;
+const EosKnowledge = imports.gi.EosKnowledge;
+const Gio = imports.gi.Gio;
+
+const InstanceOfMatcher = imports.InstanceOfMatcher;
+const utils = imports.utils;
+
+const MOCK_CONTENT_OBJECT_RESULTS = Endless.getCurrentFileDir() + '/../test-content/content-search-results.jsonld';
+const MOCK_ARTICLE_OBJECT_RESULTS = Endless.getCurrentFileDir() + '/../test-content/article-search-results.jsonld';
+
+function parse_object_from_file (filename) {
+    var file = Gio.file_new_for_path(filename);
+    var data = file.load_contents(null);
+    return JSON.parse(data[1]);
+};
+
+describe ("Search Results Marshaler", function () {
+    
+    beforeEach(function () {
+        jasmine.addMatchers(InstanceOfMatcher.customMatchers);
+    });
+
+    it ("should throw an error when called on invalid data type", function () {
+        let notSearchResults = {
+            "@type": "schema:Frobinator",
+            "numResults": 1,
+            "results": [
+                { "@type": "bogus", "synopsis": "dolla dolla bill y'all" }
+            ]
+        };
+        expect(function () {
+            let results = EosKnowledge.list_from_search_results(notSearchResults);
+        }).toThrow();
+    });
+
+    it ("should throw an error on unsupported search results", function () {
+        let badObject = { "@type": "ekv:Kitten" };
+        let searchResults = {
+            "@type": "ekv:SearchResults",
+            "numResults": 1,
+            "results": [ badObject ]
+        };
+
+        expect(function () {
+            let list = EosKnowledge.list_from_search_results(searchResults);
+        }).toThrow();
+    });
+
+    it ("should throw an error when there are too many or not enough results", function () {
+        let tooFew = {
+            "@type": "ekv:SearchResults",
+            "numResults": 1,
+            "results": []
+        };
+        let tooMany = {
+            "@type": "ekv:SearchResults",
+            "numResults": 1,
+            "results": [
+                {"@type": "ekv:ContentObject"},
+                {"@type": "ekv:ContentObject"}
+            ]
+        };
+
+        expect(function () {
+            let list = new EosKnowledge.ContentObjectModel(tooFew);
+        }).toThrow();
+
+        expect(function () {
+            let list = new EosKnowledge.ContentObjectModel(tooMany);
+        }).toThrow();
+    });
+
+    it ("should construct a list of results if the data is properly formatted", function () {
+        let mockSearchResults = parse_object_from_file(MOCK_CONTENT_OBJECT_RESULTS);
+        let objectList = new EosKnowledge.list_from_search_results(mockSearchResults);
+
+        expect(objectList.length).toBe(mockSearchResults.numResults);
+    });
+
+    it ("should construct a list of of objects based on @type", function () {
+        let contentObjectResults = parse_object_from_file(MOCK_CONTENT_OBJECT_RESULTS);
+        let contentObjectList = new EosKnowledge.list_from_search_results(contentObjectResults);
+
+        // All results in MOCK_CONTENT_OBJECT_RESULTS are of @type ContentObject,
+        // so expect that they're constructed as such
+        for (let i in contentObjectList) {
+            expect(contentObjectList[i]).toBeA(EosKnowledge.ContentObjectModel);
+        }
+
+        let articleObjectResults = parse_object_from_file(MOCK_ARTICLE_OBJECT_RESULTS);
+        let articleObjectList = new EosKnowledge.list_from_search_results(articleObjectResults);
+
+        // All results in MOCK_ARTICLE_OBJECT_RESULTS are of @type ArticleObject,
+        // so expect that they're constructed as such
+        for (let i in articleObjectList) {
+            expect(articleObjectList[i]).toBeA(EosKnowledge.ArticleObjectModel);
+        }
+    });
+});

--- a/tests/test-content/article-search-results.jsonld
+++ b/tests/test-content/article-search-results.jsonld
@@ -1,0 +1,42 @@
+{
+    "@context":
+    {
+        "schema": "http://schema.org/",
+        "xsd": "http://www.w3.org/2001/XMLSchema#",
+        "ekn": "http://localhost:3000/v2/",
+        "ekv": "ekn:_vocab/",
+        "numResults": "schema:Integer",
+        "results":
+        {
+            "@container": "@list",
+            "@id": "ekv:ContentObject"
+        },
+        "queryString": "schema:Text",
+        "queryTags": 
+        {
+            "@container": "@list",
+            "@id": "schema:keyword"
+        },
+        "queryPrefix": "schema:Text",
+        "queryLimit": "schema:Integer"
+    },
+    "@type": "ekv:SearchResults",
+    "queryString": "stark",
+    "numResults": 2,
+    "results": [
+        {
+            "@id": "ekn:asoiaf/House_Stark",
+            "@type": "ekv:ArticleObject",
+            "title": "House Stark",
+            "synopsis": "Winter is Coming",
+            "articleBody": "Everything's coming up Stark!"
+        },
+        {
+            "@id": "ekn:marvel/Tony_Stark",
+            "@type": "ekv:ArticleObject",
+            "title": "Tony Stark",
+            "synopsis": "is actually Iron Man",
+            "articleBody": "Fun fact: Iron Man was actually based on Robert Downy Jr.'s life"
+        }
+    ]
+}

--- a/tests/test-content/content-search-results.jsonld
+++ b/tests/test-content/content-search-results.jsonld
@@ -1,0 +1,40 @@
+{
+    "@context":
+    {
+        "schema": "http://schema.org/",
+        "xsd": "http://www.w3.org/2001/XMLSchema#",
+        "ekn": "http://localhost:3000/v2/",
+        "ekv": "ekn:_vocab/",
+        "numResults": "schema:Integer",
+        "results":
+        {
+            "@container": "@list",
+            "@id": "ekv:ContentObject"
+        },
+        "queryString": "schema:Text",
+        "queryTags": 
+        {
+            "@container": "@list",
+            "@id": "schema:keyword"
+        },
+        "queryPrefix": "schema:Text",
+        "queryLimit": "schema:Integer"
+    },
+    "@type": "ekv:SearchResults",
+    "queryString": "stark",
+    "numResults": 2,
+    "results": [
+        {
+            "@id": "ekn:asoiaf/House_Stark",
+            "@type": "ekv:ContentObject",
+            "title": "House Stark",
+            "synopsis": "Winter is Coming"
+        },
+        {
+            "@id": "ekn:marvel/Tony_Stark",
+            "@type": "ekv:ContentObject",
+            "title": "Tony Stark",
+            "synopsis": "is actually Iron Man"
+        }
+    ]
+}


### PR DESCRIPTION
implements list_from_search_results, which converts JSON-LD search results into a list of marshalled object models.

Merge #29 first!

[endlessm/eos-sdk#956]
