### PR TITLE
Add test content to distribution

### DIFF
--- a/tests/Makefile.am.inc
+++ b/tests/Makefile.am.inc
@@ -16,8 +16,12 @@ javascript_tests = \
 	tests/eosknowledge/testTableOfContents.js \
 	tests/eosknowledge/testTreeNode.js \
 	$(NULL)
+test_content = \
+	tests/test-content/emacs.jsonld \
+	$(NULL)
 EXTRA_DIST += \
 	$(javascript_tests) \
+	$(test_content) \
 	tests/CssClassMatcher.js \
 	tests/test-content/emacs.jsonld \
 	$(NULL)


### PR DESCRIPTION
The mock content needed for the automated tests is now included in the
dist tarball. (Currently, neither the smoke tests nor the content for
the smoke tests are included, but since they are not run by Jenkins nor
installed, that's OK.)

[endlessm/eos-sdk#975]
