### PR TITLE
Home page A functions without cards added

### DIFF
--- a/overrides/homePageA.js
+++ b/overrides/homePageA.js
@@ -160,6 +160,7 @@ const HomePageACardContainer = new Lang.Class({
     Extends: Endless.CustomContainer,
 
     _init: function (props) {
+        this._cards = [];
         this.parent(props);
     },
 
@@ -174,10 +175,13 @@ const HomePageACardContainer = new Lang.Class({
         for (let card of this._cards) {
             this.remove(card);
         }
+        this._cards = [];
     },
 
     vfunc_size_allocate: function (alloc) {
         this.parent(alloc);
+        if (this._cards.length === 0)
+            return;
         let [min, nat] = this._cards_max_preferred_width();
         let visible_cards =  Math.floor(alloc.width / min);
         let total_width = alloc.width;


### PR DESCRIPTION
The container for holding the cards wasn't working when no cards
were set. Now it should work without warnings.

Couldn't think of a good way to test this without mapping a window
to the screen, as the bugs were in size_allocate and
get_preferred... functions. Best way to test for now is comment out
adding cards in the home page smoke test. In the future this would
be a good place for dogtail.
[endlessm/eos-sdk#967]
