### PR TITLE
Stop using overrides for javascript code install

### DIFF
--- a/overrides/EosKnowledge.js
+++ b/overrides/EosKnowledge.js
@@ -1,83 +1,58 @@
-const Lang = imports.lang;
-const Endless = imports.gi.Endless;
-
-let EosKnowledge;
+const _Endless = imports.gi.Endless;
+const EosKnowledge = imports.gi.EosKnowledge;
 
 let _oldSearchPath = imports.searchPath;
-imports.searchPath.unshift(Endless.getCurrentFileDir());
+imports.searchPath.unshift(_Endless.getCurrentFileDir());
 
-const ArticleCard = imports.articleCard;
-const ArticleObjectModel = imports.articleObjectModel;
-const ArticlePageA = imports.articlePageA;
-const Card = imports.card;
-const ContentObjectModel = imports.contentObjectModel;
-const Engine = imports.engine;
-const HomePageA = imports.homePageA;
-const LessonCard = imports.lessonCard;
-const Lightbox = imports.lightbox;
-const ListCard = imports.listCard;
-const ProgressCard = imports.progressCard;
-const SectionArticlePageA = imports.sectionArticlePageA;
-const SectionPageA = imports.sectionPageA;
-const TableOfContents = imports.tableOfContents;
-const TreeNode = imports.treeNode;
-const WebviewSwitcherView = imports.webviewSwitcherView;
-const WindowA = imports.windowA;
+EosKnowledge.ArticleCard = imports.articleCard.ArticleCard;
+EosKnowledge.ArticleObjectModel = imports.articleObjectModel.ArticleObjectModel;
+EosKnowledge.ArticlePageA = imports.articlePageA.ArticlePageA;
+EosKnowledge.Card = imports.card.Card;
+EosKnowledge.ContentObjectModel = imports.contentObjectModel.ContentObjectModel;
+EosKnowledge.Engine = imports.engine.Engine;
+EosKnowledge.HomePageA = imports.homePageA.HomePageA;
+EosKnowledge.LessonCard = imports.lessonCard.LessonCard;
+EosKnowledge.Lightbox = imports.lightbox.Lightbox;
+EosKnowledge.ListCard = imports.listCard.ListCard;
+EosKnowledge.ProgressCard = imports.progressCard.ProgressCard;
+EosKnowledge.SectionArticlePageA = imports.sectionArticlePageA.SectionArticlePageA;
+EosKnowledge.SectionPageA = imports.sectionPageA.SectionPageA;
+EosKnowledge.TableOfContents = imports.tableOfContents.TableOfContents;
+EosKnowledge.tree_model_from_tree_node = imports.treeNode.tree_model_from_tree_node;
+EosKnowledge.WebviewSwitcherView = imports.webviewSwitcherView.WebviewSwitcherView;
+EosKnowledge.WindowA = imports.windowA.WindowA;
+
+// Hackzors. We need to load the gresource from javascript before any C
+// calls are made (to load the CSS). By referencing one of our C functions
+// here we force the C lib to be initialized along with it its gresource
+EosKnowledge.hello_c;
+
+// More hackzors. Work around bug where GList-type properties aren't
+// converted properly into JS values.
+// https://bugzilla.gnome.org/show_bug.cgi?id=727787
+Object.defineProperties(EosKnowledge.HistoryModel.prototype, {
+    'back-list': {
+        get: EosKnowledge.HistoryModel.prototype.get_back_list
+    },
+    'forward-list': {
+        get: EosKnowledge.HistoryModel.prototype.get_forward_list
+    },
+    // Once again with underscores, because that's the most used name to
+    // access properties with
+    'back_list': {
+        get: EosKnowledge.HistoryModel.prototype.get_back_list
+    },
+    'forward_list': {
+        get: EosKnowledge.HistoryModel.prototype.get_forward_list
+    },
+    // Once again in camelCaps, because GJS supports that notation too for
+    // properties
+    'backList': {
+        get: EosKnowledge.HistoryModel.prototype.get_back_list
+    },
+    'forwardList': {
+        get: EosKnowledge.HistoryModel.prototype.get_forward_list
+    }
+});
 
 imports.searchPath = _oldSearchPath;
-
-function _init() {
-    // "this" is imports.gi.EosKnowledge
-    EosKnowledge = this;
-
-    // Hackzors. We need to load the gresource from javascript before any C
-    // calls are made (to load the CSS). By referencing one of our C functions
-    // here we force the C lib to be initialized along with it its gresource
-    this.hello_c;
-
-    // More hackzors. Work around bug where GList-type properties aren't
-    // converted properly into JS values.
-    // https://bugzilla.gnome.org/show_bug.cgi?id=727787
-    Object.defineProperties(EosKnowledge.HistoryModel.prototype, {
-        'back-list': {
-            get: EosKnowledge.HistoryModel.prototype.get_back_list
-        },
-        'forward-list': {
-            get: EosKnowledge.HistoryModel.prototype.get_forward_list
-        },
-        // Once again with underscores, because that's the most used name to
-        // access properties with
-        'back_list': {
-            get: EosKnowledge.HistoryModel.prototype.get_back_list
-        },
-        'forward_list': {
-            get: EosKnowledge.HistoryModel.prototype.get_forward_list
-        },
-        // Once again in camelCaps, because GJS supports that notation too for
-        // properties
-        'backList': {
-            get: EosKnowledge.HistoryModel.prototype.get_back_list
-        },
-        'forwardList': {
-            get: EosKnowledge.HistoryModel.prototype.get_forward_list
-        }
-    });
-
-    EosKnowledge.ArticleCard = ArticleCard.ArticleCard;
-    EosKnowledge.ArticleObjectModel = ArticleObjectModel.ArticleObjectModel;
-    EosKnowledge.ArticlePageA = ArticlePageA.ArticlePageA;
-    EosKnowledge.Card = Card.Card;
-    EosKnowledge.ContentObjectModel = ContentObjectModel.ContentObjectModel;
-    EosKnowledge.Engine = Engine.Engine;
-    EosKnowledge.HomePageA = HomePageA.HomePageA;
-    EosKnowledge.LessonCard = LessonCard.LessonCard;
-    EosKnowledge.Lightbox = Lightbox.Lightbox;
-    EosKnowledge.ListCard = ListCard.ListCard;
-    EosKnowledge.ProgressCard = ProgressCard.ProgressCard;
-    EosKnowledge.SectionArticlePageA = SectionArticlePageA.SectionArticlePageA;
-    EosKnowledge.SectionPageA = SectionPageA.SectionPageA;
-    EosKnowledge.TableOfContents = TableOfContents.TableOfContents;
-    EosKnowledge.tree_model_from_tree_node = TreeNode.tree_model_from_tree_node;
-    EosKnowledge.WebviewSwitcherView = WebviewSwitcherView.WebviewSwitcherView;
-    EosKnowledge.WindowA = WindowA.WindowA;
-}

--- a/overrides/Makefile.am.inc
+++ b/overrides/Makefile.am.inc
@@ -1,7 +1,7 @@
 ## Copyright 2014 Endless Mobile, Inc.
 ## Included in toplevel Makefile.am
 
-overridesdir = $(datadir)/gjs-1.0/overrides
+overridesdir = $(datadir)/eos-js-common
 pkgoverridesdir = $(pkgdatadir)/overrides
 public_overrides = \
 	overrides/EosKnowledge.js \

--- a/tests/eosknowledge/testArticleCard.js
+++ b/tests/eosknowledge/testArticleCard.js
@@ -1,4 +1,4 @@
-const EosKnowledge = imports.gi.EosKnowledge;
+const EosKnowledge = imports.EosKnowledge.EosKnowledge;
 const Gtk = imports.gi.Gtk;
 
 Gtk.init(null);

--- a/tests/eosknowledge/testArticleObjectModel.js
+++ b/tests/eosknowledge/testArticleObjectModel.js
@@ -1,5 +1,5 @@
 const Endless = imports.gi.Endless;
-const EosKnowledge = imports.gi.EosKnowledge;
+const EosKnowledge = imports.EosKnowledge.EosKnowledge;
 const Gtk = imports.gi.Gtk;
 const InstanceOfMatcher = imports.InstanceOfMatcher;
 

--- a/tests/eosknowledge/testArticlePageA.js
+++ b/tests/eosknowledge/testArticlePageA.js
@@ -1,4 +1,4 @@
-const EosKnowledge = imports.gi.EosKnowledge;
+const EosKnowledge = imports.EosKnowledge.EosKnowledge;
 const Gtk = imports.gi.Gtk;
 
 const InstanceOfMatcher = imports.InstanceOfMatcher;

--- a/tests/eosknowledge/testCard.js
+++ b/tests/eosknowledge/testCard.js
@@ -1,4 +1,4 @@
-const EosKnowledge = imports.gi.EosKnowledge;
+const EosKnowledge = imports.EosKnowledge.EosKnowledge;
 const Gtk = imports.gi.Gtk;
 
 const CssClassMatcher = imports.CssClassMatcher;

--- a/tests/eosknowledge/testContentObjectModel.js
+++ b/tests/eosknowledge/testContentObjectModel.js
@@ -1,5 +1,5 @@
 const Endless = imports.gi.Endless;
-const EosKnowledge = imports.gi.EosKnowledge;
+const EosKnowledge = imports.EosKnowledge.EosKnowledge;
 
 const utils = imports.utils;
 

--- a/tests/eosknowledge/testEngine.js
+++ b/tests/eosknowledge/testEngine.js
@@ -1,5 +1,5 @@
-const EosKnowledge = imports.gi.EosKnowledge;
 const Endless = imports.gi.Endless;
+const EosKnowledge = imports.EosKnowledge.EosKnowledge;
 const Soup = imports.gi.Soup;
 
 const InstanceOfMatcher = imports.InstanceOfMatcher;

--- a/tests/eosknowledge/testHello.js
+++ b/tests/eosknowledge/testHello.js
@@ -1,4 +1,4 @@
-const EosKnowledge = imports.gi.EosKnowledge;
+const EosKnowledge = imports.EosKnowledge.EosKnowledge;
 
 describe('Sample C test', function () {
     it('returns an appropriate greeting', function () {

--- a/tests/eosknowledge/testHistoryItemModel.js
+++ b/tests/eosknowledge/testHistoryItemModel.js
@@ -1,7 +1,7 @@
 const GObject = imports.gi.GObject;
 const Lang = imports.lang;
 
-const EosKnowledge = imports.gi.EosKnowledge;
+const EosKnowledge = imports.EosKnowledge.EosKnowledge;
 
 GObject.ParamFlags.READWRITE = GObject.ParamFlags.READABLE | GObject.ParamFlags.WRITABLE;
 

--- a/tests/eosknowledge/testHistoryModel.js
+++ b/tests/eosknowledge/testHistoryModel.js
@@ -3,7 +3,7 @@
 const GObject = imports.gi.GObject;
 const Lang = imports.lang;
 
-const EosKnowledge = imports.gi.EosKnowledge;
+const EosKnowledge = imports.EosKnowledge.EosKnowledge;
 
 GObject.ParamFlags.READWRITE = GObject.ParamFlags.READABLE | GObject.ParamFlags.WRITABLE;
 

--- a/tests/eosknowledge/testHomePageA.js
+++ b/tests/eosknowledge/testHomePageA.js
@@ -1,4 +1,4 @@
-const EosKnowledge = imports.gi.EosKnowledge;
+const EosKnowledge = imports.EosKnowledge.EosKnowledge;
 const Endless = imports.gi.Endless;
 const Gtk = imports.gi.Gtk;
 

--- a/tests/eosknowledge/testLessonCard.js
+++ b/tests/eosknowledge/testLessonCard.js
@@ -1,4 +1,4 @@
-const EosKnowledge = imports.gi.EosKnowledge;
+const EosKnowledge = imports.EosKnowledge.EosKnowledge;
 const Gtk = imports.gi.Gtk;
 
 const CssClassMatcher = imports.CssClassMatcher;

--- a/tests/eosknowledge/testLightbox.js
+++ b/tests/eosknowledge/testLightbox.js
@@ -1,4 +1,4 @@
-const EosKnowledge = imports.gi.EosKnowledge;
+const EosKnowledge = imports.EosKnowledge.EosKnowledge;
 const Gtk = imports.gi.Gtk;
 
 const CssClassMatcher = imports.CssClassMatcher;

--- a/tests/eosknowledge/testListCard.js
+++ b/tests/eosknowledge/testListCard.js
@@ -1,4 +1,4 @@
-const EosKnowledge = imports.gi.EosKnowledge;
+const EosKnowledge = imports.EosKnowledge.EosKnowledge;
 const Gtk = imports.gi.Gtk;
 
 Gtk.init(null);

--- a/tests/eosknowledge/testProgressCard.js
+++ b/tests/eosknowledge/testProgressCard.js
@@ -1,4 +1,4 @@
-const EosKnowledge = imports.gi.EosKnowledge;
+const EosKnowledge = imports.EosKnowledge.EosKnowledge;
 const Gtk = imports.gi.Gtk;
 
 const CssClassMatcher = imports.CssClassMatcher;

--- a/tests/eosknowledge/testSectionArticlePageA.js
+++ b/tests/eosknowledge/testSectionArticlePageA.js
@@ -1,4 +1,4 @@
-const EosKnowledge = imports.gi.EosKnowledge;
+const EosKnowledge = imports.EosKnowledge.EosKnowledge;
 const Endless = imports.gi.Endless;
 const Gtk = imports.gi.Gtk;
 

--- a/tests/eosknowledge/testSectionPageA.js
+++ b/tests/eosknowledge/testSectionPageA.js
@@ -1,4 +1,4 @@
-const EosKnowledge = imports.gi.EosKnowledge;
+const EosKnowledge = imports.EosKnowledge.EosKnowledge;
 const Endless = imports.gi.Endless;
 const Gtk = imports.gi.Gtk;
 

--- a/tests/eosknowledge/testTableOfContents.js
+++ b/tests/eosknowledge/testTableOfContents.js
@@ -1,4 +1,4 @@
-const EosKnowledge = imports.gi.EosKnowledge;
+const EosKnowledge = imports.EosKnowledge.EosKnowledge;
 const Gtk = imports.gi.Gtk;
 
 const CssClassMatcher = imports.CssClassMatcher;

--- a/tests/eosknowledge/testTreeNode.js
+++ b/tests/eosknowledge/testTreeNode.js
@@ -1,6 +1,6 @@
 // Copyright 2014 Endless Mobile, Inc.
 
-const EosKnowledge = imports.gi.EosKnowledge;
+const EosKnowledge = imports.EosKnowledge.EosKnowledge;
 const GObject = imports.gi.GObject;
 const Gtk = imports.gi.Gtk;
 

--- a/tests/eosknowledge/testWebviewSwitcher.js
+++ b/tests/eosknowledge/testWebviewSwitcher.js
@@ -1,4 +1,4 @@
-const EosKnowledge = imports.gi.EosKnowledge;
+const EosKnowledge = imports.EosKnowledge.EosKnowledge;
 const GLib = imports.gi.GLib;
 const GObject = imports.gi.GObject;
 const Gtk = imports.gi.Gtk;

--- a/tests/eosknowledge/testWindowA.js
+++ b/tests/eosknowledge/testWindowA.js
@@ -1,5 +1,5 @@
 const Endless = imports.gi.Endless;
-const EosKnowledge = imports.gi.EosKnowledge;
+const EosKnowledge = imports.EosKnowledge.EosKnowledge;
 const GLib = imports.gi.GLib;
 const Gtk = imports.gi.Gtk;
 

--- a/tests/smoke-tests/articlePageASmokeTest.js
+++ b/tests/smoke-tests/articlePageASmokeTest.js
@@ -1,5 +1,5 @@
 const Endless = imports.gi.Endless;
-const EosKnowledge = imports.gi.EosKnowledge;
+const EosKnowledge = imports.EosKnowledge.EosKnowledge;
 const Gdk = imports.gi.Gdk;
 const Gio = imports.gi.Gio;
 const GLib = imports.gi.GLib;

--- a/tests/smoke-tests/browserSmokeTest.js
+++ b/tests/smoke-tests/browserSmokeTest.js
@@ -1,4 +1,4 @@
-const EosKnowledge = imports.gi.EosKnowledge;
+const EosKnowledge = imports.EosKnowledge.EosKnowledge;
 const Gdk = imports.gi.Gdk;
 const GLib = imports.gi.GLib;
 const GObject = imports.gi.GObject;

--- a/tests/smoke-tests/cardSmokeTest.js
+++ b/tests/smoke-tests/cardSmokeTest.js
@@ -2,7 +2,7 @@ const Gtk = imports.gi.Gtk;
 const Gdk = imports.gi.Gdk;
 const Gio = imports.gi.Gio;
 const Endless = imports.gi.Endless;
-const EosKnowledge = imports.gi.EosKnowledge;
+const EosKnowledge = imports.EosKnowledge.EosKnowledge;
 const Lang = imports.lang;
 
 const TEST_APPLICATION_ID = 'com.endlessm.knowledge.card';

--- a/tests/smoke-tests/homePageASmokeTest.js
+++ b/tests/smoke-tests/homePageASmokeTest.js
@@ -2,7 +2,7 @@ const Gtk = imports.gi.Gtk;
 const Gdk = imports.gi.Gdk;
 const Gio = imports.gi.Gio;
 const Endless = imports.gi.Endless;
-const EosKnowledge = imports.gi.EosKnowledge;
+const EosKnowledge = imports.EosKnowledge.EosKnowledge;
 const Lang = imports.lang;
 
 const TEST_APPLICATION_ID = 'com.endlessm.knowledge.pages';

--- a/tests/smoke-tests/lightboxSmokeTest.js
+++ b/tests/smoke-tests/lightboxSmokeTest.js
@@ -1,5 +1,5 @@
 const Endless = imports.gi.Endless;
-const EosKnowledge = imports.gi.EosKnowledge;
+const EosKnowledge = imports.EosKnowledge.EosKnowledge;
 const Gdk = imports.gi.Gdk;
 const Gio = imports.gi.Gio;
 const Gtk = imports.gi.Gtk;

--- a/tests/smoke-tests/scrollManagerSmokeTest.js
+++ b/tests/smoke-tests/scrollManagerSmokeTest.js
@@ -2,7 +2,7 @@ const Gio = imports.gi.Gio;
 const Gtk = imports.gi.Gtk;
 const Lang = imports.lang;
 const Endless = imports.gi.Endless;
-const EosKnowledge = imports.gi.EosKnowledge;
+const EosKnowledge = imports.EosKnowledge.EosKnowledge;
 const WebKit2 = imports.gi.WebKit2;
 Gtk.init(null);
 

--- a/tests/smoke-tests/sectionArticlePageSmokeTest.js
+++ b/tests/smoke-tests/sectionArticlePageSmokeTest.js
@@ -1,5 +1,5 @@
 const Endless = imports.gi.Endless;
-const EosKnowledge = imports.gi.EosKnowledge;
+const EosKnowledge = imports.EosKnowledge.EosKnowledge;
 const Gdk = imports.gi.Gdk;
 const Gio = imports.gi.Gio;
 const Gtk = imports.gi.Gtk;

--- a/tests/smoke-tests/sectionPageASmokeTest.js
+++ b/tests/smoke-tests/sectionPageASmokeTest.js
@@ -2,7 +2,7 @@ const Gtk = imports.gi.Gtk;
 const Gdk = imports.gi.Gdk;
 const Gio = imports.gi.Gio;
 const Endless = imports.gi.Endless;
-const EosKnowledge = imports.gi.EosKnowledge;
+const EosKnowledge = imports.EosKnowledge.EosKnowledge;
 const Lang = imports.lang;
 
 const TEST_APPLICATION_ID = 'com.endlessm.knowledge.section-page';

--- a/tests/smoke-tests/tableOfContentsSmokeTest.js
+++ b/tests/smoke-tests/tableOfContentsSmokeTest.js
@@ -1,5 +1,5 @@
 const Endless = imports.gi.Endless;
-const EosKnowledge = imports.gi.EosKnowledge;
+const EosKnowledge = imports.EosKnowledge.EosKnowledge;
 const Gdk = imports.gi.Gdk;
 const Gio = imports.gi.Gio;
 const Gtk = imports.gi.Gtk;

--- a/tests/smoke-tests/webviewSwitcherViewSmokeTest.js
+++ b/tests/smoke-tests/webviewSwitcherViewSmokeTest.js
@@ -1,4 +1,4 @@
-const EosKnowledge = imports.gi.EosKnowledge;
+const EosKnowledge = imports.EosKnowledge.EosKnowledge;
 const Gdk = imports.gi.Gdk;
 const GLib = imports.gi.GLib;
 const GObject = imports.gi.GObject;

--- a/tests/smoke-tests/windowASmokeTest.js
+++ b/tests/smoke-tests/windowASmokeTest.js
@@ -1,5 +1,5 @@
 const Endless = imports.gi.Endless;
-const EosKnowledge = imports.gi.EosKnowledge;
+const EosKnowledge = imports.EosKnowledge.EosKnowledge;
 const Gdk = imports.gi.Gdk;
 const Gio = imports.gi.Gio;
 const Gtk = imports.gi.Gtk;


### PR DESCRIPTION
Instead install EosKnowledge.js to a location on the GJS_PATH.
Instead of overrides just mess with the imports.gi.EosKnowledge
object directly in EosKnowledge.js. This gives us the rather ugly
path of imports.EosKnowledge.EosKnowledge, but makes the contents
of EosKnowledge a lot simpler.

And of course, exceptions in our javascript code just get reported
normally now
[endlessm/eos-sdk#1026]
