### PR TITLE
TreeNode properties agree with knowledge engine

### DIFF
--- a/overrides/treeNode.js
+++ b/overrides/treeNode.js
@@ -6,11 +6,11 @@ const Gtk = imports.gi.Gtk;
 
 const TABLE_OF_CONTENTS_SCHEMA = 'tableOfContents';
 const ID_SCHEMA = '@id';
-const NODE_PARENT_SCHEMA = 'nodeParent';
-const NODE_INDEX_SCHEMA = 'nodeIndex';
-const NODE_INDEX_LABEL_SCHEMA = 'nodeIndexLabel';
-const NODE_LABEL_SCHEMA = 'nodeLabel';
-const NODE_CONTENT_SCHEMA = 'nodeContent';
+const NODE_PARENT_SCHEMA = 'hasParent';
+const NODE_INDEX_SCHEMA = 'hasIndex';
+const NODE_INDEX_LABEL_SCHEMA = 'hasIndexLabel';
+const NODE_LABEL_SCHEMA = 'hasLabel';
+const NODE_CONTENT_SCHEMA = 'hasContent';
 
 /**
  * Section: TreeNode
@@ -34,8 +34,8 @@ const NODE_CONTENT_SCHEMA = 'nodeContent';
  *   hasLabel (String) - A displayable string describing the node's content
  *   hasContent (<ContentObject>) - The <ContentObject> that this node refers to
  *
- * These properties are represented by the shorthands *nodeParent*, *nodeIndex*,
- * *nodeIndexLabel*, *nodeLabel*, and *nodeContent* respectively.
+ * These properties are represented by the shorthands *hasParent*, *hasIndex*,
+ * *hasIndexLabel*, *hasLabel*, and *hasContent* respectively.
  *
  * For an example, see the <live document at http://goo.gl/t0CF7g>.
  */

--- a/tests/eosknowledge/testTreeNode.js
+++ b/tests/eosknowledge/testTreeNode.js
@@ -10,48 +10,48 @@ const TEST_OBJ = {
     tableOfContents: [
         {
             '@id': '_:1',
-            nodeIndex: 0,
-            nodeIndexLabel: '1',
-            nodeLabel: 'Foo',
-            nodeContent: 'http://skynet.com/content#Foo'
+            hasIndex: 0,
+            hasIndexLabel: '1',
+            hasLabel: 'Foo',
+            hasContent: 'http://skynet.com/content#Foo'
         },
         {
             '@id': '_:1.a',
-            nodeIndex: 0,
-            nodeIndexLabel: '1.a',
-            nodeLabel: 'Lorum',
-            nodeParent: '_:1',
-            nodeContent: 'http://skynet.com/content#Lorum'
+            hasIndex: 0,
+            hasIndexLabel: '1.a',
+            hasLabel: 'Lorum',
+            hasParent: '_:1',
+            hasContent: 'http://skynet.com/content#Lorum'
         },
         {
             '@id': '_:1.b',
-            nodeIndex: 1,
-            nodeIndexLabel: '1.b',
-            nodeLabel: 'Ipsum',
-            nodeParent: '_:1',
-            nodeContent: 'http://skynet.com/content#Ipsum'
+            hasIndex: 1,
+            hasIndexLabel: '1.b',
+            hasLabel: 'Ipsum',
+            hasParent: '_:1',
+            hasContent: 'http://skynet.com/content#Ipsum'
         },
         {
             '@id': '_:1.b.i',
-            nodeIndex: 0,
-            nodeIndexLabel: '1.b.i',
-            nodeLabel: 'Blah',
-            nodeParent: '_:1.b',
-            nodeContent: 'http://skynet.com/content#Blah'
+            hasIndex: 0,
+            hasIndexLabel: '1.b.i',
+            hasLabel: 'Blah',
+            hasParent: '_:1.b',
+            hasContent: 'http://skynet.com/content#Blah'
         },
         {
             '@id': '_:2',
-            nodeIndex: 1,
-            nodeIndexLabel: '2',
-            nodeLabel: 'Bar',
-            nodeContent: 'http://skynet.com/content#Bar'
+            hasIndex: 1,
+            hasIndexLabel: '2',
+            hasLabel: 'Bar',
+            hasContent: 'http://skynet.com/content#Bar'
         },
         {
             '@id': '_:3',
-            nodeIndex: 2,
-            nodeIndexLabel: '3',
-            nodeLabel: 'Baz',
-            nodeContent: 'http://skynet.com/content#Baz'
+            hasIndex: 2,
+            hasIndexLabel: '3',
+            hasLabel: 'Baz',
+            hasContent: 'http://skynet.com/content#Baz'
         }
     ]
 };

--- a/tests/test-content/greyjoy-article.jsonld
+++ b/tests/test-content/greyjoy-article.jsonld
@@ -27,32 +27,32 @@
     "tableOfContents": [
         {
             "@id": "_:1",
-            "nodeIndex": 0,
-            "nodeIndexLabel": "1",
-            "nodeLabel": "History",
-            "nodeContent": "ekn:asoiaf/House_Greyjoy#History"
+            "hasIndex": 0,
+            "hasIndexLabel": "1",
+            "hasLabel": "History",
+            "hasContent": "ekn:asoiaf/House_Greyjoy#History"
         },
         {
             "@id": "_:1.a",
-            "nodeIndex": 0,
-            "nodeIndexLabel": "1.a",
-            "nodeLabel": "When They Used To Be Cool",
-            "nodeParent": "_:1",
-            "nodeContent": "ekn:asoiaf/House_Greyjoy#Never"
+            "hasIndex": 0,
+            "hasIndexLabel": "1.a",
+            "hasLabel": "When They Used To Be Cool",
+            "hasParent": "_:1",
+            "hasContent": "ekn:asoiaf/House_Greyjoy#Never"
         },
         {
             "@id": "_:2",
-            "nodeIndex": 1,
-            "nodeIndexLabel": "2",
-            "nodeLabel": "Sigil",
-            "nodeContent": "ekn:asoiaf/House_Greyjoy#Literally_A_Squid"
+            "hasIndex": 1,
+            "hasIndexLabel": "2",
+            "hasLabel": "Sigil",
+            "hasContent": "ekn:asoiaf/House_Greyjoy#Literally_A_Squid"
         },
         {
             "@id": "_:3",
-            "nodeIndex": 2,
-            "nodeIndexLabel": "3",
-            "nodeLabel": "Criticisms",
-            "nodeContent": "ekn:asoiaf/House_Greyjoy#Seriously"
+            "hasIndex": 2,
+            "hasIndexLabel": "3",
+            "hasLabel": "Criticisms",
+            "hasContent": "ekn:asoiaf/House_Greyjoy#Seriously"
         } 
     ]
 }


### PR DESCRIPTION
All instances of "nodeParent" etc. have been replaced with
"hasParent", in accordance with the almighty knowledge engine

[endlessm/eos-sdk#1047]
