### PR TITLE
Include ekn-app-runner with gir package

### DIFF
--- a/debian/gir1.2-eosknowledge-0.install
+++ b/debian/gir1.2-eosknowledge-0.install
@@ -1,3 +1,4 @@
+usr/bin/ekn-app-runner
 usr/lib/girepository-1.0/EosKnowledge*.typelib
 usr/share/gjs-1.0/overrides/*
 usr/share/eos-knowledge-lib/overrides/*


### PR DESCRIPTION
ekn-app-runner is a gjs script which needs all of our overrides to
run, so I think it makes sense to be in this package

[endlessm/eos-sdk#1117]
