### PR TITLE
Include ekn-app-runner in EXTRA_DIST, fix make dist

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -115,6 +115,9 @@ CLEANFILES += $(gir_DATA) $(typelib_DATA)
 endif
 
 # # # TOOLS # # #
+
+EXTRA_DIST += tools/ekn-app-runner
+
 bin_SCRIPTS = \
 	tools/ekn-app-runner \
 	$(NULL)


### PR DESCRIPTION
We needed to include the script in EXTRA_DIST so it can be found
when running make dist, make distcheck
[endlessm/eos-sdk#1117]
