### PR TITLE
Added Media model, as well as Image and Video models

### DIFF
--- a/overrides/EosKnowledge.js
+++ b/overrides/EosKnowledge.js
@@ -20,6 +20,7 @@ const KnowledgeApp = imports.knowledgeApp;
 const LessonCard = imports.lessonCard;
 const Lightbox = imports.lightbox;
 const ListCard = imports.listCard;
+const MediaObjectModel = imports.mediaObjectModel;
 const Presenter = imports.presenter;
 const Previewer = imports.previewer;
 const ProgressCard = imports.progressCard;
@@ -88,10 +89,12 @@ function _init() {
     EosKnowledge.ContentObjectModel = ContentObjectModel.ContentObjectModel;
     EosKnowledge.Engine = Engine.Engine;
     EosKnowledge.HomePageA = HomePageA.HomePageA;
+    EosKnowledge.ImageObjectModel = MediaObjectModel.ImageObjectModel;
     EosKnowledge.KnowledgeApp = KnowledgeApp.KnowledgeApp;
     EosKnowledge.LessonCard = LessonCard.LessonCard;
     EosKnowledge.Lightbox = Lightbox.Lightbox;
     EosKnowledge.ListCard = ListCard.ListCard;
+    EosKnowledge.MediaObjectModel = MediaObjectModel.MediaObjectModel;
     EosKnowledge.Presenter = Presenter.Presenter;
     EosKnowledge.Previewer = Previewer.Previewer;
     EosKnowledge.ProgressCard = ProgressCard.ProgressCard;
@@ -99,6 +102,7 @@ function _init() {
     EosKnowledge.SectionPageA = SectionPageA.SectionPageA;
     EosKnowledge.TableOfContents = TableOfContents.TableOfContents;
     EosKnowledge.tree_model_from_tree_node = TreeNode.tree_model_from_tree_node;
+    EosKnowledge.VideoObjectModel = MediaObjectModel.VideoObjectModel;
     EosKnowledge.WebviewSwitcherView = WebviewSwitcherView.WebviewSwitcherView;
     EosKnowledge.WindowA = WindowA.WindowA;
 }

--- a/overrides/Makefile.am.inc
+++ b/overrides/Makefile.am.inc
@@ -18,6 +18,7 @@ public_overrides = \
 	overrides/lightbox.js \
 	overrides/listCard.js \
 	overrides/marginButton.js \
+	overrides/mediaObjectModel.js \
 	overrides/presenter.js \
 	overrides/progressCard.js \
 	overrides/previewer.js \

--- a/overrides/engine.js
+++ b/overrides/engine.js
@@ -134,7 +134,11 @@ const Engine = Lang.Class({
             'ekv:ContentObject':
                 EosKnowledge.ContentObjectModel,
             'ekv:ArticleObject':
-                EosKnowledge.ArticleObjectModel
+                EosKnowledge.ArticleObjectModel,
+            'ekv:ImageObject':
+                EosKnowledge.ImageObjectModel,
+            'ekv:VideoObject':
+                EosKnowledge.VideoObjectModel,
         };
 
         let json_ld_type = json_ld['@type'];

--- a/overrides/mediaObjectModel.js
+++ b/overrides/mediaObjectModel.js
@@ -1,0 +1,264 @@
+// Copyright 2014 Endless Mobile, Inc.
+
+const Endless = imports.gi.Endless;
+const EosKnowledge = imports.gi.EosKnowledge;
+const GLib = imports.gi.GLib;
+const GObject = imports.gi.GObject;
+const Gtk = imports.gi.Gtk;
+const Lang = imports.lang;
+
+const ContentObjectModel = imports.contentObjectModel;
+
+GObject.ParamFlags.READWRITE = GObject.ParamFlags.READABLE | GObject.ParamFlags.WRITABLE;
+
+/**
+ * Class: MediaObjectModel
+ * The model class for media objects. A media obejct has the same 
+ * properties as a <ContentObjectModel>, plus <content-uri>, <caption>,
+ * <encoding-format>, <height> and <width> properties
+ */
+const MediaObjectModel = new Lang.Class({
+    Name: 'MediaObjectModel',
+    GTypeName: 'EknMediaObjectModel',
+    Extends: ContentObjectModel.ContentObjectModel,
+    Properties: {
+        /**
+         * Property: content-uri
+         * The URI at which the content resides. Defaults to "about:blank"
+         */
+        'content-uri': GObject.ParamSpec.string('content-uri',
+            'Media Content URI', 'URI to the media object content',
+            GObject.ParamFlags.READWRITE | GObject.ParamFlags.CONSTRUCT,
+            'about:blank'),
+
+        /**
+         * Property: caption
+         * A displayable string which describes the media object in the same
+         * language as the MediaObject. Defaults to empty string
+         */
+        'caption': GObject.ParamSpec.string('caption',
+            'Caption', 'Displayable caption for the media',
+            GObject.ParamFlags.READWRITE | GObject.ParamFlags.CONSTRUCT,
+            ''),
+
+        /**
+         * Property: encoding-format
+         * The format in which the content is encoded. Defaults to empty string
+         */
+        'encoding-format': GObject.ParamSpec.string('encoding-format',
+            'Encoding Format', 'The format in which the content is encoded',
+            GObject.ParamFlags.READWRITE | GObject.ParamFlags.CONSTRUCT,
+            ''),
+
+        /**
+         * Property: height
+         * The height of the media in pixels. Defaults to 0
+         */
+        'height': GObject.ParamSpec.uint('height',
+            'Height', 'The height of the media in pixels',
+            GObject.ParamFlags.READWRITE | GObject.ParamFlags.CONSTRUCT,
+            0, GLib.MAXUINT32, 0),
+
+        /**
+         * Property: width
+         * The width of the media in pixels. Defaults to 0
+         */
+        'width': GObject.ParamSpec.uint('width',
+            'Width', 'The width of the media in pixels',
+            GObject.ParamFlags.READWRITE | GObject.ParamFlags.CONSTRUCT,
+            0, GLib.MAXUINT32, 0)
+    },
+    
+    _init: function (params) {
+        this.parent(params);
+    },
+
+    get caption () {
+        return this._caption;
+    },
+
+    get content_uri () {
+        return this._content_uri;
+    },
+
+    get encoding_format () {
+        return this._encoding_format;
+    },
+
+    get width () {
+        return this._width;
+    },
+
+    get height () {
+        return this._height;
+    },
+
+    set caption (v) {
+        this._caption = v;
+    },
+
+    set content_uri (v) {
+        this._content_uri = v;
+    },
+
+    set encoding_format (v) {
+        this._encoding_format = v;
+    },
+
+    set width (v) {
+        this._width = v;
+    },
+
+    set height (v) {
+        this._height = v;
+    },
+});
+
+/**
+ * Constructor: new_from_json_ld
+ * Creates an MediaObjectModel from a Knowledge Engine MediaObject
+ * JSON-LD document
+ */
+MediaObjectModel.new_from_json_ld = function (json_ld_data) {
+    let props = MediaObjectModel._props_from_json_ld(json_ld_data);
+    return new MediaObjectModel(props);
+};
+
+MediaObjectModel._props_from_json_ld = function (json_ld_data) {
+    // Inherit properties marshalled from parent class
+    let ParentClass = MediaObjectModel.__super__;
+    let props = ParentClass._props_from_json_ld(json_ld_data);
+
+    // Marshal properties specific to MediaObjectModel
+    if (json_ld_data.hasOwnProperty('@id')) {
+        props.content_uri = json_ld_data['@id'];
+    }
+
+    if (json_ld_data.hasOwnProperty('caption')) {
+        props.caption = json_ld_data.caption;
+    }
+
+    if (json_ld_data.hasOwnProperty('encodingFormat')) {
+        props.encoding_format = json_ld_data.encodingFormat;
+    }
+
+    if (json_ld_data.hasOwnProperty('height')) {
+        props.height = parseInt(json_ld_data.height);
+    }
+
+    if (json_ld_data.hasOwnProperty('width')) {
+        props.width = parseInt(json_ld_data.width);
+    }
+
+    return props;
+};
+
+/**
+ * Class: ImageObjectModel
+ * The model class for media objects. A media obejct has the same properties as
+ * a <MediaObjectModel>
+ */
+const ImageObjectModel = Lang.Class({
+    Name: 'ImageObjectModel',
+    GTypeName: 'EknImageObjectModel',
+    Extends: MediaObjectModel,
+
+    _init: function (props) {
+        this.parent(props);
+    }
+});
+
+/**
+ * Constructor: new_from_json_ld
+ * Creates an ImageObjectModel from a Knowledge Engine ImageObject
+ * JSON-LD document
+ */
+ImageObjectModel.new_from_json_ld = function (json_ld_data) {
+    let props = ImageObjectModel._props_from_json_ld(json_ld_data);
+    return new ImageObjectModel(props);
+};
+
+ImageObjectModel._props_from_json_ld = function (json_ld_data) {
+    // ImageObject inherits all its properties from its parent
+    let ParentClass = ImageObjectModel.__super__;
+    return ParentClass._props_from_json_ld(json_ld_data);
+};
+
+/**
+ * Class: VideoObjectModel
+ * The model class for media objects. A media obejct has the same 
+ * properties as a <MediaObjectModel>, plus <duration> and <transcript>
+ * properties
+ */
+const VideoObjectModel = Lang.Class({
+    Name: 'VideoObjectModel',
+    GTypeName: 'EknVideoObjectModel',
+    Extends: MediaObjectModel,
+    Properties: {
+        /**
+         * Property: duration
+         * The duration of the video in ISO 8601 format. Defaults to empty
+         * string
+         */
+        'duration': GObject.ParamSpec.string('duration',
+            'Duration', 'The duration of the video in ISO 8601 format',
+            GObject.ParamFlags.READWRITE | GObject.ParamFlags.CONSTRUCT,
+            ''),
+
+        /**
+         * Property: transcript
+         * Transcript of the video, in the same language as the video. Defaults
+         * to empty string
+         */
+        'transcript': GObject.ParamSpec.string('transcript',
+            'Transcript', 'Transcript of the video',
+            GObject.ParamFlags.READWRITE | GObject.ParamFlags.CONSTRUCT,
+            ''),
+    },
+
+    _init: function (props) {
+        this.parent(props);
+    },
+
+    get transcript () {
+        return this._transcript;
+    },
+
+    get duration () {
+        return this._duration;
+    },
+
+    set transcript (v) {
+        this._transcript = v;
+    },
+
+    set duration (v) {
+        this._duration = v;
+    },
+
+});
+
+VideoObjectModel.new_from_json_ld = function (json_ld_data) {
+    let props = VideoObjectModel._props_from_json_ld(json_ld_data);
+    return new VideoObjectModel(props);
+};
+
+/**
+ * Constructor: new_from_json_ld
+ * Creates an VideoObjectModel from a Knowledge Engine VideoObject
+ * JSON-LD document
+ */
+VideoObjectModel._props_from_json_ld = function (json_ld_data) {
+    let ParentClass = VideoObjectModel.__super__;
+    let props = ParentClass._props_from_json_ld(json_ld_data);
+
+    if (json_ld_data.hasOwnProperty('duration')) {
+        props.duration = json_ld_data.duration;
+    }
+
+    if (json_ld_data.hasOwnProperty('transcript')) {
+        props.transcript = json_ld_data.transcript;
+    }
+
+    return props;
+};

--- a/tests/Makefile.am.inc
+++ b/tests/Makefile.am.inc
@@ -16,6 +16,7 @@ javascript_tests = \
 	tests/eosknowledge/testLessonCard.js \
 	tests/eosknowledge/testLightbox.js \
 	tests/eosknowledge/testListCard.js \
+	tests/eosknowledge/testMediaObjectModels.js \
 	tests/eosknowledge/testPresenter.js \
 	tests/eosknowledge/testPreviewer.js \
 	tests/eosknowledge/testProgressCard.js \
@@ -31,8 +32,11 @@ test_content = \
 	tests/test-content/content-search-results.jsonld \
 	tests/test-content/cyprus.jsonld \
 	tests/test-content/emacs.jsonld \
+	tests/test-content/media-search-results.jsonld \
 	tests/test-content/app.json \
 	tests/test-content/greyjoy-article.jsonld \
+	tests/test-content/rick-astley-image.jsonld \
+	tests/test-content/never-gonna-give-you-up-video.jsonld \
 	tests/test-content/sample.mp4 \
 	$(NULL)
 EXTRA_DIST += \

--- a/tests/eosknowledge/testEngine.js
+++ b/tests/eosknowledge/testEngine.js
@@ -9,6 +9,7 @@ EosKnowledge.init();
 
 const MOCK_CONTENT_PATH = Endless.getCurrentFileDir() + '/../test-content/content-search-results.jsonld';
 const MOCK_ARTICLE_PATH = Endless.getCurrentFileDir() + '/../test-content/article-search-results.jsonld';
+const MOCK_MEDIA_PATH = Endless.getCurrentFileDir() + '/../test-content/media-search-results.jsonld';
 
 describe('Knowledge Engine Module', function () {
     let engine;
@@ -16,6 +17,7 @@ describe('Knowledge Engine Module', function () {
 
     const MOCK_CONTENT_RESULTS = utils.parse_object_from_path(MOCK_CONTENT_PATH);
     const MOCK_ARTICLE_RESULTS = utils.parse_object_from_path(MOCK_ARTICLE_PATH);
+    const MOCK_MEDIA_RESULTS = utils.parse_object_from_path(MOCK_MEDIA_PATH);
 
     // Setup a spy in place of the Soup-based request function
     function engine_request_spy() {
@@ -221,6 +223,16 @@ describe('Knowledge Engine Module', function () {
                 // so expect that they're constructed as such
                 for (let i in results) {
                     expect(results[i]).toBeA(EosKnowledge.ArticleObjectModel);
+                }
+                done();
+            });
+
+            mock_engine_request(undefined, MOCK_MEDIA_RESULTS);
+            engine.get_objects_by_query('mock-media-query', {}, function (err, results) {
+                // All results in MOCK_MEDIA_OBJECT_RESULTS are of @type MediaObject,
+                // so expect that they're constructed as such
+                for (let i in results) {
+                    expect(results[i]).toBeA(EosKnowledge.MediaObjectModel);
                 }
                 done();
             });

--- a/tests/eosknowledge/testMediaObjectModels.js
+++ b/tests/eosknowledge/testMediaObjectModels.js
@@ -1,0 +1,78 @@
+const Endless = imports.gi.Endless;
+const EosKnowledge = imports.gi.EosKnowledge;
+const Gtk = imports.gi.Gtk;
+const InstanceOfMatcher = imports.InstanceOfMatcher;
+
+const utils = imports.utils;
+
+EosKnowledge.init();
+
+const MOCK_IMAGE_PATH = Endless.getCurrentFileDir() + '/../test-content/rick-astley-image.jsonld';
+const MOCK_VIDEO_PATH = Endless.getCurrentFileDir() + '/../test-content/never-gonna-give-you-up-video.jsonld';
+
+describe ('Image Object Model', function () {
+    let imageObject;
+    let mockImageData = utils.parse_object_from_path(MOCK_IMAGE_PATH);
+
+    beforeEach(function () {
+        jasmine.addMatchers(InstanceOfMatcher.customMatchers);
+        imageObject = new EosKnowledge.ImageObjectModel.new_from_json_ld(mockImageData);
+    });
+
+    describe ('type', function () {
+        it ('should be an ImageObjectModel', function () {
+            expect(imageObject).toBeA(EosKnowledge.ImageObjectModel);
+        });
+
+        it ('should be an MediaObjectModel', function () {
+            expect(imageObject).toBeA(EosKnowledge.MediaObjectModel);
+        });
+    });
+
+    describe ('JSON-LD marshaler', function () {
+        it ('should construct from a JSON-LD document', function () {
+            expect(imageObject).toBeDefined();
+        });
+
+        it ('should inherit properties set by parent class (MediaObjectModel)', function () {
+            expect(imageObject.caption).toBeDefined();
+            expect(imageObject.width).toBeDefined();
+            expect(imageObject.content_uri).toBeDefined();
+            expect(imageObject.height).toBeDefined();
+        });
+    });
+});
+
+describe ('Video Object Model', function () {
+    let videoObject;
+    let mockVideoData = utils.parse_object_from_path(MOCK_VIDEO_PATH);
+
+    beforeEach(function () {
+        jasmine.addMatchers(InstanceOfMatcher.customMatchers);
+        videoObject = new EosKnowledge.VideoObjectModel.new_from_json_ld(mockVideoData);
+    });
+
+    describe ('type', function () {
+        it ('should be an VideoObjectModel', function () {
+            expect(videoObject).toBeA(EosKnowledge.VideoObjectModel);
+        });
+
+        it ('should be an MediaObjectModel', function () {
+            expect(videoObject).toBeA(EosKnowledge.MediaObjectModel);
+        });
+    });
+
+    describe ('JSON-LD marshaler', function () {
+        it ('should construct from a JSON-LD document', function () {
+            expect(videoObject).toBeDefined();
+        });
+
+        it ('should inherit properties set by parent class (MediaObjectModel)', function () {
+            expect(videoObject.caption).toBeDefined();
+            expect(videoObject.width).toBeDefined();
+            expect(videoObject.height).toBeDefined();
+            expect(videoObject.duration).toBeDefined();
+            expect(videoObject.transcript).toBeDefined();
+        });
+    });
+});

--- a/tests/test-content/media-search-results.jsonld
+++ b/tests/test-content/media-search-results.jsonld
@@ -1,0 +1,31 @@
+{
+    "@context": "http://localhost:3003/_context/SearchResults",
+    "@id": "http://localhost:3003/media/test",
+    "numResults": 2,
+    "results": [
+        {
+            "@context": "http://localhost:3000/api/_context/ImageObject",
+            "@type": "ekv:ImageObject",
+            "@id": "http://img1.wikia.nocookie.net/__cb20130318151721/epicrapbattlesofhistory/images/6/6d/Rick-astley.jpg",
+            "title": "Rick Astley: The Man, The Myth, The Legend",
+            "tags": ["inspiring", "beautiful"],
+            "caption": "Great musician, or greatest?",
+            "encodingFormat": "jpg",
+            "height": "666",
+            "width": "666"
+        },
+        {
+            "@context": "http://localhost:3000/api/_context/VideoObject",
+            "@type": "ekv:VideoObject",
+            "@id": "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+            "title": "Never Gonna Give You Up (Never Gonna Let You Down)",
+            "transcript": "We're no strangers to love, etc etc etc",
+            "tags": ["inspiring", "beautiful"],
+            "caption": "If this song was sushi, it would be a Rick Roll",
+            "encodingFormat": "mov",
+            "duration": "P666S",
+            "height": "666",
+            "width": "666"
+        }
+    ]
+}

--- a/tests/test-content/never-gonna-give-you-up-video.jsonld
+++ b/tests/test-content/never-gonna-give-you-up-video.jsonld
@@ -1,0 +1,13 @@
+{
+    "@context": "http://localhost:3000/api/_context/VideoObject",
+    "@type": "ekv:VideoObject",
+    "@id": "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+    "title": "Never Gonna Give You Up (Never Gonna Let You Down)",
+    "transcript": "We're no strangers to love, etc etc etc",
+    "tags": ["inspiring", "beautiful"],
+    "caption": "If this song was sushi, it would be a Rick Roll",
+    "encodingFormat": "mov",
+    "duration": "P666S",
+    "height": "666",
+    "width": "666"
+}

--- a/tests/test-content/rick-astley-image.jsonld
+++ b/tests/test-content/rick-astley-image.jsonld
@@ -1,0 +1,11 @@
+{
+    "@context": "http://localhost:3000/api/_context/ImageObject",
+    "@type": "ekv:ImageObject",
+    "@id": "http://img1.wikia.nocookie.net/__cb20130318151721/epicrapbattlesofhistory/images/6/6d/Rick-astley.jpg",
+    "title": "Rick Astley: The Man, The Myth, The Legend",
+    "tags": ["inspiring", "beautiful"],
+    "caption": "Great musician, or greatest?",
+    "encodingFormat": "jpg",
+    "height": "666",
+    "width": "666"
+}


### PR DESCRIPTION
MediaObjectModel is the parent class for Image and Video models, but there isn't
any actual knowledge engine type for it. Image and Video models are the only
objects which will actually be instantiated in practice

[endlessm/eos-sdk#1121]
