### PR TITLE
Kill white border around home page A

### DIFF
--- a/data/endless_knowledge.css
+++ b/data/endless_knowledge.css
@@ -183,7 +183,7 @@
     border-color: rgba(0, 0, 0, 0.80);
 }
 
-.home-page-a, .home-page-b GtkSeparator {
+.home-page-a GtkSeparator, .home-page-b GtkSeparator {
     border-style: solid;
     border-width: 3px;
     -GtkWidget-wide-separators: true;


### PR DESCRIPTION
We had an improper selector in our css, our page had a border,
and our line separators were too small
[endlessm/eos-sdk#1283]
