### PR TITLE
ContentObjectModel loads resources on creation

### DIFF
--- a/overrides/contentObjectModel.js
+++ b/overrides/contentObjectModel.js
@@ -186,7 +186,18 @@ const ContentObjectModel = new Lang.Class({
  */
 ContentObjectModel.new_from_json_ld = function (json_ld_data) {
     let props = ContentObjectModel._props_from_json_ld(json_ld_data);
-    return new EosKnowledge.ContentObjectModel(props);
+
+    let contentObjectModel = new EosKnowledge.ContentObjectModel(props);
+
+    let mediaObjectModels = [];
+    if (json_ld_data.hasOwnProperty('resources')) {
+        json_ld_data.resources.forEach(function (res) {
+            let mediaObject = EosKnowledge.MediaObjectModel.new_from_json_ld(res);
+            mediaObjectModels.push(mediaObject);
+        });
+    }
+    contentObjectModel.set_resources(mediaObjectModels);
+    return contentObjectModel;
 };
 
 ContentObjectModel._props_from_json_ld = function (json_ld_data) {

--- a/tests/eosknowledge/testContentObjectModel.js
+++ b/tests/eosknowledge/testContentObjectModel.js
@@ -77,5 +77,9 @@ describe ("Content Object Model", function () {
         it ("should have a license", function () {
             expect(contentObject.license).toEqual(mockContentData["license"]);
         });
+
+        it ("should have resources", function () {
+            expect(contentObject.get_resources()).toEqual(mockContentData['resources']);
+        });
     });
 });


### PR DESCRIPTION
On creation, the ContentObjectModel loads all the resources from the JSON-LD file, and creates MediaObjectModels that are then stored in the "resources" property.

[endlessm/eos-sdk#1308]
