### PR TITLE
Bring back transparent colors in css theme

### DIFF
--- a/data/endless_knowledge.css
+++ b/data/endless_knowledge.css
@@ -164,10 +164,7 @@ EosWindow {
 }
 
 .toc-arrow:insensitive {
-    color: rgb(204, 204, 204);
-    /* TODO: default theme svg don't support alpha, when we get our own svg for this
-     * asset, move to the color below*/
-    /*color: alpha(rgb(204, 204, 204), 0.3);*/
+    color: alpha(rgb(204, 204, 204), 0.3);
     border-color: alpha(black, 0.15);
     box-shadow: inset 0px 1px 0px alpha(white, 0.15);
 }
@@ -289,10 +286,7 @@ EosWindow {
 }
 
 .section-page-back-button {
-    color: white;
-    /* TODO: default theme svg don't support alpha, when we get our own svg for this
-     * asset, move to the color below*/
-    /*color: alpha(white, 0.75);*/
+    color: alpha(white, 0.75);
     background-color: alpha(black, 0.12);
     border-top: 1px solid alpha(white, 0.2);
     border-bottom: 1px solid alpha(white, 0.2);


### PR DESCRIPTION
With new librsvg, we should support transparent icons, so these
should show up as the proper color and now just black
[endlessm/eos-sdk#1321]
