### PR TITLE
Presenter now parses domain out of appId

### DIFF
--- a/overrides/presenter.js
+++ b/overrides/presenter.js
@@ -43,7 +43,7 @@ const Presenter = new Lang.Class({
     },
 
     _setAppContent: function(data) {
-        this._domain = data['domain'];
+        this._domain = data['appId'].split('.').pop();
         this.view.background_image_uri = data['backgroundURI'];
         this.view.home_page.title = data['appTitle'];
         this.view.home_page.subtitle = data['appSubtitle'];


### PR DESCRIPTION
Previously, the domain was directly in the app.json
file. Now, it gets parsed out of the appId field.

https://github.com/endlessm/eos-sdk/issues/1415

Don't merge until https://github.com/endlessm/eos-cms/pull/228 is merged
