### PR TITLE
Fixed smoke test for ArticlePresenter

### DIFF
--- a/tests/smoke-tests/articlePresenterSmokeTest.js
+++ b/tests/smoke-tests/articlePresenterSmokeTest.js
@@ -44,7 +44,7 @@ const TestApplication = new Lang.Class ({
             article_view: view,
             engine: engine
         });
-        presenter.load_article_from_model(articleObject);
+        presenter.article_model = articleObject;
         window.show_all();
 
     }


### PR DESCRIPTION
articlePresenterSmokeTest needed to be refactored to use the article_model setter in the articlePresenter

[endlessm/eos-sdk#1495]
