### PR TITLE
Articles can have no TOC

### DIFF
--- a/overrides/articleObjectModel.js
+++ b/overrides/articleObjectModel.js
@@ -120,4 +120,4 @@ ArticleObjectModel._props_from_json_ld = function (json_ld_data) {
     }
 
     return props;
-}
+};

--- a/overrides/articlePageA.js
+++ b/overrides/articlePageA.js
@@ -93,7 +93,9 @@ const ArticlePageA = new Lang.Class({
             xalign: 0.0
         });
         this._toc = new TableOfContents.TableOfContents({
-            expand: true
+            expand: true,
+            no_show_all: true,
+            visible: true
         });
         this._switcher = new WebviewSwitcherView.WebviewSwitcherView();
         this.parent(props);
@@ -141,6 +143,18 @@ const ArticlePageA = new Lang.Class({
     vfunc_size_allocate: function (alloc) {
         this.parent(alloc);
 
+        if (!this._toc.visible) {
+            let margin = this.EXPANDED_LAYOUT.right_margin_pct * alloc.width;
+            let switcher_alloc = new Cairo.RectangleInt({
+                x: alloc.x + margin,
+                y: alloc.y,
+                width: alloc.width - 2 * margin,
+                height: alloc.height
+            });
+            this._switcher_frame.size_allocate(switcher_alloc);
+            return;
+        }
+
         // Decide if toolbar should be collapsed
         if (alloc.width < this.COLLAPSE_TOOLBAR_WIDTH) {
             if (!this._toc.collapsed) {
@@ -182,12 +196,18 @@ const ArticlePageA = new Lang.Class({
     },
 
     vfunc_get_preferred_width: function () {
+        if (!this._toc.visible) {
+            return this._switcher.get_preferred_width();
+        }
         let [toolbar_min, toolbar_nat] = this._toolbar_frame.get_preferred_width();
         let [switcher_min, switcher_nat] = this._switcher_frame.get_preferred_width();
         return [toolbar_min + switcher_min, toolbar_nat + switcher_nat];
     },
 
     vfunc_get_preferred_height_for_width: function (width) {
+        if (!this._toc.visible) {
+            return this._switcher.get_preferred_height_for_width(width);
+        }
         let toolbar_width = this._get_toolbar_width(width);
         let [toolbar_min, toolbar_nat] = this._toolbar_frame.get_preferred_height_for_width(toolbar_width);
         let [switcher_min, switcher_nat] = this._switcher_frame.get_preferred_height_for_width(width - toolbar_width);

--- a/overrides/articlePresenter.js
+++ b/overrides/articlePresenter.js
@@ -110,11 +110,18 @@ const ArticlePresenter = new GObject.Class({
 
         this.article_view.title = this._article_model.title;
 
-        this._mainArticleSections = this._get_toplevel_toc_elements(this._article_model.table_of_contents);
-        this.article_view.toc.section_list = this._mainArticleSections.map(function (section) {
-            return section.label;
-        });
-        this.article_view.toc.selected_section = 0;
+        let _toc_visible = false;
+        if (this._article_model.table_of_contents !== undefined) {
+            this._mainArticleSections = this._get_toplevel_toc_elements(this._article_model.table_of_contents);
+            if (this._mainArticleSections.length > 0) {
+                this.article_view.toc.section_list = this._mainArticleSections.map(function (section) {
+                    return section.label;
+                });
+                this.article_view.toc.selected_section = 0;
+                _toc_visible = true;
+            }
+        }
+        this.article_view.toc.visible = _toc_visible;
         this.notify('article-model');
     },
 

--- a/tests/smoke-tests/articlePresenterSmokeTest.js
+++ b/tests/smoke-tests/articlePresenterSmokeTest.js
@@ -10,7 +10,8 @@ EosKnowledge.init();
 const TEST_APPLICATION_ID = 'com.endlessm.knowledge.article_presenter';
 const TESTDIR = Endless.getCurrentFileDir() + '/..';
 
-const MOCK_ARTICLE_PATH = Endless.getCurrentFileDir() + '/../test-content/cyprus.jsonld';
+// const MOCK_ARTICLE_PATH = Endless.getCurrentFileDir() + '/../test-content/cyprus.jsonld';
+const MOCK_ARTICLE_PATH = Endless.getCurrentFileDir() + '/../test-content/cyprus-no-toc.jsonld';
 
 const TestApplication = new Lang.Class ({
     Name: 'TestApplication',

--- a/tests/test-content/cyprus-no-toc.jsonld
+++ b/tests/test-content/cyprus-no-toc.jsonld
@@ -1,0 +1,39 @@
+{
+  "@context": "http://localhost:3000/v2/_context/ArticleObject",
+  "@id": "http://localhost:3000/api/travel/10d9cdebdf87c516",
+  "language": "en",
+  "lastModifiedDate": "2014-04-30T12:07:31",
+  "license": "Creative-Commons",
+  "resources": [
+    
+  ],
+  "sourceURL": "http://en.wikipedia.org/wiki/Cyprus",
+  "synopsis": "Cyprus i/ˈsaɪprəs/ (Greek: Κύπρος [ˈcipros]; Turkish: Kıbrıs [ˈkɯbɾɯs]), officially the Republic of Cyprus (Greek: Κυπριακή Δημοκρατία; Turkish: Kıbrıs Cumhuriyeti), is an island country in the Eastern Mediterranean Sea.[6] Cyprus is the third largest and third most populous island in the Mediterranean, and a member state of the European Union. It is located south of Turkey, west of Syria and Lebanon, northwest of Israel, north of Egypt and east of Greece.",
+  "tags": [
+    "Islands of Europe",
+    "Levant",
+    "Island countries",
+    "International islands",
+    "Countries in Europe",
+    "Hellenistic colonies",
+    "Phoenician colonies",
+    "Mediterranean islands",
+    "Member states of the Union for the Mediterranean",
+    "Republics",
+    "Member states of the Commonwealth of Nations",
+    "Near Eastern countries",
+    "Islands of Asia",
+    "Liberal democracies",
+    "Former British colonies",
+    "Commonwealth republics",
+    "Middle Eastern countries",
+    "Western Asian countries",
+    "Cyprus",
+    "Member states of the United Nations",
+    "Member states of the European Union",
+    "States and territories established in 1960"
+  ],
+  "text": "nada",
+  "title": "Cyprus",
+  "@type": "ekv:ArticleObject"
+}


### PR DESCRIPTION
The ArticlePresenter accepts ArticleObjectModels that have no Table of Contents. In this case, the letf toolbar in the ArticlePageA is hidden.

[endlessm/eos-sdk#1425]
