### PR TITLE
Properly hide the articlePage toolbar frame

### DIFF
--- a/overrides/articlePageA.js
+++ b/overrides/articlePageA.js
@@ -152,9 +152,11 @@ const ArticlePageA = new Lang.Class({
                 height: alloc.height
             });
             this._switcher_frame.size_allocate(switcher_alloc);
+            this._toolbar_frame.set_child_visible(false);
             return;
         }
 
+        this._toolbar_frame.set_child_visible(true);
         // Decide if toolbar should be collapsed
         if (alloc.width < this.COLLAPSE_TOOLBAR_WIDTH) {
             if (!this._toc.collapsed) {


### PR DESCRIPTION
When table of contents is not visible, we do not draw the toolbar
frame. We were already not giving the toolbar frame an allocation
when the toolbar is hidden, but we need to call set_child_visible
on the toolbar frame, so the container knows to no longer map the
frame
[endlessm/eos-sdk#1545]
