### PR TITLE
Mock out webview in article presenter test

### DIFF
--- a/tests/Makefile.am.inc
+++ b/tests/Makefile.am.inc
@@ -52,6 +52,7 @@ EXTRA_DIST += \
 	$(test_content) \
 	tests/CssClassMatcher.js \
 	tests/InstanceOfMatcher.js \
+	tests/MockWebview.js \
 	tests/utils.js \
 	$(NULL)
 

--- a/tests/MockWebview.js
+++ b/tests/MockWebview.js
@@ -1,0 +1,38 @@
+const GLib = imports.gi.GLib;
+const GObject = imports.gi.GObject;
+const Gtk = imports.gi.Gtk;
+const Lang = imports.lang;
+
+const MockWebview = new Lang.Class({
+    Name: 'MockWebview',
+    Extends: Gtk.Label,
+    Signals: {
+        'load-changed': {
+            param_types: [ GObject.TYPE_INT /* WebKitLoadEvent */ ]
+        },
+        'decide-policy': {
+            return_type: GObject.TYPE_BOOLEAN,
+            param_types: [
+                GObject.TYPE_OBJECT /* WebKitPolicyDecision */,
+                GObject.TYPE_INT /* WebKitPolicyDecisionType */
+            ],
+            flags: GObject.SignalFlags.RUN_LAST
+        }
+    },
+
+    // Mimic WebKitLoadEvent enum
+    STARTED: 0,
+    FINISHED: 3,
+
+    load_uri: function (uri) {
+        this.uri = uri;
+        GLib.idle_add(GLib.PRIORITY_HIGH_IDLE, function () {
+            this.emit('load-changed', this.STARTED);
+            GLib.timeout_add(GLib.PRIORITY_DEFAULT, 50 /* ms */, function () {
+                this.emit('load-changed', this.FINISHED);
+                return false;  // G_SOURCE_REMOVE
+            }.bind(this));
+            return false;  // G_SOURCE_REMOVE
+        }.bind(this));
+    }
+});

--- a/tests/eosknowledge/testArticlePresenter.js
+++ b/tests/eosknowledge/testArticlePresenter.js
@@ -1,9 +1,8 @@
 const Endless = imports.gi.Endless;
 const EosKnowledge = imports.gi.EosKnowledge;
 const Gio = imports.gi.Gio;
-const GLib = imports.gi.GLib;
-const Gtk = imports.gi.Gtk;
-const WebKit2 = imports.gi.WebKit2;
+
+const MockWebview = imports.MockWebview;
 
 EosKnowledge.init();
 
@@ -29,7 +28,7 @@ describe('Article Presenter', function () {
 
         view = new EosKnowledge.ArticlePageA();
         view.switcher.connect('create-webview', function () {
-            webview = new WebKit2.WebView();
+            webview = new MockWebview.MockWebview();
             return webview;
         });
 

--- a/tests/eosknowledge/testWebviewSwitcher.js
+++ b/tests/eosknowledge/testWebviewSwitcher.js
@@ -1,44 +1,9 @@
 const EosKnowledge = imports.gi.EosKnowledge;
-const GLib = imports.gi.GLib;
-const GObject = imports.gi.GObject;
 const Gtk = imports.gi.Gtk;
-const Lang = imports.lang;
+
+const MockWebview = imports.MockWebview;
 
 EosKnowledge.init();
-
-const MockWebview = new Lang.Class({
-    Name: 'MockWebview',
-    Extends: Gtk.Label,
-    Signals: {
-        'load-changed': {
-            param_types: [ GObject.TYPE_INT /* WebKitLoadEvent */ ]
-        },
-        'decide-policy': {
-            return_type: GObject.TYPE_BOOLEAN,
-            param_types: [
-                GObject.TYPE_OBJECT /* WebKitPolicyDecision */,
-                GObject.TYPE_INT /* WebKitPolicyDecisionType */
-            ],
-            flags: GObject.SignalFlags.RUN_LAST
-        }
-    },
-
-    // Mimic WebKitLoadEvent enum
-    STARTED: 0,
-    FINISHED: 3,
-
-    load_uri: function (uri) {
-        this.uri = uri;
-        GLib.idle_add(GLib.PRIORITY_HIGH_IDLE, function () {
-            this.emit('load-changed', this.STARTED);
-            GLib.timeout_add(GLib.PRIORITY_DEFAULT, 50 /* ms */, function () {
-                this.emit('load-changed', this.FINISHED);
-                return false;  // G_SOURCE_REMOVE
-            }.bind(this));
-            return false;  // G_SOURCE_REMOVE
-        }.bind(this));
-    }
-});
 
 describe('Webview switcher view', function () {
     let switcher;
@@ -66,7 +31,7 @@ describe('Webview switcher view', function () {
         beforeEach(function() {
             createWebview = jasmine.createSpy('createWebview').and.callFake(function () {
                 previousView = currentView;
-                currentView = new MockWebview();
+                currentView = new MockWebview.MockWebview();
                 return currentView;
             });
             switcher.connect('create-webview', createWebview);


### PR DESCRIPTION
The real webview was somehow making requests to the knowledge engine
(a URI in the testing code?) These were failing on Jenkins because
there is no knowledge engine running there.

The Engine class (and, in fact, the view) should be mocked out of this
test, but I'll open a new issue for that.

[endlessm/eos-sdk#1528]
