### PR TITLE
Initialize EosKnowledge module before running knowledge app.

### DIFF
--- a/tools/ekn-app-runner
+++ b/tools/ekn-app-runner
@@ -8,6 +8,7 @@ if (ARGV.length !== 2) {
 
 } else {
 
+    EosKnowledge.init();
     let app = new EosKnowledge.KnowledgeApp({
         application_id: ARGV[0],
         flags: 0


### PR DESCRIPTION
Previously we were not calling EosKnowledge.init() before
running a knowledge app. This caused a seg fault when trying
to create a Clutter Gstreamer instance.

https://github.com/endlessm/eos-sdk/issues/1605
