### PR TITLE
Simply animate the page on LOAD_COMMITTED

### DIFF
--- a/overrides/webviewSwitcherView.js
+++ b/overrides/webviewSwitcherView.js
@@ -189,7 +189,7 @@ const WebviewSwitcherView = new Lang.Class({
         let offscreen = new Gtk.OffscreenWindow();
 
         let load_id = view.connect('load-changed', function (v, status) {
-            if (status === WebKit2.LoadEvent.FINISHED) {
+            if (status === WebKit2.LoadEvent.COMMITTED) {
                 view.show_all();
                 view.reparent(this);
                 if(offscreen !== null) {


### PR DESCRIPTION
Instead of waiting until the page has completely finished loading (which
takes a very long time for pages with many images), just wait for the
signal which indicates that some data has been received

[endlessm/eos-sdk#1613]
