### PR TITLE
Fix scrolling by explicitly selecting IDs in smooth_scroll

### DIFF
--- a/data/scroll_manager.js
+++ b/data/scroll_manager.js
@@ -81,7 +81,7 @@ $('a').map(function (element) {
 window.addEventListener('hashchange', function (e) {
     var hash = window.location.hash;
     if (hash.indexOf(SCROLL_TO_PREFIX) === 0) {
-        var destinationHash = '#' + hash.split(SCROLL_TO_PREFIX)[1];
+        var destinationHash = hash.split(SCROLL_TO_PREFIX)[1];
         return scrollTo(destinationHash);
     } else {
         return true;

--- a/data/smooth_scroll.js
+++ b/data/smooth_scroll.js
@@ -140,7 +140,7 @@ window.getSmoothScroll = (function (window, document, undefined) {
 		var fixedHeader = document.querySelector('[data-scroll-header]'); // Get the fixed header
 		var headerHeight = fixedHeader === null ? 0 : (fixedHeader.offsetHeight + fixedHeader.offsetTop); // Get the height of a fixed header if one exists
 		var startLocation = window.pageYOffset; // Current location on the page
-		var endLocation = _getEndLocation( document.querySelector(anchor), headerHeight, offset ); // Scroll to location
+		var endLocation = _getEndLocation( document.querySelector('[id="' + anchor + '"]'), headerHeight, offset ); // Scroll to location
 		var animationInterval; // interval timer
 		var distance = endLocation - startLocation; // distance to travel
 		var documentHeight = _getDocumentHeight();


### PR DESCRIPTION
Previously, we were using document.querySelector() to select
anchors by ID in the page to which we wanted to scroll. Wikipedia
often has periods in their ID names, so querySelector thinks you
are trying to select a class. Now we explicitly select by
[id="name_of_id"] so that it looks for a tag with that literal id
and doesn't mistake periods for the beginning of a class selector.

https://github.com/endlessm/eos-sdk/issues/1637
