### PR TITLE
Only hide article title in template A

### DIFF
--- a/overrides/articlePresenter.js
+++ b/overrides/articlePresenter.js
@@ -227,7 +227,8 @@ const ArticlePresenter = new GObject.Class({
 
         webview.inject_js_from_resource('resource:///com/endlessm/knowledge/smooth_scroll.js');
         webview.inject_js_from_resource('resource:///com/endlessm/knowledge/scroll_manager.js');
-        webview.inject_css_from_resource('resource:///com/endlessm/knowledge/hide_title.css');
+        if (this.template_type === 'A')
+            webview.inject_css_from_resource('resource:///com/endlessm/knowledge/hide_title.css');
 
         webview.connect('notify::uri', function () {
             if (webview.uri.indexOf('#') >= 0) {


### PR DESCRIPTION
Previously we were always hiding the article title in HTML for
all knowledge apps. Since template B articles don't have a separate
title label off to the side, we should show the title in HTML. So
only hide the title if it is template B.

https://github.com/endlessm/eos-sdk/issues/1650
