### PR TITLE
Don't reload page when triggering a scroll

### DIFF
--- a/overrides/articlePresenter.js
+++ b/overrides/articlePresenter.js
@@ -214,10 +214,9 @@ const ArticlePresenter = new GObject.Class({
 
     _scroll_to_section: function (index) {
         // tells the webkit webview directly to scroll to a ToC entry
-        let location = this._mainArticleSections[index].content.slice(1);
-        let baseURI = this._webview.uri.split('#')[0];
-        let selectedSectionURI = baseURI + '#scroll-to-' + location;
-        this._webview.load_uri(selectedSectionURI);
+        let location = this._mainArticleSections[index].content;
+        let script = 'scrollManager.scrollTo(LOCATION)'.replace('LOCATION', location.toSource());
+        this._webview.run_javascript(script, null, null);
     },
 
     _get_toplevel_toc_elements: function (tree) {


### PR DESCRIPTION
Previously we were calling load_uri whenever we scrolled
to another section of the page. This is bad because the
whole page has to reload. Now we trigger the scroll
by executing web javascript.

[endlessm/eos-sdk#1652]
