### PR TITLE
Make sure title on SectionPageB wraps if too long

### DIFF
--- a/overrides/sectionPageB.js
+++ b/overrides/sectionPageB.js
@@ -7,6 +7,7 @@ const GLib = imports.gi.GLib;
 const GObject = imports.gi.GObject;
 const Gtk = imports.gi.Gtk;
 const Lang = imports.lang;
+const Pango = imports.gi.Pango;
 
 const SectionPage = imports.sectionPage;
 
@@ -82,6 +83,10 @@ const SectionPageB = new Lang.Class({
         title_label.xalign = 0;
         title_label.yalign = 1;
         title_label.expand = true;
+        title_label.wrap_mode = Pango.WrapMode.WORD;
+        title_label.ellipsize = Pango.EllipsizeMode.END;
+        title_label.max_width_chars = 1;
+        title_label.lines = 2;
 
         this._title_label_revealer = new Gtk.Revealer({
             reveal_child: true,


### PR DESCRIPTION
Previously, the title label would not wrap and so if
the user was on a small resolution, it would push the
article list off the screen. Now we make sure it wraps,
by word.

https://github.com/endlessm/eos-sdk/issues/1662
