### PR TITLE
Hide lightbox when back button clicked

### DIFF
--- a/overrides/presenter.js
+++ b/overrides/presenter.js
@@ -230,6 +230,9 @@ const Presenter = new Lang.Class({
     },
 
     _on_back: function () {
+        // Make sure to hide any outstanding lightbox overlays
+        // that might have been showing on the article page
+        this.view.lightbox.reveal_overlays = false;
         let visible_page = this.view.get_visible_page();
         if (visible_page === this.view.article_page) {
             if (this._search_origin_page === this.view.home_page) {


### PR DESCRIPTION
Previously when a resource was being shown in the lightbox
and the user clicked the back button in the top bar, the
lightbox would stay on the screen as the window transitioned
to the previous page. Now that lightbox hides first.

https://github.com/endlessm/eos-sdk/issues/1693
