### PR TITLE
Style scrollbar slider

### DIFF
--- a/data/endless_knowledge.css
+++ b/data/endless_knowledge.css
@@ -379,6 +379,10 @@ EknWindow.show-article-page {
 
 .section-page-b .scrollbar.trough {
     background-color: alpha(black, 0.5);
+    background-image: linear-gradient(89deg,
+                                      alpha(white, 0.1) 0%,
+                                      alpha(black, 0.1) 100%);
+    box-shadow: inset 1px 0px 0px 0px alpha(black, 0.15);
 }
 
 .section-page-b .scrollbar.slider {
@@ -396,13 +400,16 @@ EknWindow.show-article-page {
     /*font-weight: 300;*/
 }
 
+/* FIXME: for the time being, until we can properly customize the webkit
+scrollbars, style the GTK scrollbars to look slightly more like them */
 .scrollbar {
-    -GtkRange-trough-border: 4px;
-    -GtkRange-slider-width: 5px;
+    -GtkRange-trough-border: 3px;
+    -GtkRange-slider-width: 8px;
 }
 
 .scrollbar.slider {
     background-color: #333333;
+    border-radius: 20px;
 }
 
 .article-page-switcher-frame {


### PR DESCRIPTION
Rather than sinking time into styling the Webkit scrollbar right now,
I discussed this solution with Mac: style the trough of the text cards
scrollbar per the design specs, but style the slider to look more
unified with the Webkit scrollbar.

This is temporary; eventually they should both look like the design
specs.

[endlessm/eos-sdk#1661]
