### PR TITLE
Template B styling to design specs

### DIFF
--- a/data/endless_knowledge.css
+++ b/data/endless_knowledge.css
@@ -1,3 +1,6 @@
+@define-color template-b-text-color #eeccf8;
+@define-color template-b-text-color-hover #d64970;
+
 EosWindow {
     /* Changed color here so scrollbars are visible. Only affects smoke tests all
      * apps have image backgrounds.*/
@@ -54,18 +57,34 @@ EknWindow.show-article-page {
 }
 
 .text-card {
-    font-size: 1.2em;
-    font-weight: bold;
-    color: #eeccf8;
-    padding: 10px;
-    background-color: alpha(#eae7e9, 0);
+    font-family: Lato;
+    font-size: 1.58em; /* 18pt at 72 DPI 768px */
+    font-weight: normal;
+    color: @template-b-text-color;
+    padding: 6px;
+    border: 2px solid alpha(white, 0);
+    background-color: alpha(white, 0);
     transition: color 250ms ease-in-out;
     transition: background-color 250ms ease-in-out;
+
+    /* FIXME: The background-image and border transitions seem to stop the
+    background-color transition from executing. So I'm disabling them for now. */
+    /*transition: border 250ms ease-in-out;
+    transition: background-image 250ms ease-in-out;*/
 }
 
 .text-card:hover {
-    color: #d64970;
-    background-color: #eae7e9;
+    font-weight: bold;
+    color: @template-b-text-color-hover;
+    text-shadow: 0px 1px 0px white;
+    padding: 5.5px; /* ugh; this is needed because Lato Bold is rendered with
+                       a slightly different height than Lato Regular */
+    border: 2px solid white;
+    background-color: alpha(white, 0.9);
+    background-image: linear-gradient(-179deg,
+                                      alpha(white, 0.05) 0%,
+                                      alpha(black, 0.05) 100%);
+    box-shadow: 0px 0px 20px 0px black;
 }
 
 .text-card .card-title {
@@ -136,31 +155,41 @@ EknWindow.show-article-page {
 }
 
 @define-color card-b-border-color alpha(black, 0.7);
-@define-color card-b-border-color-hover #d2d2d2;
+@define-color card-b-border-color-hover white;
 
 .card-b {
     border-style: solid;
-    border-width: 6px;
+    border-width: 5px;
     border-color: @card-b-border-color;
+    box-shadow: -4px 0px 20px 0px alpha(black, 0.40);
     transition: border-color 250ms ease-in-out;
 }
 
 .card-b:hover {
     border-color: @card-b-border-color-hover;
+    box-shadow: 0px 0px 10px 0px alpha(black, 0.81);
 }
 
 .card-b .card-title {
-    color: #eeccf8;
-    font-size: 1.5em;
-    padding: 1em 0em;
+    color: @template-b-text-color;
+    font-size: 2.45em; /* 28pt at 72 DPI 768px */
+    padding: .5em 0em;
     background-color: @card-b-border-color;
     transition: color 250ms ease-in-out;
     transition: background-color 250ms ease-in-out;
+    /* FIXME The following two transitions stop the background-color transition
+    from executing? */
+    /*transition: text-shadow 250ms ease-in-out;
+    transition: background-image 250ms ease-in-out;*/
 }
 
 .card-b .card-title:hover {
-    color: #d64970;
+    color: @template-b-text-color-hover;
+    text-shadow: 0px 1px 0px white;
     background-color: @card-b-border-color-hover;
+    background-image: linear-gradient(-179deg,
+                                      alpha(white, 0.15) 0%,
+                                      alpha(black, 0.15) 100%);
 }
 
 .lightbox-container {
@@ -368,9 +397,9 @@ EknWindow.show-article-page {
 }
 
 .section-page-b .section-page-title {
-    font-size: 4em;
-    padding: 1em 1.5em;
-    font-weight: bold;
+    font-size: 6.33em; /* 72pt at 72 DPI 768px */
+    padding: 0.25em 0.25em;
+    color: white;
 }
 
 .section-page-b GtkScrolledWindow {


### PR DESCRIPTION
This is the knowledge library-specific part of the CSS styling for the
Template B apps: Animals, Celebrities, Cooking, Dinosaurs, and How To.
The apps themselves actually need very little custom CSS: two colors
and a font, basically. All the real changes are in this commit.

[endlessm/eos-sdk#1669]
