### PR TITLE
Only template A shows top title label

### DIFF
--- a/overrides/articlePage.js
+++ b/overrides/articlePage.js
@@ -37,6 +37,15 @@ const ArticlePage = new Lang.Class({
     Extends: Endless.CustomContainer,
     Properties: {
         /**
+         * Property: show-top-title
+         *
+         * Set true if the top title label should be visible when the toc is
+         * either hidden or collapsed.
+         */
+        'show-top-title':  GObject.ParamSpec.boolean('show-top-title', 'Show Top Title',
+            'Whether to show the top title label when toc is collapsed/hidden',
+            GObject.ParamFlags.READWRITE | GObject.ParamFlags.CONSTRUCT_ONLY, true),
+        /**
          * Property: title
          *
          * A string title of the article being viewed. Defaults to the empty
@@ -202,7 +211,9 @@ const ArticlePage = new Lang.Class({
                 height: alloc.height
             });
             this._toolbar_frame.set_child_visible(false);
-            this._top_title_label.visible = true;
+            if (this.show_top_title) {
+                this._top_title_label.visible = true;
+            }
             this._switcher_frame.size_allocate(switcher_alloc);
             return;
         }

--- a/overrides/sectionArticlePageA.js
+++ b/overrides/sectionArticlePageA.js
@@ -60,7 +60,9 @@ const SectionArticlePageA = new Lang.Class({
         props = props || {};
 
         this._section_page = new SectionPageA.SectionPageA();
-        this._article_page = new ArticlePage.ArticlePage();
+        this._article_page = new ArticlePage.ArticlePage({
+            show_top_title: true
+        });
         this._transition_duration = 0;
 
         /*

--- a/overrides/sectionArticlePageB.js
+++ b/overrides/sectionArticlePageB.js
@@ -57,7 +57,9 @@ const SectionArticlePageB = new Lang.Class({
 
     _init: function (props) {
         this._section_page = new SectionPageB.SectionPageB();
-        this._article_page = new ArticlePage.ArticlePage();
+        this._article_page = new ArticlePage.ArticlePage({
+            show_top_title: false
+        });
         this._article_page.toc.hide();
         this._article_page.has_margins = false;
         this._transition_duration = 0;


### PR DESCRIPTION
Previously, the top title label would show up in template B
since it didn't have a toc. However, in template B, we want
the title to only show in the HTML, so now the articlePage
needs to know what template type it is and switch accordingly
