### PR TITLE
Point engine requests to 127.0.0.1, rather than localhost

### DIFF
--- a/overrides/engine.js
+++ b/overrides/engine.js
@@ -26,12 +26,16 @@ const Engine = Lang.Class({
          * The hostname of the Knowledge Engine service. You generally don't
          * need to set this.
          *
-         * Defaults to 'localhost'
+         * Defaults to '127.0.0.1'
+         * FIXME: the default should just be localhost, but libsoup has a bug
+         * whereby it does not resolve localhost when it is offline:
+         * https://bugzilla.gnome.org/show_bug.cgi?id=692291
+         * Once this bug is fixed, we should change this to be localhost.
          */
         'host': GObject.ParamSpec.string('host',
             'Knowledge Engine Hostname', 'HTTP hostname for the Knowledge Engine service',
             GObject.ParamFlags.READWRITE | GObject.ParamFlags.CONSTRUCT_ONLY,
-            'localhost'),
+            '127.0.0.1'),
 
         /**
          * Property: port

--- a/tests/eosknowledge/testEngine.js
+++ b/tests/eosknowledge/testEngine.js
@@ -60,8 +60,8 @@ describe('Knowledge Engine Module', function () {
             expect(engine.port).toBe(3003);
         });
 
-        it('should default its hostname to localhost', function () {
-            expect(engine.host).toBe('localhost');
+        it('should default its hostname to 127.0.0.1', function () {
+            expect(engine.host).toBe('127.0.0.1');
         });
     });
 
@@ -108,7 +108,7 @@ describe('Knowledge Engine Module', function () {
             let domain = 'thrones';
             let id = 'tyrion';
             let mock_uri = engine.get_ekn_uri(domain, id);
-            let correct_uri = Soup.URI.new('http://localhost:3003/api/thrones/tyrion');
+            let correct_uri = Soup.URI.new('http://127.0.0.1:3003/api/thrones/tyrion');
             expect(mock_uri.to_string(false)).toBe(correct_uri.to_string(false));
 
         });
@@ -145,7 +145,7 @@ describe('Knowledge Engine Module', function () {
             let request_spy = engine_request_spy();
             let mock_domain = 'foo';
             let mock_id = 'bar';
-            let expected_uri = Soup.URI.new('http://localhost:3003/api/foo/bar');
+            let expected_uri = Soup.URI.new('http://127.0.0.1:3003/api/foo/bar');
 
             engine.get_object_by_id(mock_domain, mock_id, noop);
             let last_req_args = request_spy.calls.mostRecent().args;

--- a/tests/smoke-tests/mediaObjectSmokeTest.js
+++ b/tests/smoke-tests/mediaObjectSmokeTest.js
@@ -107,9 +107,9 @@ const TestApplication = new Lang.Class ({
     _get_mock_media_objects: function () {
         let json = [
             {
-                "@context": "http://localhost:3003/api/_context/ImageObject",
+                "@context": "http://127.0.0.1:3003/api/_context/ImageObject",
                 "@type": "ekv:ImageObject",
-                "@id": "http://localhost:3003/img/stallman_up",
+                "@id": "http://127.0.0.1:3003/img/stallman_up",
                 "contentURL": "file://" + TESTBUILDDIR + "/test-content/Richard_Stallman_at_Pittsburgh_University.jpg",
                 "title": "Richard Stallman at Pittsburgh University,",
                 "tags": ["bear", "beard"],
@@ -121,9 +121,9 @@ const TestApplication = new Lang.Class ({
                 "width": "666"
             },
             {
-                "@context": "http://localhost:3003/api/_context/ImageObject",
+                "@context": "http://127.0.0.1:3003/api/_context/ImageObject",
                 "@type": "ekv:ImageObject",
-                "@id": "http://localhost:3003/img/emacs_colorsyntax",
+                "@id": "http://127.0.0.1:3003/img/emacs_colorsyntax",
                 "contentURL": "file://" + TESTBUILDDIR + "/test-content/emacs-colorsyntax.png",
                 "title": "Editing C source code in GNU Emacs",
                 "tags": ["Editor", "emacs"],
@@ -133,9 +133,9 @@ const TestApplication = new Lang.Class ({
                 "width": "666"
             },
             {
-                "@context": "http://localhost:3003/api/_context/ImageObject",
+                "@context": "http://127.0.0.1:3003/api/_context/ImageObject",
                 "@type": "ekv:ImageObject",
-                "@id": "http://localhost:3003/img/emacs_buffers",
+                "@id": "http://127.0.0.1:3003/img/emacs_buffers",
                 "contentURL": "file://" + TESTBUILDDIR + "/test-content/Emacs_Dired_buffers.png",
                 "title": "Editing multiple Dired buffers in GNU Emacs",
                 "tags": ["Dired buffers", "emacs"],

--- a/tests/test-content/article-search-results.jsonld
+++ b/tests/test-content/article-search-results.jsonld
@@ -3,7 +3,7 @@
     {
         "schema": "http://schema.org/",
         "xsd": "http://www.w3.org/2001/XMLSchema#",
-        "ekn": "http://localhost:3003/v2/",
+        "ekn": "http://127.0.0.1:3003/v2/",
         "ekv": "ekn:_vocab/",
         "numResults": "schema:Integer",
         "results":

--- a/tests/test-content/content-search-results.jsonld
+++ b/tests/test-content/content-search-results.jsonld
@@ -3,7 +3,7 @@
     {
         "schema": "http://schema.org/",
         "xsd": "http://www.w3.org/2001/XMLSchema#",
-        "ekn": "http://localhost:3003/v2/",
+        "ekn": "http://127.0.0.1:3003/v2/",
         "ekv": "ekn:_vocab/",
         "numResults": "schema:Integer",
         "results":

--- a/tests/test-content/cyprus-no-toc.jsonld
+++ b/tests/test-content/cyprus-no-toc.jsonld
@@ -1,6 +1,6 @@
 {
-  "@context": "http://localhost:3003/v2/_context/ArticleObject",
-  "@id": "http://localhost:3003/api/travel/10d9cdebdf87c516",
+  "@context": "http://127.0.0.1:3003/v2/_context/ArticleObject",
+  "@id": "http://127.0.0.1:3003/api/travel/10d9cdebdf87c516",
   "language": "en",
   "lastModifiedDate": "2014-04-30T12:07:31",
   "license": "Creative-Commons",

--- a/tests/test-content/cyprus.jsonld
+++ b/tests/test-content/cyprus.jsonld
@@ -1,6 +1,6 @@
 {
-  "@context": "http://localhost:3003/v2/_context/ArticleObject",
-  "@id": "http://localhost:3003/api/travel/10d9cdebdf87c516",
+  "@context": "http://127.0.0.1:3003/v2/_context/ArticleObject",
+  "@id": "http://127.0.0.1:3003/api/travel/10d9cdebdf87c516",
   "language": "en",
   "lastModifiedDate": "2014-04-30T12:07:31",
   "license": "Creative-Commons",

--- a/tests/test-content/greyjoy-article.jsonld
+++ b/tests/test-content/greyjoy-article.jsonld
@@ -1,6 +1,6 @@
 {
     "@context": [
-        "http://localhost:3003/v2/_context/ContentObject.jsonld",
+        "http://127.0.0.1:3003/v2/_context/ContentObject.jsonld",
         {
             "wordCount": "schema:Integer",
             "articleBody": "schema:mainContentText",

--- a/tests/test-content/media-search-results.jsonld
+++ b/tests/test-content/media-search-results.jsonld
@@ -1,10 +1,10 @@
 {
-    "@context": "http://localhost:3003/_context/SearchResults",
-    "@id": "http://localhost:3003/media/test",
+    "@context": "http://127.0.0.1:3003/_context/SearchResults",
+    "@id": "http://127.0.0.1:3003/media/test",
     "numResults": 2,
     "results": [
         {
-            "@context": "http://localhost:3003/api/_context/ImageObject",
+            "@context": "http://127.0.0.1:3003/api/_context/ImageObject",
             "@type": "ekv:ImageObject",
             "@id": "http://img1.wikia.nocookie.net/__cb20130318151721/epicrapbattlesofhistory/images/6/6d/Rick-astley.jpg",
             "title": "Rick Astley: The Man, The Myth, The Legend",
@@ -15,7 +15,7 @@
             "width": "666"
         },
         {
-            "@context": "http://localhost:3003/api/_context/VideoObject",
+            "@context": "http://127.0.0.1:3003/api/_context/VideoObject",
             "@type": "ekv:VideoObject",
             "@id": "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
             "title": "Never Gonna Give You Up (Never Gonna Let You Down)",

--- a/tests/test-content/never-gonna-give-you-up-video.jsonld
+++ b/tests/test-content/never-gonna-give-you-up-video.jsonld
@@ -1,5 +1,5 @@
 {
-    "@context": "http://localhost:3003/api/_context/VideoObject",
+    "@context": "http://127.0.0.1:3003/api/_context/VideoObject",
     "@type": "ekv:VideoObject",
     "@id": "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
     "title": "Never Gonna Give You Up (Never Gonna Let You Down)",

--- a/tests/test-content/rick-astley-image.jsonld
+++ b/tests/test-content/rick-astley-image.jsonld
@@ -1,5 +1,5 @@
 {
-    "@context": "http://localhost:3003/api/_context/ImageObject",
+    "@context": "http://127.0.0.1:3003/api/_context/ImageObject",
     "@type": "ekv:ImageObject",
     "@id": "http://img1.wikia.nocookie.net/__cb20130318151721/epicrapbattlesofhistory/images/6/6d/Rick-astley.jpg",
     "title": "Rick Astley: The Man, The Myth, The Legend",


### PR DESCRIPTION
When you are offline, libsoup cannot resolve localhost to
127.0.0.1, so instead we should hard code that IP address
in there.

https://github.com/endlessm/eos-sdk/issues/1715
