### PR TITLE
Wrap by char as well as by word.

### DIFF
--- a/overrides/sectionPage.js
+++ b/overrides/sectionPage.js
@@ -4,6 +4,7 @@ const EosKnowledge = imports.gi.EosKnowledge;
 const GObject = imports.gi.GObject;
 const Gtk = imports.gi.Gtk;
 const Lang = imports.lang;
+const Pango = imports.gi.Pango;
 
 /**
  * Class: SectionPage
@@ -29,7 +30,11 @@ const SectionPage = new Lang.Class({
     },
 
     _init: function (props) {
-        this._title_label = new Gtk.Label();
+        this._title_label = new Gtk.Label({
+            wrap_mode: Pango.WrapMode.WORD_CHAR,
+            ellipsize: Pango.EllipsizeMode.END,
+            max_width_chars: 1,
+        });
 
         this._title = null;
 

--- a/overrides/sectionPageB.js
+++ b/overrides/sectionPageB.js
@@ -83,9 +83,6 @@ const SectionPageB = new Lang.Class({
         title_label.xalign = 0;
         title_label.yalign = 1;
         title_label.expand = true;
-        title_label.wrap_mode = Pango.WrapMode.WORD;
-        title_label.ellipsize = Pango.EllipsizeMode.END;
-        title_label.max_width_chars = 1;
         title_label.lines = 2;
 
         this._title_label_revealer = new Gtk.Revealer({


### PR DESCRIPTION
Previously we were only wrapping by word.
But we can also have sitautions where the title
is one really long word, in which case we should
wrap by char as well.

https://github.com/endlessm/eos-sdk/issues/1662
