### PR TITLE
Include mo locale files in debian package

### DIFF
--- a/debian/libeosknowledge-0-0.install
+++ b/debian/libeosknowledge-0-0.install
@@ -1,1 +1,2 @@
 usr/lib/libeosknowledge*.so.*
+usr/share/locale/*


### PR DESCRIPTION
We forgot to acutally put them in a .install file
[endlessm/eos-sdk#1711]
