### PR TITLE
Captions will always limit to 5 lines in lightbox

### DIFF
--- a/overrides/mediaInfobox.js
+++ b/overrides/mediaInfobox.js
@@ -118,7 +118,10 @@ const MediaInfobox = new Lang.Class({
     set caption (v) {
         if (this._caption === v) return;
         if (v.length > 0) {
-            this._caption_label.label = v;
+            // FIXME: We may want to stick this text content in a scroll
+            // area of some sort, and keep newlines. But for now we remove
+            // newlines so the label ellipsizing will work
+            this._caption_label.label = v.split('\n').join(' ');
             this._caption_label.show();
         } else {
             this._caption_label.hide();


### PR DESCRIPTION
Some image captions have newlines in the strings themselves, which
will mess up our gtk label ellipsizing. Replace the newlines with
spaces and the label ellipses work again
[endlessm/eos-sdk#1720]
