### PR TITLE
Ping knowledge engine on app startup

### DIFF
--- a/overrides/engine.js
+++ b/overrides/engine.js
@@ -57,6 +57,28 @@ const Engine = Lang.Class({
     },
 
     /**
+     * Function: ping
+     * Pings the knowledge engine with a dummy request. Used to wake
+     * up the knowledge engine from its slumber.
+     *
+     * Parameters:
+     *
+     *   domain - The knowledge engine domain
+     */
+    _DUMMY_QUERY : 'frango',
+    ping: function (domain) {
+        let req_uri = this.get_ekn_uri(domain, undefined, {q: this._DUMMY_QUERY, limit: 1});
+        this._send_json_ld_request(req_uri, function (err, json_ld) {
+            if (typeof err !== 'undefined') {
+                // error occurred during request, so immediately fail with err
+                printerr("Failed to ping EKN");
+            } else{
+                // Successfully pinged knowledge engine
+            }
+        }.bind(this));
+    },
+
+    /**
      * Function: get_object_by_id
      * Sends a request for a Knowledge Engine object at *domain* with ID *id*.
      * *callback* is a function which takes *err* and *result* parameters.

--- a/overrides/presenter.js
+++ b/overrides/presenter.js
@@ -62,6 +62,8 @@ const Presenter = new Lang.Class({
         }
 
         this._engine = new Engine.Engine();
+        // Ping server to spin up knowledge engine
+        this._engine.ping(this._domain);
 
         this._history_model = new EosKnowledge.HistoryModel();
         this._article_presenter = new ArticlePresenter.ArticlePresenter({


### PR DESCRIPTION
The knowledge engine is socket activated by systemd
so we should ping it on app startup to ensure that
it is active before any real requests are made. This
improves performance of the app.

https://github.com/endlessm/eos-sdk/issues/1810
