### PR TITLE
Configure with --enable-inspector to use WebKit inspector

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -190,6 +190,13 @@ AM_COND_IF([ENABLE_JS_DOC], [], [can_make_dist=no])
 AM_CONDITIONAL([CAN_MAKE_DIST], [test "x$can_make_dist" = "xyes"])
 AC_MSG_RESULT([$can_make_dist])
 
+# --enable-inspector: Allow opening the WebKit inspector in the webviews by
+# right-clicking
+AC_ARG_ENABLE([inspector], AS_HELP_STRING([--enable-inspector],
+    [Allow activating WebKit inspector on HTML pages (default=no)]))
+AS_IF([test "x$enable_inspector" != "xyes"], [inspector=false], [inspector=true])
+AC_SUBST([inspector])
+
 # Required libraries
 # ------------------
 PKG_CHECK_MODULES([EOS_KNOWLEDGE], [

--- a/overrides/config.js.in
+++ b/overrides/config.js.in
@@ -1,2 +1,3 @@
 // Private module for configure-time constants
 const GETTEXT_PACKAGE = '@GETTEXT_PACKAGE@';
+const inspector_enabled = @inspector@;

--- a/overrides/eknWebview.js
+++ b/overrides/eknWebview.js
@@ -5,6 +5,8 @@ const Gtk = imports.gi.Gtk;
 const Lang = imports.lang;
 const WebKit2 = imports.gi.WebKit2;
 
+const Config = imports.config;
+
 /**
  * Class: EknWebview
  * WebKit WebView subclass which provides utility functions for loading
@@ -27,6 +29,8 @@ const EknWebview = new Lang.Class({
     _init: function (params) {
         this._injection_handlers = [];
         this.parent(params);
+
+        this.get_settings().enable_developer_extras = Config.inspector_enabled;
 
         this.connect('decide-policy', this._onNavigation.bind(this));
     },


### PR DESCRIPTION
This allows you to open the WebKit inspector if you configured with
--enable-inspector. The default is to disable. The right-click menu is
still enabled so that you can copy text from knowledge engine
documents.

[endlessm/eos-sdk#1775]
