### PR TITLE
Card A resizes on state flags changed

### DIFF
--- a/overrides/backButtonOverlay.js
+++ b/overrides/backButtonOverlay.js
@@ -44,6 +44,12 @@ const BackButtonOverlay = new Lang.Class({
         }.bind(this));
         this._back_button.get_style_context().add_class(EosKnowledge.STYLE_CLASS_SECTION_PAGE_BACK_BUTTON);
         this._back_button.show_all();
+        // Our button size changes via css state selectors on hover, and for
+        // some reason Gtk isn't handling this queue resize for us
+        this._back_button.connect('state-flags-changed', function () {
+            this._back_button.queue_resize();
+        }.bind(this));
+
 
         this.add_overlay(this._back_button);
     }

--- a/overrides/cardA.js
+++ b/overrides/cardA.js
@@ -29,6 +29,11 @@ const CardA = new Lang.Class({
         this.parent(props);
 
         this.get_style_context().add_class(EosKnowledge.STYLE_CLASS_CARD_A);
+        // Our button size changes via css state selectors on hover, and for
+        // some reason Gtk isn't handling this queue resize for us
+        this.connect('state-flags-changed', function () {
+            this.queue_resize();
+        }.bind(this));
     },
 
     // TODO: we do want all cards to be the same size, but we may want to make


### PR DESCRIPTION
Sometimes our article cards would appear stuck in a hover state,
where the internal state of the card would return to a normal state
but it was still sized like a hovered card. Resizing every time state
flags changed fixes this
[endlessm/eos-sdk#1674]
