### PR TITLE
See all categories hides itself when not necessary

### DIFF
--- a/overrides/categoriesPage.js
+++ b/overrides/categoriesPage.js
@@ -26,6 +26,12 @@ const CategoriesPage = new Lang.Class({
     GTypeName: 'EknCategoriesPage',
     Extends: Gtk.ScrolledWindow,
 
+    Properties: {
+        'animating': GObject.ParamSpec.boolean('animating',
+            'Animating', 'Set true if this page is animating and should hide its show all button',
+            GObject.ParamFlags.READWRITE, false),
+    },
+
     Signals: {
         /**
          * Event: show-home
@@ -53,6 +59,7 @@ const CategoriesPage = new Lang.Class({
             label: _("HOME")
         });
 
+        this._animating = false;
         this._button_stack.connect('notify::transition-running', Lang.bind(this, function (running) {
             let home_page_request = !this._button_stack.transition_running && this._button_stack.visible_child != this._home_button;
             if (home_page_request) {
@@ -62,7 +69,7 @@ const CategoriesPage = new Lang.Class({
 
         this._button_stack.add(this._invisible_frame);
         this._button_stack.add(this._home_button);
-        this._home_button.connect('clicked', this._onHomeClicked.bind(this));
+        this._home_button.connect('clicked', this._hide_button.bind(this));
 
         this._card_grid = new Gtk.FlowBox({
             valign: Gtk.Align.START,
@@ -82,6 +89,19 @@ const CategoriesPage = new Lang.Class({
         this.parent(props);
         this.add(this._grid);
         this.show_all();
+    },
+
+    get animating () {
+        return this._animating;
+    },
+
+    set animating (v) {
+        if (v === this._animating)
+            return;
+        this._animating = v;
+        if (!this._animating && this.get_mapped()) {
+            this._show_button();
+        }
     },
 
     set cards (v) {
@@ -104,12 +124,12 @@ const CategoriesPage = new Lang.Class({
         return this._cards;
     },
 
-    _onHomeClicked: function () {
+    _hide_button: function () {
         this._button_stack.transition_type = Gtk.StackTransitionType.SLIDE_UP;
         this._button_stack.visible_child = this._invisible_frame;
     },
 
-    showButton: function () {
+    _show_button: function () {
         this._button_stack.transition_type = Gtk.StackTransitionType.SLIDE_DOWN;
         this._button_stack.visible_child = this._home_button;
     }

--- a/overrides/window.js
+++ b/overrides/window.js
@@ -204,13 +204,8 @@ const Window = new Lang.Class({
             this._section_article_page = new SectionArticlePage.SectionArticlePageA();
             // Connection so that tab buttons are revealed after page transition
             this.page_manager.connect('notify::transition-running', Lang.bind(this, function () {
-                if (!this.page_manager.transition_running) {
-                    if (this.page_manager.visible_child === this.home_page) {
-                        this.home_page.showButton();
-                    } else if (this.page_manager.visible_child === this.categories_page) {
-                        this.categories_page.showButton();
-                    }
-                }
+                this.home_page.animating = this.page_manager.transition_running;
+                this.categories_page.animating = this.page_manager.transition_running;
             }));
         }
         this._section_article_page.connect('back-clicked', function () {


### PR DESCRIPTION
Added an all-cards-visible property to the home page a container
and used that to update the button visibility state.

Then ran into problems where updating the button visible would
automatically trigger the category page transition, so needed
to change how that was handled as well.

Switched to a model where the toplevel window just lets the pages
know if they are currently animating, and they handle showing and
hiding the buttons themselves
[endlessm/eos-sdk#1846]
