### PR TITLE
Search boxes should have constant width

### DIFF
--- a/overrides/homePageA.js
+++ b/overrides/homePageA.js
@@ -102,6 +102,7 @@ const HomePageA = new Lang.Class({
         this._button_stack.visible_child = this._all_categories_button;
     },
 
+    _SEARCH_BOX_WIDTH: 400,
     pack_widgets: function (title_image, search_box) {
         title_image.margin_bottom = 30;
 
@@ -111,8 +112,10 @@ const HomePageA = new Lang.Class({
             expand: true,
             orientation: Gtk.Orientation.VERTICAL
         });
-        inner_grid.attach(title_image, 0, 0, 3, 1);
-        inner_grid.attach(search_box, 0, 1, 3, 1);
+        search_box.width_request = this._SEARCH_BOX_WIDTH;
+        search_box.halign = Gtk.Align.CENTER;
+        inner_grid.add(title_image);
+        inner_grid.add(search_box);
 
         this.orientation = Gtk.Orientation.VERTICAL;
         this.add(inner_grid);

--- a/overrides/homePageB.js
+++ b/overrides/homePageB.js
@@ -34,10 +34,11 @@ const HomePageB = new Lang.Class({
         this.get_style_context().add_class(EosKnowledge.STYLE_CLASS_HOME_PAGE_B);
     },
 
+    _SEARCH_BOX_WIDTH: 350,
     pack_widgets: function (title_image, search_box) {
         title_image.vexpand = true;
         search_box.halign = Gtk.Align.CENTER;
-        search_box.width_chars = 40;
+        search_box.width_request = this._SEARCH_BOX_WIDTH;
 
         let card_container_frame = new Gtk.Frame();
         card_container_frame.get_style_context().add_class(EosKnowledge.STYLE_CLASS_CARD_CONTAINER);


### PR DESCRIPTION
As per design request, search box should not expand with
the size of the grid on the home page. Instead the
search boxes should have a constant width across
all apps.

[endlessm/eos-sdk#1842]
