### PR TITLE
Sdk/1869

### DIFF
--- a/data/endless_knowledge.css
+++ b/data/endless_knowledge.css
@@ -50,13 +50,17 @@ EknWindow.show-article-page {
 }
 
 .card-a .card-title {
-    padding: 17px 0px 17px 0px;
+    padding: 4px 0px 4px 0px;
     color: #d16550;
     font-family: 'Montserrat', sans-serif;
     font-size: 0.9em;
     font-weight: bold;
     text-shadow: 0px 1px 0px white;
     transition: padding 250ms ease-in-out;
+}
+
+.home-page-a .card-a .card-title {
+    padding: 9px 0px 9px 0px;
 }
 
 .text-card {

--- a/overrides/articleCard.js
+++ b/overrides/articleCard.js
@@ -1,5 +1,6 @@
 // Copyright 2014 Endless Mobile, Inc.
 
+const Gtk = imports.gi.Gtk;
 const Lang = imports.lang;
 
 const CardA = imports.cardA;
@@ -20,5 +21,17 @@ const ArticleCard = new Lang.Class({
 
     _init: function (props) {
         this.parent(props);
-    }
+    },
+
+    pack_widgets: function (title_label, synopsis_label, image_frame) {
+        title_label.xalign = 0;
+        synopsis_label.xalign = 0;
+        synopsis_label.yalign = 0;
+        let grid = new Gtk.Grid({
+            orientation: Gtk.Orientation.VERTICAL
+        });
+        grid.add(title_label);
+        grid.add(synopsis_label);
+        this.add(grid);
+    },
 });

--- a/overrides/card.js
+++ b/overrides/card.js
@@ -54,7 +54,9 @@ const Card = new Lang.Class({
     _init: function(props) {
         this._title_label = new Gtk.Label({
             hexpand: true,
+            wrap_mode: Pango.WrapMode.WORD_CHAR,
             ellipsize: Pango.EllipsizeMode.END,
+            lines: 2,
             max_width_chars: 1,
             visible: false,
             no_show_all: true
@@ -62,7 +64,7 @@ const Card = new Lang.Class({
         this._synopsis_label = new Gtk.Label({
             hexpand: true,
             ellipsize: Pango.EllipsizeMode.END,
-            wrap_mode: Pango.WrapMode.WORD,
+            wrap_mode: Pango.WrapMode.WORD_CHAR,
             lines: 8,
             max_width_chars: 1,
             visible: false,


### PR DESCRIPTION
Merge endlessm/eos-sdk#1839 first! This is based on that issue so I could get the new font sizes before getting all the sizing working correctly. Once that is merged those commits can just be rebased away.

This adds a extra line to category and article card titles, which I think is an important fix to get in given how many article (and even category names on some apps) were ellipsizing.

[endlessm/eos-sdk#1869]
