### PR TITLE
Template article cards fade in when first displayed

### DIFF
--- a/data/endless_knowledge.css
+++ b/data/endless_knowledge.css
@@ -7,6 +7,23 @@ EosWindow {
     background-color: #888888;
 }
 
+.card {
+    opacity: 0.0;
+}
+
+.card.visible {
+    opacity: 1.0;
+}
+
+.card.fade-in {
+    /* FIXME: we have to add in a margin transition here or we override the card a
+     * margin transition. Would be good to have to copy the margin theme to two
+     * places. Investigate and fix. */
+    transition: opacity 1000ms ease-in-out,
+                margin 250ms ease-in-out;
+    opacity: 1.0;
+}
+
 .card .thumbnail {
     background-position: center;
     background-size: cover;

--- a/overrides/card.js
+++ b/overrides/card.js
@@ -8,6 +8,8 @@ const Pango = imports.gi.Pango;
 
 const CompositeButton = imports.compositeButton;
 
+GObject.ParamFlags.READWRITE = GObject.ParamFlags.READABLE | GObject.ParamFlags.WRITABLE;
+
 /**
  * Class: Card
  * Base class for topic cards in the knowledge app UI
@@ -48,7 +50,11 @@ const Card = new Lang.Class({
          */
         'thumbnail-uri': GObject.ParamSpec.string('thumbnail-uri', 'Thumbnail URI',
             'URI of the background image',
-            GObject.ParamFlags.READABLE | GObject.ParamFlags.WRITABLE, '')
+            GObject.ParamFlags.READABLE | GObject.ParamFlags.WRITABLE, ''),
+        'fade-in': GObject.ParamSpec.boolean('fade-in', 'Fade in',
+            'True if the card should fade in to being visible.',
+            GObject.ParamFlags.READWRITE | GObject.ParamFlags.CONSTRUCT_ONLY,
+            false),
     },
 
     _init: function(props) {
@@ -84,6 +90,16 @@ const Card = new Lang.Class({
         this._title_label.get_style_context().add_class(EosKnowledge.STYLE_CLASS_CARD_TITLE);
         this._synopsis_label.get_style_context().add_class(EosKnowledge.STYLE_CLASS_CARD_SYNOPSIS);
         this._image_frame.get_style_context().add_class(EosKnowledge.STYLE_CLASS_THUMBNAIL);
+        if (this.fade_in) {
+            // FIXME: for some reason even if initial opacity = 0 in css, the
+            // opacity will start at 1. Triggering a 'notify' on opacity seems
+            // to get the actual initial opacity value in css to be respected
+            this.opacity = 0;
+            this.opacity = 1;
+            this.get_style_context().add_class('fade-in');
+        } else {
+            this.get_style_context().add_class('visible');
+        }
 
         this.pack_widgets(this._title_label, this._synopsis_label, this._image_frame);
         this.show_all();

--- a/overrides/presenter.js
+++ b/overrides/presenter.js
@@ -340,10 +340,16 @@ const Presenter = new Lang.Class({
     },
 
     _new_card_from_article_model: function (model) {
-        let card_class = this._template_type === 'B' ? TextCard.TextCard : ArticleCard.ArticleCard;
+        let fade_in = true;
+        let card_class = ArticleCard.ArticleCard;
+        if (this._template_type === 'B') {
+            fade_in = false;
+            card_class = TextCard.TextCard;
+        }
         let card = new card_class({
             title: model.title,
-            synopsis: model.synopsis
+            synopsis: model.synopsis,
+            fade_in: fade_in,
         });
         card.connect('clicked', function () {
             this._on_article_card_clicked(card, model);


### PR DESCRIPTION
To give a nice smooth animation when loading results
[endlessm/eos-sdk#1865]
