### PR TITLE
Template B card titles only use one line

### DIFF
--- a/overrides/articleCard.js
+++ b/overrides/articleCard.js
@@ -24,6 +24,7 @@ const ArticleCard = new Lang.Class({
     },
 
     pack_widgets: function (title_label, synopsis_label, image_frame) {
+        title_label.lines = 2;
         title_label.xalign = 0;
         synopsis_label.xalign = 0;
         synopsis_label.yalign = 0;

--- a/overrides/card.js
+++ b/overrides/card.js
@@ -62,7 +62,6 @@ const Card = new Lang.Class({
             hexpand: true,
             wrap_mode: Pango.WrapMode.WORD_CHAR,
             ellipsize: Pango.EllipsizeMode.END,
-            lines: 2,
             max_width_chars: 1,
             visible: false,
             no_show_all: true

--- a/overrides/cardA.js
+++ b/overrides/cardA.js
@@ -36,6 +36,11 @@ const CardA = new Lang.Class({
         }.bind(this));
     },
 
+    pack_widgets: function (title_label, synopsis_label, image_frame) {
+        title_label.lines = 2;
+        this.parent(title_label, synopsis_label, image_frame);
+    },
+
     // TODO: we do want all cards to be the same size, but we may want to make
     // this size scale with resolution down the road
     vfunc_get_preferred_width: function () {

--- a/overrides/cardB.js
+++ b/overrides/cardB.js
@@ -27,6 +27,7 @@ const CardB = new Lang.Class({
     },
 
     pack_widgets: function (title_label, synopsis_label, image_frame) {
+        title_label.lines = 1;
         title_label.valign = Gtk.Align.END;
         // Make title label "transparent" to mouse events
         title_label.connect_after('realize', function (widget) {

--- a/overrides/textCard.js
+++ b/overrides/textCard.js
@@ -36,6 +36,7 @@ const TextCard = new Lang.Class({
     },
 
     pack_widgets: function (title_label, synopsis_label, image_frame) {
+        title_label.lines = 1;
         title_label.xalign = 0.0;
         this.add(title_label);
     }


### PR DESCRIPTION
Put in a change that allowed two lines for titles on template A
apps. This accidentally applied to template B as well. Set up
the template B cards to ellipsize after one line of title, as
they should
[endlessm/eos-sdk#1895]
