### PR TITLE
Decrease background image parallax

### DIFF
--- a/data/endless_knowledge.css
+++ b/data/endless_knowledge.css
@@ -33,7 +33,7 @@ EosWindow {
 EknWindow {
     background-position: 0% 50%;
     background-repeat: no-repeat;
-    transition: background-position 0.5s ease-in-out;
+    transition: background-position 0.5s ease;
 }
 
 EknWindow.show-home-page {

--- a/overrides/window.js
+++ b/overrides/window.js
@@ -25,7 +25,7 @@ GObject.ParamFlags.READWRITE = GObject.ParamFlags.READABLE | GObject.ParamFlags.
  * therefore also how zoomed in the background image is from its
  * original size.
  */
-const PARALLAX_BACKGROUND_SCALE = 1.2;
+const PARALLAX_BACKGROUND_SCALE = 1.1;
 
 /**
  * Class: Window


### PR DESCRIPTION
Background image slides half as much as before when transitioning
between pages.

[endlessm/eos-sdk#1883]
