### PR TITLE
Cards not sensitive till they are fully faded in

### DIFF
--- a/overrides/card.js
+++ b/overrides/card.js
@@ -4,6 +4,7 @@ const EosKnowledge = imports.gi.EosKnowledge;
 const Gtk = imports.gi.Gtk;
 const GObject = imports.gi.GObject;
 const Lang = imports.lang;
+const Mainloop = imports.mainloop;
 const Pango = imports.gi.Pango;
 
 const CompositeButton = imports.compositeButton;
@@ -98,6 +99,12 @@ const Card = new Lang.Class({
             this.opacity = 0;
             this.opacity = 1;
             this.get_style_context().add_class('fade-in');
+            // Cards not sensitive till fully faded in
+            this.set_sensitive(false);
+            Mainloop.timeout_add(1000, function () {
+                this.set_sensitive(true);
+                return false;
+            }.bind(this));
         } else {
             this.get_style_context().add_class('visible');
         }


### PR DESCRIPTION
A work around fix for a bug where the hover state animating
while the card was fading in would result in the cards getting
stuck at an intermediate opacity

Since they are not sensitive they while fading they will not
trigger the hover state animation until its safe
[endlessm/eos-sdk#1865]
