### PR TITLE
Only lock the main page UI, and not the top bar in lock_ui

### DIFF
--- a/overrides/window.js
+++ b/overrides/window.js
@@ -518,14 +518,14 @@ const Window = new Lang.Class({
     },
 
     lock_ui: function () {
-        let gdk_window = this.get_window();
+        let gdk_window = this.page_manager.get_window();
         gdk_window.cursor = Gdk.Cursor.new(Gdk.CursorType.WATCH);
-        this.sensitive = false;
+        this.page_manager.sensitive = false;
     },
 
     unlock_ui: function () {
-        let gdk_window = this.get_window();
+        let gdk_window = this.page_manager.get_window();
         gdk_window.cursor = Gdk.Cursor.new(Gdk.CursorType.ARROW);
-        this.sensitive = true;
+        this.page_manager.sensitive = true;
     }
 });


### PR DESCRIPTION
This will allow the user to quit the app, even if in the middle of
some loading operation.

[endlessm/eos-sdk#1903]
