### PR TITLE
All Cards in category page should be centered

### DIFF
--- a/overrides/categoriesPage.js
+++ b/overrides/categoriesPage.js
@@ -73,7 +73,7 @@ const CategoriesPage = new Lang.Class({
 
         this._card_grid = new Gtk.FlowBox({
             valign: Gtk.Align.START,
-            halign: Gtk.Align.START,
+            halign: Gtk.Align.CENTER,
             homogeneous: true,
             expand: true,
             max_children_per_line: 10000,


### PR DESCRIPTION
Changed the alignment so that all the cards in the category page appear centered, no matter the resolution.

[endlessm/eos-sdk#1838]