### PR TITLE
Escape colons when selecting sections in article

### DIFF
--- a/data/scroll_manager.js
+++ b/data/scroll_manager.js
@@ -23,11 +23,16 @@ const SCROLLED_PAST_PREFIX = '#scrolled-past-';
 // we want to watch for when user scrolls
 const SCROLL_NOTIFIER_MATCHER = '.mw-headline';
 
+function sanitize_hash (hash) {
+    var clean_hash = hash.replace(/([.:])/g, '\\$1');
+    return clean_hash;
+}
+
 // If the anchor at the specified hash exists, scroll to it.
 // Returns whether the caller should propagate events
 window.scrollTo = function (hash, duration) {
-    var target = $(hash.replace(/\./g, '\\.'));
-    if (target.length) {
+    var target = $(sanitize_hash(hash));
+    if (target.length > 0) {
         var body = $('html,body');
         var maxScroll = $(document).height() - $(window).height();
         body.stop();


### PR DESCRIPTION
Previously, when selecting a section to which to
scroll in an article, we were not escaping colons,
which (since they have special meaning in CSS) meant
that we could not select the desired section. Now
we escape those colons.

[endlessm/eos-sdk#1924]
