### PR TITLE
Managed card title capitalization

### DIFF
--- a/overrides/homePageA.js
+++ b/overrides/homePageA.js
@@ -125,6 +125,10 @@ const HomePageA = new Lang.Class({
     },
 
     pack_cards: function (cards) {
+        cards = cards.map(function (card) {
+            card.title = card.title.toUpperCase();
+            return card;
+        });
         this._card_container.remove_cards();
         this._card_container.add_cards(this._cards);
     }

--- a/overrides/homePageB.js
+++ b/overrides/homePageB.js
@@ -66,6 +66,7 @@ const HomePageB = new Lang.Class({
         for (let card of cards) {
             let col = i % columns;
             let row = Math.floor(i / columns);
+            card.title = card.title.toUpperCase();
             this._card_container.attach(card, col, row, 1, 1);
             i++;
         }

--- a/overrides/sectionPage.js
+++ b/overrides/sectionPage.js
@@ -61,7 +61,7 @@ const SectionPage = new Lang.Class({
     set title (v) {
         if (this._title === v) return;
         this._title = v;
-        this._title_label.label = this._title;
+        this._title_label.label = this._title.charAt(0).toUpperCase() + this._title.slice(1).toLowerCase();
         this.notify('title');
     },
 


### PR DESCRIPTION
After a design QA, it was requested to have the following capitalization for card titles:
- Home page cards: All caps.
- Section page cards: Sentence capitalization.

This is a temporary measure, since in the future, every app will specify this behavior independently.

[endlessm/eos-sdk#1870]
