### PR TITLE
Remove text shadow to fix transition to no results page

### DIFF
--- a/data/endless_knowledge.css
+++ b/data/endless_knowledge.css
@@ -475,9 +475,7 @@ EknWindow.show-no-search-results-page {
 .no-search-results-page-a .no-search-results-page-try-again-label {
     font-family: Lato;
     color: white;
-    /* FIXME: this text shadow slows down page transitions horribly. Probably
-     * something that needs to be fixed in Gtk or lower on the stack. */
-    /*text-shadow: 0px 1px 10px alpha(black, 0.30);*/
+    text-shadow: 0px 1px 10px alpha(black, 0.30);
 }
 
 .no-search-results-page-a .no-search-results-page-no-results-label {
@@ -505,6 +503,13 @@ EknWindow.show-no-search-results-page {
     color: white;
     text-shadow: 0px 1px 10px alpha(black, 0.30);
     padding-left: 100px;
+}
+
+/* FIXME: this text shadow slows down page transitions horribly. Probably
+something that needs to be fixed in Gtk or lower on the stack. */
+.no-search-results-page-a.animating *,
+.no-search-results-page-b.animating * {
+    text-shadow: none;
 }
 
 /* FIXME: for the time being, until we can properly customize the webkit

--- a/overrides/window.js
+++ b/overrides/window.js
@@ -301,6 +301,13 @@ const Window = new Lang.Class({
             'transition-duration', GObject.BindingFlags.SYNC_CREATE);
         this.page_manager.bind_property('transition-duration', this._section_article_page.article_page.switcher,
             'transition-duration', GObject.BindingFlags.SYNC_CREATE);
+        this.page_manager.connect('notify::transition-running', function () {
+            let context = this._no_search_results_page.get_style_context();
+            if (this.page_manager.transition_running)
+                context.add_class(EosKnowledge.STYLE_CLASS_ANIMATING);
+            else
+                context.remove_class(EosKnowledge.STYLE_CLASS_ANIMATING);
+        }.bind(this));
         this.get_style_context().add_class(EosKnowledge.STYLE_CLASS_SHOW_HOME_PAGE);
         this.connect('size-allocate', Lang.bind(this, function(widget, allocation) {
             let win_width = allocation.width;


### PR DESCRIPTION
The text shadow was making that transition extremely choppy for
reasons not clear to me
[endlessm/eos-sdk#1976]
