### PR TITLE
Utils file for tests is clearly differentiated

### DIFF
--- a/tests/eosknowledge/testArticleObjectModel.js
+++ b/tests/eosknowledge/testArticleObjectModel.js
@@ -3,7 +3,7 @@ const EosKnowledge = imports.gi.EosKnowledge;
 const Gtk = imports.gi.Gtk;
 const InstanceOfMatcher = imports.InstanceOfMatcher;
 
-const utils = imports.utils;
+const utils = imports.tests.utils;
 
 EosKnowledge.init();
 

--- a/tests/eosknowledge/testContentObjectModel.js
+++ b/tests/eosknowledge/testContentObjectModel.js
@@ -1,7 +1,7 @@
 const Endless = imports.gi.Endless;
 const EosKnowledge = imports.gi.EosKnowledge;
 
-const utils = imports.utils;
+const utils = imports.tests.utils;
 
 EosKnowledge.init();
 

--- a/tests/eosknowledge/testEngine.js
+++ b/tests/eosknowledge/testEngine.js
@@ -3,7 +3,7 @@ const Endless = imports.gi.Endless;
 const Soup = imports.gi.Soup;
 
 const InstanceOfMatcher = imports.InstanceOfMatcher;
-const utils = imports.utils;
+const utils = imports.tests.utils;
 
 EosKnowledge.init();
 

--- a/tests/eosknowledge/testMediaInfobox.js
+++ b/tests/eosknowledge/testMediaInfobox.js
@@ -3,7 +3,7 @@ const EosKnowledge = imports.gi.EosKnowledge;
 const Gtk = imports.gi.Gtk;
 const InstanceOfMatcher = imports.InstanceOfMatcher;
 
-const utils = imports.utils;
+const utils = imports.tests.utils;
 
 EosKnowledge.init();
 

--- a/tests/eosknowledge/testMediaObjectModels.js
+++ b/tests/eosknowledge/testMediaObjectModels.js
@@ -3,7 +3,7 @@ const EosKnowledge = imports.gi.EosKnowledge;
 const Gtk = imports.gi.Gtk;
 const InstanceOfMatcher = imports.InstanceOfMatcher;
 
-const utils = imports.utils;
+const utils = imports.tests.utils;
 
 EosKnowledge.init();
 


### PR DESCRIPTION
After adding a new utils.js class for overrides, the tests broke. Now we clearly identify tests/utils.js to be used in the Jasmine tests.

[endlessm/eos-sdk#1996]
