### PR TITLE
contentUrl is now part of ContentObjectModel

### DIFF
--- a/overrides/contentObjectModel.js
+++ b/overrides/contentObjectModel.js
@@ -13,7 +13,7 @@ GObject.ParamFlags.READWRITE = GObject.ParamFlags.READABLE | GObject.ParamFlags.
  * This is the base class for all content objects in the knowledge app.
  *
  * This object can be configured with a <title>, <thumbnail>, <language>,
- * <copyright-holder>, <source-uri>, <synopsis>, <resources>, <last-modified-date>, 
+ * <copyright-holder>, <source-uri>, <content-uri>, <synopsis>, <resources>, <last-modified-date>,
  * <tags>, and <license> properties.
  */
 const ContentObjectModel = new Lang.Class({
@@ -59,6 +59,14 @@ const ContentObjectModel = new Lang.Class({
          */
         'source-uri': GObject.ParamSpec.string('source-uri', 'Source URL', 'URI of the source page',
             GObject.ParamFlags.READWRITE | GObject.ParamFlags.CONSTRUCT, ''),
+        /**
+         * Property: content-uri
+         * A string with the URI to the file content for this object.
+         */
+        'content-uri': GObject.ParamSpec.string('content-uri', 'Object Content URL',
+            'URI of the source content file',
+            GObject.ParamFlags.READWRITE | GObject.ParamFlags.CONSTRUCT,
+            'about:blank'),
         /**
          * Property: synopsis
          * The synopsis for this content object. Defaults to an empty string.
@@ -162,6 +170,10 @@ const ContentObjectModel = new Lang.Class({
         return this._source_url;
     },
 
+    get content_uri () {
+        return this._content_uri;
+    },
+
     get synopsis () {
         return this._synopsis;
     },
@@ -215,6 +227,10 @@ const ContentObjectModel = new Lang.Class({
 
     set source_url (v) {
         this._source_url = v;
+    },
+
+    set content_uri (v) {
+        this._content_uri = v;
     },
 
     set synopsis (v) {
@@ -338,6 +354,9 @@ ContentObjectModel._props_from_json_ld = function (json_ld_data) {
 
     if(json_ld_data.hasOwnProperty('sourceURL'))
         props.source_uri = json_ld_data.sourceURL;
+
+    if (json_ld_data.hasOwnProperty('contentURL'))
+        props.content_uri = json_ld_data.contentURL;
 
     if(json_ld_data.hasOwnProperty('synopsis'))
         props.synopsis = json_ld_data.synopsis;

--- a/overrides/mediaObjectModel.js
+++ b/overrides/mediaObjectModel.js
@@ -14,23 +14,14 @@ GObject.ParamFlags.READWRITE = GObject.ParamFlags.READABLE | GObject.ParamFlags.
 /**
  * Class: MediaObjectModel
  * The model class for media objects. A media obejct has the same 
- * properties as a <ContentObjectModel>, plus <content-uri>, <caption>,
- * <encoding-format>, <height> and <width> properties
+ * properties as a <ContentObjectModel>, plus <caption>, <encoding-format>, <height>
+ * and <width> properties
  */
 const MediaObjectModel = new Lang.Class({
     Name: 'MediaObjectModel',
     GTypeName: 'EknMediaObjectModel',
     Extends: ContentObjectModel.ContentObjectModel,
     Properties: {
-        /**
-         * Property: content-uri
-         * The URI at which the content resides. Defaults to "about:blank"
-         */
-        'content-uri': GObject.ParamSpec.string('content-uri',
-            'Media Content URI', 'URI to the media object content',
-            GObject.ParamFlags.READWRITE | GObject.ParamFlags.CONSTRUCT,
-            'about:blank'),
-
         /**
          * Property: caption
          * A displayable string which describes the media object in the same
@@ -77,10 +68,6 @@ const MediaObjectModel = new Lang.Class({
         return this._caption;
     },
 
-    get content_uri () {
-        return this._content_uri;
-    },
-
     get encoding_format () {
         return this._encoding_format;
     },
@@ -95,10 +82,6 @@ const MediaObjectModel = new Lang.Class({
 
     set caption (v) {
         this._caption = v;
-    },
-
-    set content_uri (v) {
-        this._content_uri = v;
     },
 
     set encoding_format (v) {
@@ -141,10 +124,6 @@ MediaObjectModel._props_from_json_ld = function (json_ld_data) {
     // Marshal properties specific to MediaObjectModel
     if (json_ld_data.hasOwnProperty('caption')) {
         props.caption = json_ld_data.caption;
-    }
-
-    if (json_ld_data.hasOwnProperty('contentURL')) {
-        props.content_uri = json_ld_data.contentURL;
     }
 
     if (json_ld_data.hasOwnProperty('encodingFormat')) {


### PR DESCRIPTION
To serve PDF documents, we are adding a contentUrl property to the ContentObjectModel, so that the ArticleObjectModel can use it to point to the path of the PDF file. Since this property was already being used by the MediaObjectModel, we are refactoring these objects to move the property up in the class hierarchy.

[endlessm/eos-sdk#1355]
