### PR TITLE
Fix build

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -3,7 +3,7 @@ Priority: standard
 Maintainer: Philip Chimento <philip@endlessm.com>
 Build-Depends: autotools-dev,
                debhelper (>= 8.0.0),
-               eos-sdk-dev,
+               eos-sdk-0-dev,
                gir1.2-gtkclutter-1.0,
                gir1.2-clutter-gst-2.0,
                gir1.2-endless-0,


### PR DESCRIPTION
This updates the build dependencies to the new name of the SDK dev
package: eos-sdk-0-dev.

[endlessm/eos-sdk#418]
