### PR TITLE
Shared library's init needs XDG_RUNTIME_DIR

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -9,6 +9,8 @@
 # Uncomment this to turn on verbose mode.
 #export DH_VERBOSE=1
 
+export XDG_RUNTIME_DIR=/tmp
+
 %:
 	dh $@  --with autotools-dev --with gir
 


### PR DESCRIPTION
The init code of the shared library, which is called every time the
shared library is loaded -- including for GObject introspection and
Gtk-doc scanners -- tries to initialize clutter. That will fail, but
it will also abort the program entirely if XDG_RUNTIME_DIR is not set.
Therefore, we set it to /tmp as a workaround.
