### PR TITLE
Article presenter loads pdfs from knowledge engine

### DIFF
--- a/overrides/articleObjectModel.js
+++ b/overrides/articleObjectModel.js
@@ -23,16 +23,6 @@ const ArticleObjectModel = new Lang.Class({
     Extends: ContentObjectModel.ContentObjectModel,
     Properties: {
         /**
-         * Property: article-content-uri
-         * The URI at which the main textual portion of the article resides. Defaults to
-         * "about:blank"
-         */
-        'article-content-uri': GObject.ParamSpec.string('article-content-uri',
-            'Article Content URI', 'URI to the main textual portion of the article',
-            GObject.ParamFlags.READWRITE | GObject.ParamFlags.CONSTRUCT,
-            'about:blank'),
-
-        /**
          * Property: word-count
          * Integer indicating how many words are in the article
          */
@@ -57,20 +47,12 @@ const ArticleObjectModel = new Lang.Class({
         this.parent(params);
     },
 
-    get article_content_uri () {
-        return this._article_content_uri;
-    },
-
     get word_count () {
         return this._word_count;
     },
 
     get table_of_contents () {
         return this._table_of_contents;
-    },
-
-    set article_content_uri (v) {
-        this._article_content_uri = v;
     },
 
     set word_count (v) {
@@ -107,10 +89,6 @@ ArticleObjectModel._props_from_json_ld = function (json_ld_data) {
     let props = ParentClass._props_from_json_ld(json_ld_data);
 
     // Marshal properties specific to ArticleObjectModel
-    if (json_ld_data.hasOwnProperty('@id')) {
-        props.article_content_uri = json_ld_data['@id'];
-    }
-
     if (json_ld_data.hasOwnProperty('wordCount')) {
         props.word_count = parseInt(json_ld_data.wordCount);
     }

--- a/tests/smoke-tests/articlePresenterSmokeTest.js
+++ b/tests/smoke-tests/articlePresenterSmokeTest.js
@@ -43,7 +43,7 @@ const TestApplication = new Lang.Class ({
             article_view: view,
             engine: engine
         });
-        articleObject.article_content_uri = "file://" + TESTDIR + "/test-content/Brazil.html";
+        articleObject.ekn_id = "file://" + TESTDIR + "/test-content/Brazil.html";
         presenter.load_article(articleObject, EosKnowledge.LoadingAnimationType.NONE);
         window.show_all();
 

--- a/tests/smoke-tests/mediaObjectSmokeTest.js
+++ b/tests/smoke-tests/mediaObjectSmokeTest.js
@@ -31,7 +31,7 @@ const TestApplication = new Lang.Class ({
         });
 
         this._model = new EosKnowledge.ArticleObjectModel.new_from_json_ld(this._get_mock_article_data());
-        this._model.article_content_uri = 'file://' + TESTBUILDDIR + '/test-content/emacs.html';
+        this._model.ekn_id = 'file://' + TESTBUILDDIR + '/test-content/emacs.html';
         this._model.set_resources(this._get_mock_media_objects());
 
         this._view = new EosKnowledge.ArticlePage();


### PR DESCRIPTION
When a article model has a content URI, we do type detection on that
file to determine what kind of view to load it with.

Right now thats only pdfs, but could be more in the future.
[endlessm/eos-sdk#1354]
