### PR TITLE
Template A card thumbnails display at proper size

### DIFF
--- a/data/endless_knowledge.css
+++ b/data/endless_knowledge.css
@@ -26,7 +26,7 @@ EosWindow {
 
 .card .thumbnail {
     background-position: center;
-    background-size: cover;
+    background-size: 100% 100%;
     border-width: 0px;
 }
 
@@ -68,6 +68,17 @@ EknWindow.show-no-search-results-page {
 
 .card-a:hover {
     margin: 3px;
+}
+
+.card-a .thumbnail {
+    transition: padding 250ms ease-in-out;
+    padding-top: 133px; /* Height of our assets from design */
+}
+
+.card-a .thumbnail:hover {
+    /* Width grows from 163 to 171 right now. 133 * 171 / 163 = 139. This should
+     * preserve aspect ratio, while growing. */
+    padding-top: 139px;
 }
 
 .card-a .card-title {

--- a/overrides/cardA.js
+++ b/overrides/cardA.js
@@ -38,6 +38,9 @@ const CardA = new Lang.Class({
 
     pack_widgets: function (title_label, synopsis_label, image_frame) {
         title_label.lines = 2;
+        title_label.expand = true;
+        image_frame.hexpand = true;
+        image_frame.vexpand = false;
         this.parent(title_label, synopsis_label, image_frame);
     },
 


### PR DESCRIPTION
Their height was wrong, so now hard coded the height in the css.
It turned out to be remarkably tricky to get things to animate
and render properly. I tried hard coding the width as well in css,
but the image would jitter oddly when animating to its larger size.
So I left the image hexpanding to kill the jitter.

Finally even when the image is rendering at the right size, it will
still be fuzzed when background-size: cover; is used. So using
background-size: 100% 100%; This gives us clarity of those images,
but will break the aspect ratio of image that do not conform to
the 163x133 size
[endlessm/eos-sdk#2044]
