### PR TITLE
Inject JS to remove eos-no-links from apps

### DIFF
--- a/data/eos-knowledge-library.gresource.xml
+++ b/data/eos-knowledge-library.gresource.xml
@@ -5,5 +5,6 @@
     <file>endless_reader.css</file>
     <file>hide_title.css</file>
     <file>scroll_manager.js</file>
+    <file>no_link_remover.js</file>
   </gresource>
 </gresources>

--- a/data/no_link_remover.js
+++ b/data/no_link_remover.js
@@ -1,0 +1,1 @@
+$(".eos-no-link").contents().unwrap();

--- a/overrides/articlePresenter.js
+++ b/overrides/articlePresenter.js
@@ -312,6 +312,7 @@ const ArticlePresenter = new GObject.Class({
         let webview = new EosKnowledge.EknWebview();
 
         webview.inject_js_from_resource('resource:///com/endlessm/knowledge/scroll_manager.js');
+        webview.inject_js_from_resource('resource:///com/endlessm/knowledge/no_link_remover.js');
         if (this.template_type === 'A')
             webview.inject_css_from_resource('resource:///com/endlessm/knowledge/hide_title.css');
 


### PR DESCRIPTION
We need to inject some custom Javascript to handle links that have been built with the 'eos-no-link' class. These are not to be treated as links by the knowledge apps, but may appear clickable in eos-encyclopedia.

(Philip & Fernando)

[endlessm/eos-sdk#1773]
