### PR TITLE
Refactor common application code

### DIFF
--- a/overrides/EosKnowledge.js
+++ b/overrides/EosKnowledge.js
@@ -9,6 +9,7 @@ let EosKnowledge;
 let _oldSearchPath = imports.searchPath.slice(0);
 imports.searchPath.unshift(Endless.getCurrentFileDir());
 
+const Application = imports.application;
 const ArticleCard = imports.articleCard;
 const ArticleObjectModel = imports.articleObjectModel;
 const ArticlePage = imports.articlePage;
@@ -89,6 +90,7 @@ function _init() {
         }
     });
 
+    EosKnowledge.Application = Application.Application;
     EosKnowledge.ArticleCard = ArticleCard.ArticleCard;
     EosKnowledge.ArticleObjectModel = ArticleObjectModel.ArticleObjectModel;
     EosKnowledge.ArticlePage = ArticlePage.ArticlePage;

--- a/overrides/Makefile.am.inc
+++ b/overrides/Makefile.am.inc
@@ -5,6 +5,7 @@ overridesdir = $(datadir)/gjs-1.0/overrides
 pkgoverridesdir = $(pkgdatadir)/overrides
 public_overrides = \
 	overrides/EosKnowledge.js \
+	overrides/application.js \
 	overrides/articleCard.js \
 	overrides/articleObjectModel.js \
 	overrides/articlePage.js \

--- a/overrides/application.js
+++ b/overrides/application.js
@@ -1,0 +1,86 @@
+const Endless = imports.gi.Endless;
+const Gdk = imports.gi.Gdk;
+const GObject = imports.gi.GObject;
+const Gtk = imports.gi.Gtk;
+const Lang = imports.lang;
+
+GObject.ParamFlags.READWRITE = GObject.ParamFlags.READABLE | GObject.ParamFlags.WRITABLE;
+
+/**
+ * Class: Application
+ * Common application class for various templates and knowledge apps
+ *
+ * This class contains various shared functionality for knowledge apps.
+ * If you are creating an app using the knowledge engine and it does not fit one
+ * of the existing classes such as <KnowledgeApp> or <Reader.Application>, then
+ * you should probably inherit from this class.
+ *
+ * Parent class:
+ *   Endless.Application
+ */
+const Application = new Lang.Class({
+    Name: 'Application',
+    GTypeName: 'EknApplication',
+    Extends: Endless.Application,
+    Properties: {
+        /**
+         * Property: resource-file
+         * File handle pointing to the app's GResource
+         *
+         * You must set this property on construction.
+         * An example value would be:
+         * > Gio.File.new_for_uri('resource:///com/endlessm/smoke-grinder')
+         *
+         * Flags:
+         *   construct only
+         */
+        'resource-file': GObject.ParamSpec.object('resource-file',
+            'Resource file', 'File handle pointing to the app GResource',
+            GObject.ParamFlags.READWRITE | GObject.ParamFlags.CONSTRUCT_ONLY,
+            GObject.Object.$gtype),
+            /* FIXME: The above should be Gio.File.$gtype; properties with an
+            interface type are broken until GJS 1.42 */
+        /**
+         * Property: css-file
+         * File handle pointing to the app's general CSS file
+         *
+         * You must set this property on construction.
+         * However, the usual way to do so is to set it in the constructor of a
+         * subclass.
+         * This is a Gio.File that should point to the CSS file containing
+         * the styling for this application type.
+         * (This is augmented if your <resource-file> contains a file called
+         * overrides.css.)
+         *
+         * Flags:
+         *   construct only
+         */
+        'css-file': GObject.ParamSpec.object('css-file', 'CSS file',
+            'File handle pointing to the general CSS file',
+            GObject.ParamFlags.READWRITE | GObject.ParamFlags.CONSTRUCT_ONLY,
+            GObject.Object.$gtype),
+            /* FIXME: The above should be Gio.File.$gtype; properties with an
+            interface type are broken until GJS 1.42 */
+    },
+
+    _init: function (props) {
+        this.parent(props);
+    },
+
+    vfunc_startup: function () {
+        this.parent();
+
+        let provider = new Gtk.CssProvider();
+        provider.load_from_file(this.css_file);
+        Gtk.StyleContext.add_provider_for_screen(Gdk.Screen.get_default(),
+            provider, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION);
+
+        let overrides_css_file = this.resource_file.get_child('overrides.css');
+        let overrides_provider = new Gtk.CssProvider();
+        overrides_provider.load_from_file(overrides_css_file);
+        // Add overrides with one step higher priority than the default
+        // knowledge app CSS
+        Gtk.StyleContext.add_provider_for_screen(Gdk.Screen.get_default(),
+            overrides_provider, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION + 1);
+    },
+});

--- a/overrides/knowledgeApp.js
+++ b/overrides/knowledgeApp.js
@@ -1,49 +1,23 @@
-const Gtk = imports.gi.Gtk;
-const Gdk = imports.gi.Gdk;
 const Gio = imports.gi.Gio;
-const Endless = imports.gi.Endless;
 const Lang = imports.lang;
 
+const EknApplication = imports.application;
 const Presenter = imports.presenter;
-
-const ENDLESS_PREFIX = '/com/endlessm/';
 
 const KnowledgeApp = new Lang.Class ({
     Name: 'KnowledgeApp',
     GTypeName: 'EknKnowledgeApp',
-    Extends: Endless.Application,
+    Extends: EknApplication.Application,
 
-    _init: function(props, gresource_filename){
+    _init: function (props) {
+        props = props || {};
+        props.css_file = Gio.File.new_for_uri('resource:///com/endlessm/knowledge/endless_knowledge.css');
         this.parent(props);
-        this._gresource_filename = gresource_filename;
     },
 
     vfunc_startup: function() {
         this.parent();
-        let provider = new Gtk.CssProvider();
-        let css_file = Gio.File.new_for_uri('resource:///com/endlessm/knowledge/endless_knowledge.css');
-        provider.load_from_file(css_file);
-        Gtk.StyleContext.add_provider_for_screen(Gdk.Screen.get_default(),
-                                                 provider,
-                                                 Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION);
-
-        // Load and register the GResource which has content for this app
-        let resource = Gio.Resource.load(this._gresource_filename);
-        resource._register();
-
-        // Parse the appname and personality from the gresource
-        let appname = resource.enumerate_children(ENDLESS_PREFIX, Gio.FileQueryInfoFlags.NONE, null)[0];
-        let app_resource_uri = 'resource://' + ENDLESS_PREFIX + appname;
-        let app_json_file_uri = app_resource_uri + 'app.json';
-
-        let overrides_css_file = Gio.File.new_for_uri(app_resource_uri + 'overrides.css');
-        let overrides_provider = new Gtk.CssProvider();
-        overrides_provider.load_from_file(overrides_css_file);
-        // Add overrides with one step higher priority than the default
-        // knowledge app CSS
-        Gtk.StyleContext.add_provider_for_screen(Gdk.Screen.get_default(),
-            overrides_provider, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION + 1);
-
-        let presenter = new Presenter.Presenter(this, app_json_file_uri);
+        let app_json_file = this.resource_file.get_child('app.json');
+        let presenter = new Presenter.Presenter(this, app_json_file.get_uri());
     }
 });

--- a/tools/ekn-app-runner
+++ b/tools/ekn-app-runner
@@ -1,18 +1,39 @@
 #!/usr/bin/env gjs
 
 const EosKnowledge = imports.gi.EosKnowledge;
+const Gio = imports.gi.Gio;
+const System = imports.system;
 
 if (ARGV.length !== 2) {
-
     printerr("Run this script by passing it an app ID and a gresource file");
-
-} else {
-
-    let app = new EosKnowledge.KnowledgeApp({
-        application_id: ARGV[0],
-        flags: 0
-    }, ARGV[1]);
-
-    app.run([]);
+    System.exit(1);
 }
+
+let resource = Gio.Resource.load(ARGV[1]);
+resource._register();
+
+let appname = resource.enumerate_children('/com/endlessm',
+    Gio.FileQueryInfoFlags.NONE, null)[0];
+let resource_file = Gio.File.new_for_uri('resource:///com/endlessm/' + appname);
+let app_info_file = resource_file.get_child('app.json');
+let [success, contents, length, etag] = app_info_file.load_contents(null);
+let app_info = JSON.parse(contents);
+
+let AppClass;
+switch(app_info['templateType']) {
+case 'A':
+case 'B':
+    AppClass = EosKnowledge.KnowledgeApp;
+    break;
+default:
+    printerr('Unknown template type', app_info['templateType']);
+    System.exit(1);
+}
+
+let app = new AppClass({
+    application_id: ARGV[0],
+    flags: Gio.ApplicationFlags.FLAGS_NONE,
+    resource_file: resource_file,
+});
+app.run([]);
 


### PR DESCRIPTION
Move code which will be used in both the knowledge application class
and the reader application class into a parent class. Read the app.json
file in ekn-app-runner to determine which application class should be
launched.

[endlessm/eos-sdk#2129]
