### PR TITLE
Ensure callbacks are only called once in Engine.js

### DIFF
--- a/overrides/engine.js
+++ b/overrides/engine.js
@@ -101,17 +101,20 @@ const Engine = Lang.Class({
             if (typeof err !== 'undefined') {
                 // error occurred during request, so immediately fail with err
                 callback(err, undefined);
+                return;
             }
 
+            let model;
             try {
                 if (json_ld === null)
                     throw new Error("Received null object response for " + req_uri.to_string(false));
-                let model = this._model_from_json_ld(json_ld);
-                callback(undefined, model);
+                model = this._model_from_json_ld(json_ld);
             } catch (err) {
                 // Error marshalling the JSON-LD object
                 callback(err, undefined);
+                return;
             }
+            callback(undefined, model);
         }.bind(this));
     },
 
@@ -143,22 +146,25 @@ const Engine = Lang.Class({
             if (typeof err !== 'undefined') {
                 // error occurred during request, so immediately fail with err
                 callback(err, undefined);
+                return;
             }
 
+            let search_results;
             try {
                 if (json_ld === null)
                     throw new Error("Received null object response for " + req_uri.to_string(false));
-                let search_results = this._results_list_from_json_ld(json_ld);
-                let get_more_results = function (batch_size, new_callback) {
-                    query_obj.offset = json_ld.numResults + json_ld.offset;
-                    query_obj.limit = batch_size;
-                    this.get_objects_by_query(domain, query_obj, new_callback);
-                }.bind(this);
-                callback(undefined, search_results, get_more_results);
+                search_results = this._results_list_from_json_ld(json_ld);
             } catch (err) {
                 // Error marshalling (at least) one of the JSON-LD results
                 callback(err, undefined);
+                return;
             }
+            let get_more_results = function (batch_size, new_callback) {
+                query_obj.offset = json_ld.numResults + json_ld.offset;
+                query_obj.limit = batch_size;
+                this.get_objects_by_query(domain, query_obj, new_callback);
+            }.bind(this);
+            callback(undefined, search_results, get_more_results);
         }.bind(this));
     },
 
@@ -267,11 +273,12 @@ const Engine = Lang.Class({
             let json_ld_response;
             try {
                 json_ld_response = JSON.parse(message.response_body.data);
-                callback(undefined, json_ld_response);
             } catch (err) {
                 // JSON parse error
                 callback(err, undefined);
+                return;
             }
+            callback(undefined, json_ld_response);
         });
     }
 });

--- a/tests/eosknowledge/testEngine.js
+++ b/tests/eosknowledge/testEngine.js
@@ -166,6 +166,17 @@ describe('Knowledge Engine Module', function () {
                 done();
             });
         });
+
+        it('does not call its callback more than once', function (done) {
+            mock_engine_request(new Error('I am an error'), undefined);
+
+            let callback_called = 0;
+            engine.get_object_by_id('foo', 'bar', function (err, res) {
+                callback_called++;
+            });
+            setTimeout(done, 100); // pause for a moment for any more callbacks
+            expect(callback_called).toEqual(1);
+        });
     });
 
     describe('get_objects_by_query', function () {
@@ -275,6 +286,17 @@ describe('Knowledge Engine Module', function () {
                 }
                 done();
             });
+        });
+
+        it('does not call its callback more than once', function (done) {
+            mock_engine_request(new Error('I am an error'), undefined);
+
+            let callback_called = 0;
+            engine.get_objects_by_query('mock-query', {}, function (err, res) {
+                callback_called++;
+            });
+            setTimeout(done, 100); // pause for a moment for any more callbacks
+            expect(callback_called).toEqual(1);
         });
     });
 });


### PR DESCRIPTION
These changes ensure that the Engine methods return immediately after
calling their asynchronous callbacks, and that callbacks are not called
within a try block -- for example, if a successful callback was called
within a try block and threw an exception, that exception would cause
the error callback to be called as well.

This adds tests for the bug, but the tests themselves do not fail;
instead, the presence of the test causes other tests to fail without
this fix! That would indicate that callbacks are being called more than
they ought to be, and generating exceptions during other tests.

(Fernando, Patrick, Philip)

[endlessm/eos-sdk#2131]
