### PR TITLE
Fix the webview switcher test

### DIFF
--- a/tests/eosknowledge/testWebviewSwitcher.js
+++ b/tests/eosknowledge/testWebviewSwitcher.js
@@ -1,4 +1,5 @@
 const EosKnowledge = imports.gi.EosKnowledge;
+const Gio = imports.gi.Gio;
 const Gtk = imports.gi.Gtk;
 
 const MockWebview = imports.MockWebview;
@@ -118,7 +119,7 @@ describe('Webview switcher view', function () {
         it('creates a new view for the requested URI when a page is loaded', function () {
             switcher.load_uri('baked://beans');
             expect(createViewForFile.calls.count()).toEqual(1);
-            expect(createViewForFile.calls.argsFor(0)[1].get_uri()).toEqual('baked://beans');
+            expect(createViewForFile.calls.argsFor(0)[1].get_uri()).toEqual(Gio.File.new_for_uri('baked://beans').get_uri());
         });
 
         describe('asynchronously with animation', function () {


### PR DESCRIPTION
The webview switcher test was failing because GFile
was appending a trailing slash to the uri. This commit
makes sure that the constant to which we compare it
has also gone through Gio so that a slash is added.
