### PR TITLE
Grab focus of view after switching it onscreen

### DIFF
--- a/overrides/articlePage.js
+++ b/overrides/articlePage.js
@@ -237,6 +237,7 @@ const ArticlePage = new Lang.Class({
             this._switcher.add(view);
         }
         this._switcher.visible_child = view;
+        view.grab_focus();
 
         if (this._switcher.transition_running) {
             let id = this._switcher.connect('notify::transition-running', function () {


### PR DESCRIPTION
We want to make sure that the view has focus
after being switched on screen so that, e.g.
links have the right mouse over behaviour.

[endlessm/eos-sdk#1840]
