### PR TITLE
Allow copy paste from javascript in the ekn webview

### DIFF
--- a/overrides/eknWebview.js
+++ b/overrides/eknWebview.js
@@ -30,7 +30,9 @@ const EknWebview = new Lang.Class({
         this._injection_handlers = [];
         this.parent(params);
 
-        this.get_settings().enable_developer_extras = Config.inspector_enabled;
+        let settings = this.get_settings();
+        settings.enable_developer_extras = Config.inspector_enabled;
+        settings.javascript_can_access_clipboard = true;
 
         this.connect('decide-policy', this._onNavigation.bind(this));
     },


### PR DESCRIPTION
A web setting which allows you to run document.execCommand("Copy");
from javascript. We need the ability to copy to the clipboard
from javascript to enable our copy button overlay next to a
selection
[endlessm/eos-sdk#2182]
