### PR TITLE
Give windows a title

### DIFF
--- a/overrides/presenter.js
+++ b/overrides/presenter.js
@@ -46,7 +46,8 @@ const Presenter = new Lang.Class({
         this._template_type = app_content['templateType'];
         this.view = new Window.Window({
             application: app,
-            template_type: this._template_type
+            template_type: this._template_type,
+            title: app_content['appTitle'],
         });
         this._previewer = new Previewer.Previewer({
             visible: true

--- a/overrides/reader/presenter.js
+++ b/overrides/reader/presenter.js
@@ -253,6 +253,7 @@ const Presenter = new Lang.Class({
     // ID and the app's headline.
     _parse_app_info: function (info) {
         this._domain = info['appId'].split('.').pop();
+        this.view.title = info['appTitle'];
     },
 });
 

--- a/tests/test-content/app.json
+++ b/tests/test-content/app.json
@@ -1,6 +1,7 @@
 {
     "titleImageURI": "resource:///com/endlessm/thrones/agot.svg",
     "appId": "com.endlessm.thrones-en",
+    "appTitle": "Game of Thrones",
     "backgroundHomeURI": "resource:///com/endlessm/thrones/background.jpg",
     "backgroundSectionURI": "resource:///com/endlessm/thrones/background_blurred.jpg",
     "language": "en",


### PR DESCRIPTION
The window gets a title equal to the "appTitle" key in app.json --
otherwise the app ID shows up on the desktop overview.

[endlessm/eos-shell#3383]
