### PR TITLE
Always show internal children to pdfview

### DIFF
--- a/overrides/PDFView.js
+++ b/overrides/PDFView.js
@@ -39,6 +39,7 @@ const PDFView = new Lang.Class({
         });
         let view = new EvinceView.View();
         view.set_model(document_model);
+        view.show_all();
 
         let child = this.get_child();
         if (child !== null)


### PR DESCRIPTION
We make a new evince view inside of the pdf view every time,
load_uri is called. We need to make sure to show it when we do
[endlessm/eos-sdk#2246]
