### PR TITLE
Make table of contents undefined for PDF articles

### DIFF
--- a/overrides/articlePresenter.js
+++ b/overrides/articlePresenter.js
@@ -162,6 +162,9 @@ const ArticlePresenter = new GObject.Class({
             }.bind(this));
         } else if (type === 'application/pdf') {
             let view = this._get_pdfview_for_uri(uri);
+            // FIXME: Remove this line once we support table of contents
+            // widget for PDFs
+            this._article_model.table_of_contents = undefined;
             this.article_view.switch_in_content_view(view, animation_type);
             ready();
         } else {


### PR DESCRIPTION
We don't support the table of contents widget for
PDF articles so we should set the property to
undefined, which ensures that it does not get
shown. Revert this commit once we support PDF
table of contents.

[endlessm/eos-sdk#2291]
