### PR TITLE
History model properly update when actived from search provider

### DIFF
--- a/overrides/presenter.js
+++ b/overrides/presenter.js
@@ -339,6 +339,7 @@ const Presenter = new Lang.Class({
     },
 
     on_search_result_activated: function (model, query) {
+        this._add_history_object_for_article_page(model);
         this._article_presenter.load_article(model, EosKnowledge.LoadingAnimationType.NONE,
             function () {
                 this.view.search_box.text = query;


### PR DESCRIPTION
We weren't stick the article model in our history when going through
the on_search_result_activated code path, so our history was
getting messed up.

[endlessm/eos-sdk#2270]
