### PR TITLE
ArticleObjectModel provides beginPage and endPage

### DIFF
--- a/docs/reference/eosknowledge/eosknowledge-docs.xml
+++ b/docs/reference/eosknowledge/eosknowledge-docs.xml
@@ -41,6 +41,7 @@
   <index id="api-index-full">
     <title>API Index</title>
     <xi:include href="xml/api-index-full.xml"><xi:fallback /></xi:include>
+    <xi:include href="xml/api-index-0.2.xml"><xi:fallback /></xi:include>
   </index>
 
   <index id="deprecated-api-index" role="deprecated">

--- a/overrides/articleObjectModel.js
+++ b/overrides/articleObjectModel.js
@@ -67,6 +67,33 @@ const ArticleObjectModel = new Lang.Class({
             'Article Number for the Reader App',
             GObject.ParamFlags.READWRITE | GObject.ParamFlags.CONSTRUCT,
             0, GLib.MAXUINT32, 0),
+
+        /**
+         * Property: page-begin
+         * Integer that indicates the page number in which the article begins.
+         * Defaults to 1, which means that the ArticleObject begins in the first page
+         * of a PDF document.
+         *
+         * Since: 0.2
+         */
+        'page-begin': GObject.ParamSpec.uint('page-begin', 'PDF Begin Page',
+            'Page number where the article begins for this PDF article',
+            GObject.ParamFlags.READWRITE | GObject.ParamFlags.CONSTRUCT,
+            1, GLib.MAXUINT32, 1),
+
+        /**
+         * Property: page-end
+         * Integer that indicates the page number in which the article ends, if the article
+         * is actually a subset of the whole PDF document.
+         * Defaults to 0, which means that the ArticleObject ends in the last page
+         * of a PDF document.
+         *
+         * Since: 0.2
+         */
+        'page-end': GObject.ParamSpec.uint('page-end', 'PDF End Page',
+            'Page number where the article ends for this PDF article',
+            GObject.ParamFlags.READWRITE | GObject.ParamFlags.CONSTRUCT,
+            0, GLib.MAXUINT32, 0),
     },
     
     _init: function (params) {
@@ -89,6 +116,14 @@ const ArticleObjectModel = new Lang.Class({
         return this._article_number;
     },
 
+    get page_begin () {
+        return this._page_begin;
+    },
+
+    get page_end () {
+        return this._page_end;
+    },
+
     set word_count (v) {
         this._word_count = v;
     },
@@ -103,6 +138,14 @@ const ArticleObjectModel = new Lang.Class({
 
     set article_number(v) {
         this._article_number = v;
+    },
+
+    set page_begin (v) {
+        this._page_begin = v;
+    },
+
+    set page_end (v) {
+        this._page_end = v;
     },
 });
 
@@ -149,6 +192,18 @@ ArticleObjectModel._props_from_json_ld = function (json_ld_data) {
         if (json_ld_data.articleNumber < 0)
             throw new Error('Article number must be a non-negative integer.');
         props.article_number = parseInt(json_ld_data.articleNumber);
+    }
+
+    if (json_ld_data.hasOwnProperty('pageBegin')) {
+        if (json_ld_data.pageBegin < 0)
+            throw new Error('Begin Page must be a positive integer.');
+        props.page_begin = parseInt(json_ld_data.pageBegin);
+    }
+
+    if (json_ld_data.hasOwnProperty('pageEnd')) {
+        if (json_ld_data.pageEnd < 0)
+            throw new Error('End Page must be a non-negative integer.');
+        props.page_end = parseInt(json_ld_data.pageEnd);
     }
 
     return props;

--- a/tests/Makefile.am.inc
+++ b/tests/Makefile.am.inc
@@ -54,6 +54,7 @@ test_content = \
 	tests/test-content/media-search-results.jsonld \
 	tests/test-content/never-gonna-give-you-up-video.jsonld \
 	tests/test-content/overrides.css \
+	tests/test-content/pdf-article.jsonld \
 	tests/test-content/pdf-sample1.pdf \
 	tests/test-content/rick-astley-image.jsonld \
 	tests/test-content/sample.mp4 \

--- a/tests/eosknowledge/testArticleObjectModel.js
+++ b/tests/eosknowledge/testArticleObjectModel.js
@@ -68,3 +68,27 @@ describe ('Reader App Article Object', function () {
         expect(readerArticleObject.article_number).toBeGreaterThan(-1);
     });
 });
+
+describe ('PDF Article Object', function () {
+    let pdfArticleObject;
+    let mockPdfArticleData = utils.parse_object_from_path(MOCK_ARTICLES_PATH + 'pdf-article.jsonld');
+
+    beforeEach (function () {
+        jasmine.addMatchers(InstanceOfMatcher.customMatchers);
+
+        pdfArticleObject = new EosKnowledge.ArticleObjectModel.new_from_json_ld(mockPdfArticleData);
+    });
+
+    it ('should present the properties inherent to the PDF Article Object', function () {
+        expect(pdfArticleObject.page_begin).toBeDefined();
+        expect(pdfArticleObject.page_end).toBeDefined();
+    });
+
+    it ('should properly parse properties inherent to the PDF Article Object', function () {
+        expect(pdfArticleObject.page_begin).toEqual(jasmine.any(Number));
+        expect(pdfArticleObject.page_begin).toBeGreaterThan(0);
+
+        expect(pdfArticleObject.page_end).toEqual(jasmine.any(Number));
+        expect(pdfArticleObject.page_end).toBeGreaterThan(-1);
+    });
+});

--- a/tests/test-content/pdf-article.jsonld
+++ b/tests/test-content/pdf-article.jsonld
@@ -1,0 +1,42 @@
+{
+    "@context": [
+        "http://127.0.0.1:3003/v2/_context/ContentObject.jsonld",
+        {
+            "wordCount": "schema:Integer",
+            "articleBody": "schema:mainContentText",
+            "articleObject": "ekv:ArticleObject#",
+            "treeNode": "ekv:TreeNode#",
+            "hasContent": {
+                "@type": "@id",
+                "@id": "treeNode:hasContent"
+            },
+            "hasParent": "treeNode:hasParent",
+            "hasLabel": "treeNode:hasLabel",
+            "hasIndex": "treeNode:hasIndex",
+            "hasIndexLabel": "treeNode:hasIndexLabel",
+            "pageBegin": "ekv:ArticleObject#pageBegin",
+            "pageEnd": "ekv:ArticleObject#pageEnd",
+            "tableOfContents": {
+                "@container": "@list",
+                "@id": "ekv:TreeNode"
+            }
+        }
+    ],
+    "@id": "ekn:pdf_app/Sample_Document",
+    "@type": "ekv:ArticleObject",
+    "title": "Sample PDF Document",
+    "synopsis": "Sample PDF Document",
+    "pageBegin": 1,
+    "pageEnd": 5,
+    "articleBody": "This is a sample PDF article.",
+    "resources": [
+        {
+            "@id": "ekn:docs/pdf-sample1.pdf",
+            "@type": "ekv:ImageObject",
+            "contentURL": "ekn:_docs/pdf-sample1.pdf",
+            "caption": "Sample PDF",
+            "contentSize": "32KB",
+            "encodingFormat": "pdf"
+        }
+    ]
+}


### PR DESCRIPTION
For PDF article objects, we need beginPage and endPage properties for the cases in which the article object is a subset of the pages of a PDF document.

[endlessm/eos-sdk#2214]
