### PR TITLE
Flipped nav buttons for right-to-left locales

### DIFF
--- a/data/endless_knowledge.css
+++ b/data/endless_knowledge.css
@@ -597,23 +597,23 @@ scrollbars, style the GTK scrollbars to look slightly more like them */
     box-shadow: 0px 1px alpha(black, 0.8); /* FIXME: box-shadow outset doesn't currently work in GTK */
 }
 
-.nav-back-button {
+.nav-back-button, .nav-forward-button.rtl {
     border-left: 0px;
     border-radius: 0px 27px 27px 0px;
     padding: 15px 15px 15px 0px;
 }
 
-.nav-forward-button {
+.nav-forward-button, .nav-back-button.rtl {
     border-radius: 27px 0px 0px 27px;
     border-right: 0px;
     padding: 15px 0px 15px 15px;
 }
 
-.nav-back-button:hover {
+.nav-back-button:hover, .nav-forward-button.rtl:hover {
     padding-left: 15px;
 }
 
-.nav-forward-button:hover {
+.nav-forward-button:hover, .nav-back-button.rtl:hover {
     padding-right: 15px;
 }
 

--- a/eosknowledge/ekn-macros.h
+++ b/eosknowledge/ekn-macros.h
@@ -316,6 +316,12 @@ enum_type##_get_type (void) \
 #define EKN_STYLE_CLASS_NAV_FORWARD_BUTTON "nav-forward-button"
 
 /**
+ * EKN_STYLE_CLASS_RTL:
+ * A CSS class to match the Right-to-left (RTL) assets in the UI.
+ */
+#define EKN_STYLE_CLASS_RTL "rtl"
+
+/**
  * EKN_STYLE_CLASS_SECTION_PAGE_TITLE:
  *
  * A CSS class to match the title on the SectionPage of the knowledge apps.

--- a/overrides/navButtonOverlay.js
+++ b/overrides/navButtonOverlay.js
@@ -111,8 +111,8 @@ const NavButtonOverlay = new Lang.Class({
 
         this.parent(props);
 
-        this._back_button.image = this._create_new_image(this.back_image_uri, 'go-previous-symbolic');
-        this._forward_button.image = this._create_new_image(this.forward_image_uri, 'go-next-symbolic');
+        this._style_nav_button(this._back_button, this.back_image_uri, 'go-previous-symbolic', 'go-previous-rtl-symbolic');
+        this._style_nav_button(this._forward_button, this.forward_image_uri, 'go-next-symbolic', 'go-next-rtl-symbolic');
 
         Utils.set_hand_cursor_on_widget(this._back_button);
         Utils.set_hand_cursor_on_widget(this._forward_button);
@@ -141,6 +141,15 @@ const NavButtonOverlay = new Lang.Class({
 
     get forward_visible () {
         return this._forward_button.visible;
+    },
+
+    _style_nav_button: function (button, image_uri, fallback_icon_name, fallback_rtl_icon_name) {
+        if (this.get_default_direction() === Gtk.TextDirection.RTL) {
+            button.image = this._create_new_image(image_uri, fallback_rtl_icon_name);
+            button.get_style_context().add_class(EosKnowledge.STYLE_CLASS_RTL);
+        } else {
+            button.image = this._create_new_image(image_uri, fallback_icon_name);
+        }
     },
 
     _create_new_image: function (image_uri, fallback_icon_name) {


### PR DESCRIPTION
The NavButtonOverlay now flips the buttons when the locale's text direction is right-to-left.

Notice that in addition to the theme icons, the styling needs to be reversed as well.

[endlessm/eos-sdk#2287]
