### PR TITLE
Grab focus of content view after load article

### DIFF
--- a/overrides/articlePage.js
+++ b/overrides/articlePage.js
@@ -249,6 +249,12 @@ const ArticlePage = new Lang.Class({
         }
     },
 
+    content_view_grab_focus: function () {
+        if (this._switcher.visible_child) {
+            this._switcher.visible_child.grab_focus();
+        }
+    },
+
     vfunc_size_allocate: function (alloc) {
         this.parent(alloc);
 

--- a/overrides/articlePresenter.js
+++ b/overrides/articlePresenter.js
@@ -131,6 +131,7 @@ const ArticlePresenter = new GObject.Class({
 
         // If we've already loaded/are already loading the page already, just return.
         if (this._article_model && this._article_model.ekn_id === model.ekn_id) {
+            this.article_view.content_view_grab_focus();
             ready();
             return;
         }


### PR DESCRIPTION
We want to make sure the content view (e.g. webview)
has focus after showing the article page, even if no
new article is being loaded.

[endlessm/eos-sdk#2307]
