### PR TITLE
Only set search box query on user entered search

### DIFF
--- a/overrides/presenter.js
+++ b/overrides/presenter.js
@@ -266,6 +266,7 @@ const Presenter = new Lang.Class({
             return;
         }
 
+        this.view.search_box.text = query;
         this._add_history_object_for_search_page(JSON.stringify({
             q: query
         }));
@@ -284,7 +285,6 @@ const Presenter = new Lang.Class({
         // We clear the search box in the home page after each search.
         // The topbar search box should also clear once an article has been chosen.
         this.view.home_page.search_box.text = '';
-        this.view.search_box.text = query.q;
 
         this._engine.get_objects_by_query(this._domain, query, this._load_section_page.bind(this));
     },

--- a/overrides/window.js
+++ b/overrides/window.js
@@ -472,7 +472,6 @@ const Window = new Lang.Class({
      * This method causes the window to animate to the article page.
      */
     show_article_page: function () {
-        this._search_box.text = '';
         this.page_manager.transition_type = Gtk.StackTransitionType.SLIDE_LEFT;
         this._section_article_page.show_article = true;
         this.page_manager.visible_child = this._lightbox;


### PR DESCRIPTION
Previously we were clearing the top-bar search box
when the user selected an article and then
programmatically repopulating it when the user
went back the search page. But this makes search
entry think it should fire off another autocomplete
request. So instead we leave the search bar to have
what the user put in.

[endlessm/eos-sdk#2306]
