### PR TITLE
Search box only suggests prefixed titles.

### DIFF
--- a/overrides/contentObjectModel.js
+++ b/overrides/contentObjectModel.js
@@ -34,6 +34,12 @@ const ContentObjectModel = new Lang.Class({
         'title': GObject.ParamSpec.string('title', 'Title', 'The title of a document or media object',
             GObject.ParamFlags.READWRITE | GObject.ParamFlags.CONSTRUCT, ''),
         /**
+         * Property: original-title
+         * A string with the original title of the content object. Defaults to an empty string.
+         */
+        'original-title': GObject.ParamSpec.string('original-title', 'Original Title', 'The original title (wikipedia title) of a document or media object',
+            GObject.ParamFlags.READWRITE | GObject.ParamFlags.CONSTRUCT, ''),
+        /**
          * Property: thumbnail
          * A ImageObjectModel representing the thumbnail image. Must be set to type GObject, since
          * ImageObjectModel subclasses this class and so we cannot reference it here.
@@ -350,6 +356,9 @@ ContentObjectModel._props_from_json_ld = function (json_ld_data) {
 
     if(json_ld_data.hasOwnProperty('title'))
         props.title = json_ld_data.title;
+
+    if(json_ld_data.hasOwnProperty('originalTitle'))
+        props.original_title = json_ld_data.originalTitle;
 
     if(json_ld_data.hasOwnProperty('language'))
         props.language = json_ld_data.language;

--- a/overrides/presenter.js
+++ b/overrides/presenter.js
@@ -294,6 +294,29 @@ const Presenter = new Lang.Class({
         this.view.lightbox.reveal_overlays = false;
     },
 
+    /*
+     * Returns either the title or origin_title of the obj, depending on which one
+     * is closer to having query as a prefix. Doesn't use a simple indexOf, because
+     * of the fact that query might not be accented, even when titles are.
+     */
+    _get_prefixed_title: function (obj, query) {
+        let title = obj.title.toLowerCase();
+        let original_title = obj.original_title.toLowerCase();
+        query = query.toLowerCase();
+
+        for (let i = 0; i < query.length; i++) {
+            if (title[i] !== original_title[i]) {
+                if (title[i] === query[i]) {
+                    return obj.title;
+                } else if (original_title[i] === query[i]) {
+                    return obj.original_title;
+                }
+            }
+        }
+
+        return obj.title
+    },
+
     _on_search_text_changed: function (view, entry) {
         let query = this._sanitize_query(entry.text);
         this._latest_search_text = query;
@@ -310,10 +333,10 @@ const Presenter = new Lang.Class({
             } else {
                 entry.set_menu_items(results.map(function (obj) {
                     return {
-                        title: obj.title,
+                        title: this._get_prefixed_title(obj, query),
                         id: obj.ekn_id
                     };
-                }));
+                }.bind(this)));
                 this._autocomplete_results = results;
             }
         }.bind(this));


### PR DESCRIPTION
Since we index articles by both their original (wikipedia) title and
the title assigned by content, when users received autocomplete
suggestions in the search box, they always showed the article's title,
even when it did not contain their search as a substring.

Now it will show either the original or assigned title, depending on
which one is prefixed by the user's query.

[endlessm/eos-sdk#2397]
