### PR TITLE
Remove offscreen window.

### DIFF
--- a/overrides/articlePresenter.js
+++ b/overrides/articlePresenter.js
@@ -103,7 +103,6 @@ const ArticlePresenter = new GObject.Class({
         this._article_model = null;
         this._webview = null;
         this._webview_load_id = 0;
-        this._offscreen_window = new Gtk.OffscreenWindow();
 
         this._connect_toc_widget();
         this.article_view.connect('new-view-transitioned', this._update_title_and_toc.bind(this));
@@ -328,8 +327,6 @@ const ArticlePresenter = new GObject.Class({
             }
         }.bind(this));
 
-        this._offscreen_window.add(webview);
-        this._offscreen_window.show_all();
         webview.load_uri(uri);
         return webview;
     },


### PR DESCRIPTION
Previously we thought that webkit webviews
needed to be loaded in an offscreen window.
This is not true, so we should remove the
offscreen window.

[endlessm/eos-sdk#2409]
