### PR TITLE
Refactor for dependency injection in presenter.js

### DIFF
--- a/overrides/knowledgeApp.js
+++ b/overrides/knowledgeApp.js
@@ -1,14 +1,9 @@
 const Gio = imports.gi.Gio;
 const Gdk = imports.gi.Gdk;
 const Lang = imports.lang;
-const System = imports.system;
 
-const ArticlePresenter = imports.articlePresenter;
 const EknApplication = imports.application;
-const Engine = imports.engine;
 const Presenter = imports.presenter;
-const Window = imports.window;
-const Utils = imports.utils;
 
 const KnowledgeApp = new Lang.Class ({
     Name: 'KnowledgeApp',
@@ -43,36 +38,10 @@ const KnowledgeApp = new Lang.Class ({
         this.parent();
         if (!this._presenter) {
             let app_json_file = this.resource_file.get_child('app.json');
-            let app_content = Utils.parse_object_from_file(app_json_file);
-            let domain = app_content['appId'].split('.').pop();
-            let template_type = app_content['templateType'];
-
-            let view = new Window.Window({
-                application: this,
-                template_type: template_type,
-                title: app_content['appTitle'],
-            });
-
-            view.home_page.title_image_uri = app_content['titleImageURI'];
-            view.background_image_uri = app_content['backgroundHomeURI'];
-            view.blur_background_image_uri = app_content['backgroundSectionURI'];
-
-            let engine = new Engine.Engine();
-
-            let article_presenter = new ArticlePresenter.ArticlePresenter({
-                article_view: view.article_page,
-                engine: engine,
-                template_type: template_type,
-            });
-
             this._presenter = new Presenter.Presenter({
-                article_presenter: article_presenter,
-                domain: domain,
-                engine: engine,
-                template_type: template_type,
-                view: view,
+                application: this,
+                app_file: app_json_file,
             });
-            this._presenter.set_sections(app_content['sections']);
         }
 
         this._presenter.view.show_all();

--- a/overrides/reader/application.js
+++ b/overrides/reader/application.js
@@ -2,9 +2,7 @@ const Gio = imports.gi.Gio;
 const Lang = imports.lang;
 
 const EknApplication = imports.application;
-const Engine = imports.engine;
 const Presenter = imports.reader.presenter;
-const Window = imports.reader.window;
 
 /**
  * Class: Reader.Application
@@ -31,13 +29,9 @@ const Application = new Lang.Class({
         this.parent();
 
         let app_json_file = this.resource_file.get_child('app.json');
-        let view = new Window.Window({
-            application: this,
-        });
         let presenter = new Presenter.Presenter({
+            application: this,
             app_file: app_json_file,
-            engine: new Engine.Engine(),
-            view: view,
         });
     },
 });

--- a/overrides/reader/presenter.js
+++ b/overrides/reader/presenter.js
@@ -10,6 +10,9 @@ const WebKit2 = imports.gi.WebKit2;
 const ArticlePage = imports.reader.articlePage;
 const Config = imports.config;
 const EknWebview = imports.eknWebview;
+const Engine = imports.engine;
+const Utils = imports.utils;
+const Window = imports.reader.window;
 
 String.prototype.format = Format.format;
 let _ = Gettext.dgettext.bind(null, Config.GETTEXT_PACKAGE);
@@ -82,8 +85,18 @@ const Presenter = new Lang.Class({
     _init: function (props) {
         this.parent(props);
 
-        let [success, contents] = this.app_file.load_contents(null);
-        this._parse_app_info(JSON.parse(contents));
+        let app_json = Utils.parse_object_from_file(this.app_file);
+        this._parse_app_info(app_json);
+
+        if (this.view === null) {
+            let view = new Window.Window({
+                application: this.application,
+            });
+        }
+
+        if (this.engine === null) {
+            let engine = new Engine.Engine();
+        }
 
         this._article_models = [];
         // Load all articles in this issue

--- a/tests/eosknowledge/testPresenter.js
+++ b/tests/eosknowledge/testPresenter.js
@@ -1,17 +1,11 @@
 const EosKnowledge = imports.gi.EosKnowledge;
 const Endless = imports.gi.Endless;
 const Gio = imports.gi.Gio;
-const GLib = imports.gi.GLib;
 const GObject = imports.gi.GObject;
-const Gtk = imports.gi.Gtk;
 const Lang = imports.lang;
 
-const TESTDIR = Endless.getCurrentFileDir() + '/..';
-// Working directory should be top of the builddir
-const TESTBUILDDIR = GLib.get_current_dir() + '/tests';
-
 function parse_object_from_path(path) {
-    let file = Gio.file_new_for_uri(path);
+    let file = Gio.file_new_for_path(path);
     let [success, data] = file.load_contents(null);
     return JSON.parse(data);
 }
@@ -24,15 +18,15 @@ const MockView = new Lang.Class({
         this.parent();
         let connectable_object = {
             connect: function () {},
-        }
+        };
         this.section_page = connectable_object;
         this.home_page = connectable_object;
         this.categories_page = connectable_object;
         this.article_page = connectable_object;
         this.lightbox = {};
         this.history_buttons = {
-            forward_button: new Gtk.Button(),
-            back_button: new Gtk.Button(),
+            forward_button: new GObject.Object(),
+            back_button: new GObject.Object(),
         };
     },
 
@@ -72,31 +66,29 @@ describe('Presenter', function () {
     let view;
     let engine;
     let article_presenter;
-    let test_app_filename = 'file://' + TESTDIR + '/test-content/app.json';
+    let test_app_filename = Endless.getCurrentFileDir() + '/../test-content/app.json';
 
     beforeEach(function () {
 
         data = parse_object_from_path(test_app_filename);
-
-        // Load and register the GResource which has content for this app
-        let resource = Gio.Resource.load(TESTBUILDDIR + '/test-content/test-content.gresource');
-        resource._register();
 
         view = new MockView();
         engine = new MockEngine();
         article_presenter = new MockArticlePresenter();
         spyOn(engine, 'ping');
         presenter = new EosKnowledge.Presenter({
+            app_file: Gio.File.new_for_path(test_app_filename),
             article_presenter: article_presenter,
-            domain: 'mock_domain',
-            template_type: 'A',
             engine: engine,
             view: view,
         });
-        presenter.set_sections(data['sections']);
     });
 
     it('can be constructed', function () {});
+
+    it('can set title image on view from json', function () {
+        expect(presenter.view.home_page.title_image_uri).toBe(data['titleImageURI']);
+    });
 
     it('pings the knowledge engine on construction', function () {
          expect(engine.ping).toHaveBeenCalled();


### PR DESCRIPTION
This should be squashed into the previous commit, allows for dependency
injection presenter without pushing more logic into the application
code.

This will allow us to keep making our application code load as little
as possible and have our search provider activation be fast
[endlessm/eos-sdk#1567-changes]
