### PR TITLE
Card images maintain aspect ratio when resized

### DIFF
--- a/data/endless_knowledge.css
+++ b/data/endless_knowledge.css
@@ -244,6 +244,10 @@ EknWindow.show-no-search-results-page {
     box-shadow: 0px 0px 10px 0px alpha(black, 0.81);
 }
 
+.card-b .thumbnail {
+    background-size: cover;
+}
+
 .card-b .card-title {
     color: @template-b-text-color;
     font-size: 1.8em;


### PR DESCRIPTION
Template B card backgrounds were being stretched out when the window was resized. Now, they are re-scaled while keeping the image proportion.

[endlessm/eos-sdk#2334]
