### PR TITLE
Done page background does not tile

### DIFF
--- a/data/endless_reader.css
+++ b/data/endless_reader.css
@@ -21,6 +21,11 @@ EosWindow {
     color: alpha(black, 0.1);
 }
 
+.done-page {
+    background-size: cover;
+    background-position: center;
+}
+
 .done-page .headline {
     font-family: Roboto;
     font-weight: bold;


### PR DESCRIPTION
We set the background size to cover so it will strech to cover the
page while preserving its background ratio, and background position
to center
[endlessm/eos-sdk#2529]
