### PR TITLE
Removed debug_back_button binding to bookmark_issue.

### DIFF
--- a/overrides/reader/presenter.js
+++ b/overrides/reader/presenter.js
@@ -150,9 +150,6 @@ const Presenter = new Lang.Class({
         //Bind properties
         this.view.bind_property('current-page', this.view.nav_buttons,
             'back-visible', GObject.BindingFlags.DEFAULT | GObject.BindingFlags.SYNC_CREATE);
-        this.settings.bind_property('bookmark-issue',
-            this.view.issue_nav_buttons.back_button, 'sensitive',
-            GObject.BindingFlags.DEFAULT | GObject.BindingFlags.SYNC_CREATE);
     },
 
     // Right now these functions are just stubs which we will need to flesh out
@@ -176,6 +173,7 @@ const Presenter = new Lang.Class({
     },
 
     _load_all_content: function () {
+        this.view.issue_nav_buttons.back_button.sensitive = (this.settings.bookmark_issue !== 0);
         this.engine.get_objects_by_query(this._domain, {
             tag: 'issueNumber' + this.settings.bookmark_issue,
             limit: RESULTS_SIZE,

--- a/tests/eosknowledge/reader/testPresenter.js
+++ b/tests/eosknowledge/reader/testPresenter.js
@@ -16,15 +16,36 @@ const MockUserSettingsModel = new Lang.Class({
     Extends: GObject.Object,
     Properties: {
         'bookmark-issue': GObject.ParamSpec.uint('bookmark-issue', '', '',
-            GObject.ParamFlags.READWRITE | GObject.ParamFlags.CONSTRUCT,
+            GObject.ParamFlags.READWRITE,
             0, GLib.MAXINT64, 0),
         'bookmark-page': GObject.ParamSpec.uint('bookmark-page', '', '',
-            GObject.ParamFlags.READWRITE | GObject.ParamFlags.CONSTRUCT,
+            GObject.ParamFlags.READWRITE,
             0, GLib.MAXINT64, 0),
         'update-timestamp': GObject.ParamSpec.uint('update-timestamp', 'Last Update Time',
             'Last time content was updated',
             GObject.ParamFlags.READWRITE,
             0, GLib.MAXINT64, 0),
+    },
+
+    _init: function (props) {
+        props = props || {};
+        this._bookmark_issue = 0;
+        this._bookmark_page = 0;
+        this._update_timestamp = 0;
+        this.parent(props);
+    },
+
+    get bookmark_issue() {
+        if (this._bookmark_issue)
+            return this._bookmark_issue;
+        return 0;
+    },
+
+    set bookmark_issue(v) {
+        if (this._bookmark_issue === v)
+            return;
+        this._bookmark_issue = v;
+        this.notify('bookmark-issue');
     },
 });
 
@@ -287,7 +308,6 @@ describe('Reader presenter', function () {
         it('disables the debug back button when returning to the first issue', function () {
             settings.bookmark_issue = 5;
             settings.bookmark_issue = 0;
-            settings.notify('bookmark-issue');
             expect(view.issue_nav_buttons.back_button.sensitive).toBe(false);
         });
 


### PR DESCRIPTION
The binding wasn't correctly handling rapid updates to
bookmark_issue.

Now, whenever bookmark_issue gets changed, the value of
the debug back button's sensitivity will update.

[endlessm/eos-sdk#2438]
