### PR TITLE
searchProvider: escape description before sending it over

### DIFF
--- a/js/search/searchProvider.js
+++ b/js/search/searchProvider.js
@@ -211,7 +211,8 @@ const SearchProvider = Lang.Class({
                 };
 
                 if (typeof obj.synopsis !== 'undefined') {
-                    result.description = new GLib.Variant('s', obj.synopsis);
+                    let displayDesc = GLib.markup_escape_text(obj.synopsis, -1);
+                    result.description = new GLib.Variant('s', displayDesc);
                 }
                 result_gvariants.push(result);
             }


### PR DESCRIPTION
The description expects markup, so make sure to escape the synopsis
string before passing it over.

[endlessm/eos-shell#4387]
