### PR TITLE
Port xapian query construction to knowledge-lib

### DIFF
--- a/js/Makefile.am.inc
+++ b/js/Makefile.am.inc
@@ -11,6 +11,7 @@ search_files = \
 	js/search/mediaObjectModel.js \
 	js/search/searchProvider.js \
 	js/search/treeNode.js \
+	js/search/xapianQuery.js \
 	$(NULL)
 searchdir = $(jsdir)/search
 dist_search_DATA = $(search_files)

--- a/js/search/xapianQuery.js
+++ b/js/search/xapianQuery.js
@@ -1,0 +1,133 @@
+// Xapian prefixes used to query data
+const XAPIAN_PREFIX_EXACT_TITLE = 'exact_title:';
+const XAPIAN_PREFIX_ID = 'id:';
+const XAPIAN_PREFIX_TAG = 'tag:';
+const XAPIAN_PREFIX_TITLE = 'title:';
+
+// Xapian QueryParser operators
+// docs: http://xapian.org/docs/queryparser.html
+const XAPIAN_OP_AND = " AND ";
+const XAPIAN_OP_OR = " OR ";
+const XAPIAN_OP_NEAR = " NEAR ";
+const XAPIAN_OP_NOT = "NOT ";
+
+// The value numbers where certain info is stored in our Xapian documents
+const XAPIAN_SOURCE_URL_VALUE_NO = 0;
+const XAPIAN_RANK_VALUE_NO = 1;
+const XAPIAN_ARTICLE_NUMBER_VALUE_NO = 2;
+
+function parenthesize (clause) {
+    return '(' + clause + ')';
+}
+
+function capitalize (word) {
+    return word.charAt(0).toUpperCase() + word.slice(1).toLowerCase();
+}
+
+function emptyQueries (query) {
+    return query !== '()';
+}
+
+function quote (clause) {
+    return '"' + clause + '"';
+}
+
+// matches any contiguous whitespace
+const WHITESPACE_REGEX = /\s+/;
+
+// matches any delimiter which indicates a separate Xapian term
+const TERM_DELIMITER_REGEX = /[\s\-]+/;
+
+function sanitize (query) {
+    // Remove excess white space
+    query = query.split(WHITESPACE_REGEX).join(' ').trim();
+
+    // Escape xapian special characters: http://xapian.org/docs/queryparser.html
+    let xapianOperators = ['AND', 'OR', 'NOT', 'XOR', 'NEAR', 'ADJ'];
+    let xapianSyntaxChars = ['(', ')', '+', '-', '\'', '"'];
+
+    // RegExp to match xapian operators or special characters
+    let regexString = xapianOperators.concat(xapianSyntaxChars.map(function (chr) {
+        return '\\' + chr;
+    })).join('|');
+    let regex = new RegExp(regexString, 'g');
+
+    // If we find a xapian operator term, lower case it.
+    // If we find a xapian syntax character, remove it.
+    // Anything else can stay as is.
+    return query.replace(regex, function (match) {
+        if (xapianOperators.indexOf(match) !== -1) {
+            return match.toLowerCase();
+        } else if (xapianSyntaxChars.indexOf(match) !== -1) {
+            return '';
+        } else {
+            return match; // Fallback case
+        }
+    }).trim();
+}
+
+function xapian_join_clauses (clauses) {
+    return clauses.map(parenthesize).join(XAPIAN_OP_AND);
+}
+
+function xapian_query_clause (q) {
+    let sanitized_query = sanitize(q);
+    let separateTerms = sanitized_query.split(TERM_DELIMITER_REGEX);
+
+    let exactTitleClause = XAPIAN_PREFIX_EXACT_TITLE + separateTerms.map(capitalize).join('_');
+    let bodyClause = sanitized_query;
+    let genericTitleClause = sanitized_query.split(' ').filter(function (term) {
+        return term.length > 1;
+    }).map(function (term) {
+        return XAPIAN_PREFIX_TITLE + term;
+    }).join(XAPIAN_OP_OR);
+
+    return [genericTitleClause, bodyClause, exactTitleClause].map(parenthesize)
+        .filter(emptyQueries)
+        .join(XAPIAN_OP_OR);
+}
+
+function xapian_prefix_clause (prefix) {
+    let sanitized_query = sanitize(prefix);
+    let separateTerms = sanitized_query.split(TERM_DELIMITER_REGEX);
+
+    let prefixTerm = separateTerms.join('_');
+
+    // Don't do a wildcard search if there is only one letter. It will cripple xapian
+    return prefixTerm.length > 1 ? XAPIAN_PREFIX_EXACT_TITLE + prefixTerm + '*' : XAPIAN_PREFIX_EXACT_TITLE + prefixTerm;
+}
+
+
+// Tag lists should be joined as a series of
+// individual tag queries joined by ORs, so an article that has
+// any of the tags will match
+// e.g. [foo,bar,baz] => "K:foo OR K:bar OR K:baz"
+function xapian_tag_clause (tags) {
+    let prefixedTagsArr = tags
+        .map(quote)
+        .map(function (tag) { return XAPIAN_PREFIX_TAG + tag; });
+
+    return prefixedTagsArr.join(XAPIAN_OP_OR);
+}
+
+// The argument id here is a full uri, e.g. ekn://animals/s0m3ha5h
+// We want just the hash portion.
+function xapian_id_clause (id) {
+    // Verify that ekn id is of the right form
+    let ekn_matcher = /^ekn:\/\/(api\/)?[A-Z]+-?[A-Z]*\/[A-Z0-9]+$/i
+    if (!ekn_matcher.test(id))
+        throw new Error("Received invalid ekn uri " + id)
+
+    return XAPIAN_PREFIX_ID + id.split('/').slice(-1)[0];
+}
+
+function xapian_string_to_value_no(xapian_string) {
+    switch (xapian_string) {
+        case 'rank':
+            return XAPIAN_RANK_VALUE_NO;
+        case 'articleNumber':
+            return XAPIAN_ARTICLE_NUMBER_VALUE_NO;
+        default:
+            return undefined;
+    }
+}

--- a/tests/Makefile.am.inc
+++ b/tests/Makefile.am.inc
@@ -44,6 +44,7 @@ javascript_tests = \
 	tests/eosknowledgesearch/testEngine.js \
 	tests/eosknowledgesearch/testMediaObjectModels.js \
 	tests/eosknowledgesearch/testTreeNode.js \
+	tests/eosknowledgesearch/testXapianQuery.js \
 	$(NULL)
 test_content = \
 	tests/test-content/agot.svg \

--- a/tests/eosknowledgesearch/testEngine.js
+++ b/tests/eosknowledgesearch/testEngine.js
@@ -99,7 +99,15 @@ describe('Knowledge Engine Module', function () {
                 q: undefined,
                 tag: 'lannister',
             }
-            expect(function(){ engine.get_xapian_uri(bad_query_obj)}).toThrow(new Error('Parameter value is undefined!'));
+            expect(function(){ engine.get_xapian_uri(bad_query_obj)}).toThrow(new Error('Parameter value is undefined: q'));
+        });
+
+        it('throws error if it receives unexpected query value', function () {
+            let bad_query_obj = {
+                something_unknown: 'blah',
+            };
+
+            expect(function(){ engine.get_xapian_uri(bad_query_obj)}).toThrow(new Error('Unexpected property value something_unknown'));
         });
 
         it('sets collapse to 0', function () {
@@ -110,6 +118,41 @@ describe('Knowledge Engine Module', function () {
             let mock_uri = engine.get_xapian_uri(query_obj);
             let mock_query_obj = mock_uri.get_query();
             expect(get_query_vals_for_key(mock_query_obj, 'collapse')).toEqual('0');
+        });
+
+        it('sets order field', function () {
+            let query_obj = {
+                q: 'tyrion',
+                order: 'asc',
+            };
+
+            let mock_uri = engine.get_xapian_uri(query_obj);
+            let mock_query_obj = mock_uri.get_query();
+            expect(get_query_vals_for_key(mock_query_obj, 'order')).toEqual('asc');
+        });
+
+        it('sets correct default values for cutoff, limit, offset, and order', function () {
+            let query_obj = {
+                q: 'tyrion',
+            };
+
+            let mock_uri = engine.get_xapian_uri(query_obj);
+            let mock_query_obj = mock_uri.get_query();
+            expect(get_query_vals_for_key(mock_query_obj, 'cutoff')).toEqual('20');
+            expect(get_query_vals_for_key(mock_query_obj, 'limit')).toEqual('10');
+            expect(get_query_vals_for_key(mock_query_obj, 'offset')).toEqual('0');
+            expect(get_query_vals_for_key(mock_query_obj, 'order')).toEqual('asc');
+        });
+
+        it('will not override a value of zero', function () {
+            let query_obj = {
+                q: 'tyrion',
+                limit: 0,
+            };
+
+            let mock_uri = engine.get_xapian_uri(query_obj);
+            let mock_query_obj = mock_uri.get_query();
+            expect(get_query_vals_for_key(mock_query_obj, 'limit')).toEqual('0');
         });
 
         it('sets path correctly', function () {
@@ -124,26 +167,34 @@ describe('Knowledge Engine Module', function () {
             expect(get_query_vals_for_key(query_obj, 'path')).toEqual('/foo/db');
         });
 
-        // FIXME: this testing coverage should get a lot more extensive when we
-        // correctly construct xapian queries.
-        it('makes correct query URIs', function () {
+        it('supports combinations of queries', function () {
             let query_obj = {
-                q: 'tyrion',
+                q: 'tyrion wins',
+                tag: ['lannister', 'bro'],
+                prefix: 'gam',
                 offset: 5,
                 limit: 2,
             };
-            let query_parms = {
-                q: '(tyrion)',
-                offset: '5',
-                limit: '2',
+            let mock_uri = engine.get_xapian_uri(query_obj);
+            let mock_query_obj = mock_uri.get_query();
+            let serialized_query = get_query_vals_for_key(mock_query_obj, 'q');
+            let parts = serialized_query.split(' AND ');
+            let expected_parts = ['((title:tyrion OR title:wins) OR (tyrion wins) OR (exact_title:Tyrion_Wins))', '(tag:"lannister" OR tag:"bro")', '(exact_title:gam*)'];
+            let isMatch = expected_parts.sort().join('') === parts.sort().join('');
+            expect(isMatch).toBe(true);
+        });
+
+        it('supports single ID queries', function () {
+            let query_obj = {
+                id: 'ekn://domain/someId',
+            };
+            let query_params = {
+                q: '(id:some_id)',
             };
 
             let mock_uri = engine.get_xapian_uri(query_obj);
             let mock_query_obj = mock_uri.get_query();
-            for (let key in query_obj) {
-                expect(get_query_vals_for_key(mock_query_obj, key))
-                    .toEqual(query_parms[key]);
-            }
+            expect(get_query_vals_for_key(mock_query_obj, 'q'));
         });
     });
 

--- a/tests/eosknowledgesearch/testXapianQuery.js
+++ b/tests/eosknowledgesearch/testXapianQuery.js
@@ -1,0 +1,96 @@
+const XapianQuery = imports.xapianQuery;
+
+
+describe('Xapian Query Module', function () {
+    let xq;
+
+    beforeEach(function () {
+        xq = XapianQuery;
+    });
+
+    describe('xapian query', function () {
+        it('should ignore excess whitespace (except for tags)', function () {
+            let q = 'whoa      man';
+            let q_result = xq.xapian_query_clause(q);
+            expect(q_result).toBe('(title:whoa OR title:man) OR (whoa man) OR (exact_title:Whoa_Man)');
+
+            let prefix_result = xq.xapian_prefix_clause(q);
+            expect(prefix_result).toBe('exact_title:whoa_man*');
+        });
+
+        it('should lowercase xapian operator terms in general query', function () {
+            let q = 'PENN AND tELLER';
+            let q_result = xq.xapian_query_clause(q);
+            expect(q_result).toBe('(title:PENN OR title:and OR title:tELLER) OR (PENN and tELLER) OR (exact_title:Penn_And_Teller)');
+
+            let prefix_result = xq.xapian_prefix_clause(q);
+            expect(prefix_result).toBe('exact_title:PENN_and_tELLER*');
+        });
+
+        it('should remove parentheses in user terms', function () {
+            let q = 'foo (bar) baz ((';
+            let q_result = xq.xapian_query_clause(q);
+            expect(q_result).toBe('(title:foo OR title:bar OR title:baz) OR (foo bar baz) OR (exact_title:Foo_Bar_Baz)');
+
+            let prefix_result = xq.xapian_prefix_clause(q);
+            expect(prefix_result).toBe('exact_title:foo_bar_baz*');
+        });
+
+        it('should support requests with tags', function () {
+            let tags = ['cats', 'dogs', 'turtles'];
+            let result = xq.xapian_tag_clause(tags);
+            expect(result).toBe('tag:"cats" OR tag:"dogs" OR tag:"turtles"');
+        });
+
+        it('should support requests with querystring', function () {
+            let q = 'little search';
+            let result = xq.xapian_query_clause(q);
+            expect(result).toBe('(title:little OR title:search) OR (little search) OR (exact_title:Little_Search)');
+        });
+
+        it('should support requests with prefix', function () {
+            let q = 'Bar';
+            let result = xq.xapian_prefix_clause(q);
+            expect(result).toBe('exact_title:Bar*');
+        });
+
+        it('should surround multiword tags in quotes', function () {
+            let tags = ['cat zombies'];
+            let result = xq.xapian_tag_clause(tags);
+            expect(result).toBe('tag:"cat zombies"');
+        });
+
+        it('should not add empty queries', function () {
+            let q = 'a';
+            let result = xq.xapian_query_clause(q);
+            expect(result).toBe('(a) OR (exact_title:A)');
+        });
+
+        it('should not submit a prefix query for one letter queries', function () {
+            let q = 'a';
+            let result = xq.xapian_prefix_clause(q);
+            expect(result).toBe('exact_title:a');
+        });
+
+        it('should map sortBy strings to xapian values', function () {
+            let result = xq.xapian_string_to_value_no('rank');
+            expect(result).toBe(1);
+            let undefined_result = xq.xapian_string_to_value_no('unsupportedXapianValue');
+            expect(undefined_result).toBe(undefined);
+        });
+
+        it('should support id queries', function () {
+            let result = xq.xapian_id_clause('ekn://domain/someId');
+            expect(result).toBe('id:someId');
+        });
+
+        it('should throw error if receives invalid ekn id', function () {
+            let bad_ids = ['ekn://bad1/somehash', 'noEknScheme', 'ekn://noId', 'ekn://domain/badha$h',
+            'ekn://api/too/many/parts', 'ekn://underscore_/id'];
+
+            bad_ids.forEach(function (bad_id) {
+                expect(function(){ xq.xapian_id_clause(bad_id)}).toThrow(new Error('Received invalid ekn uri ' + bad_id));
+            });
+        });
+    });
+});


### PR DESCRIPTION
Now that we handle all xapian communication
right here in the knowledge lib, we need to add
support for all the fancy xapian query construction
we had in knowledge engine. This commit adds
that. Supports general query, prefix, and tag
search.

[endlessm/eos-sdk#2636]
