### PR TITLE
Send lang param during xapian queries

### DIFF
--- a/js/Makefile.am.inc
+++ b/js/Makefile.am.inc
@@ -12,6 +12,7 @@ search_files = \
 	js/search/engine.js \
 	js/search/mediaObjectModel.js \
 	js/search/searchProvider.js \
+	js/search/searchUtils.js \
 	js/search/treeNode.js \
 	js/search/xapianQuery.js \
 	$(NULL)

--- a/js/search/searchUtils.js
+++ b/js/search/searchUtils.js
@@ -1,0 +1,21 @@
+const GLib = imports.gi.GLib;
+
+/* Returns the current locale's language code, or null if one cannot be found */
+function get_current_language () {
+    var locales = GLib.get_language_names();
+
+    // we don't care about the last entry of the locales list, since it's
+    // always 'C'. If we get there without finding a suitable language, return
+    // null
+    while (locales.length > 1) {
+        var next_locale = locales.shift();
+
+        // if the locale includes a country code or codeset (e.g. "en.utf8"),
+        // skip it
+        if (next_locale.indexOf('_') === -1 && next_locale.indexOf('.') === -1) {
+            return next_locale;
+        }
+    }
+
+    return null;
+}

--- a/tests/eosknowledge/testArticlePresenter.js
+++ b/tests/eosknowledge/testArticlePresenter.js
@@ -16,6 +16,7 @@ const MockEngine = new Lang.Class({
         this.parent();
         this.host = 'localhost';
         this.port = 3003;
+        this.language = '';
     },
 
     get_object_by_id: function () {},

--- a/tests/eosknowledge/testPresenter.js
+++ b/tests/eosknowledge/testPresenter.js
@@ -37,6 +37,7 @@ const MockEngine = new Lang.Class({
         this.parent();
         this.host = 'localhost';
         this.port = 3003;
+        this.language = '';
     },
 
     get_object_by_id: function () {},

--- a/tests/eosknowledgesearch/testEngine.js
+++ b/tests/eosknowledgesearch/testEngine.js
@@ -51,7 +51,7 @@ describe('Knowledge Engine Module', function () {
 
     beforeEach(function () {
         jasmine.addMatchers(InstanceOfMatcher.customMatchers);
-        engine = new EosKnowledgeSearch.Engine.get_default();
+        engine = new EosKnowledgeSearch.Engine();
         engine.content_path = '/test';
     });
 
@@ -129,6 +129,21 @@ describe('Knowledge Engine Module', function () {
             let mock_uri = engine.get_xapian_uri(query_obj);
             let mock_query_obj = mock_uri.get_query();
             expect(get_query_vals_for_key(mock_query_obj, 'order')).toEqual('asc');
+        });
+
+        it('should use the lang param iff a language is set', function () {
+            let query_obj = {
+                q: 'tyrion',
+            };
+
+            let mock_uri = engine.get_xapian_uri(query_obj);
+            let mock_query_obj = mock_uri.get_query();
+            expect(get_query_vals_for_key(mock_query_obj, 'lang')).toEqual([]);
+
+            engine.language = 'en';
+            let mock_uri = engine.get_xapian_uri(query_obj);
+            let mock_query_obj = mock_uri.get_query();
+            expect(get_query_vals_for_key(mock_query_obj, 'lang')).toEqual('en');
         });
 
         it('sets correct default values for cutoff, limit, offset, and order', function () {


### PR DESCRIPTION
To take advantage of term stemming and spelling questions, we need to inform
the xapian-bridge of the language to be used. This commit adds a new language
param to the Engine class, and causes the singleton engine to default to the
current system locale.

[endlessm/eos-sdk#2660]
