### PR TITLE
contentObjectModel: only reference ekn ids, not other models

### DIFF
--- a/overrides/articlePresenter.js
+++ b/overrides/articlePresenter.js
@@ -21,8 +21,7 @@ GObject.ParamFlags.READWRITE = GObject.ParamFlags.READABLE | GObject.ParamFlags.
  * and an <ArticlePage>. It connects to signals on the view's widgets and handles
  * those events accordingly.
  *
- * Its properties are an <article-model>, <article-view> and a <engine>. The engine is for
- * communication with the Knowledge Engine server.
+ * Its properties are an <article-model>, <article-view>.
  */
 const ArticlePresenter = new GObject.Class({
     Name: 'ArticlePresenter',
@@ -50,15 +49,6 @@ const ArticlePresenter = new GObject.Class({
             GObject.Object.$gtype),
 
         /**
-         * Property: engine
-         *
-         * The <Engine> widget created by this widget. Construct-only.
-         */
-        'engine': GObject.ParamSpec.object('engine', 'Engine module',
-            'The engine module to connect to EKN',
-            GObject.ParamFlags.READWRITE | GObject.ParamFlags.CONSTRUCT_ONLY,
-            GObject.Object.$gtype),
-        /**
          * Property: template-type
          *
          * A string for the template type the window should render as
@@ -70,28 +60,15 @@ const ArticlePresenter = new GObject.Class({
     },
     Signals: {
         /**
-         * Event: media-object-clicked
-         * Emitted when a media URI in the article page is clicked.
-         * Passes the ID of the media object that was clicked and whether it is
-         * a resource of the parent article model.
+         * Event: ekn-link-clicked
+         * Emitted when a ekn id link in the article page is clicked.
+         * Passes the ID.
          */
-        'media-object-clicked': {
+        'ekn-link-clicked': {
             param_types: [
-                GObject.TYPE_OBJECT /* MediaContentObject */,
-                GObject.TYPE_BOOLEAN /* Whether the media object is internal */
+                GObject.TYPE_STRING /* MediaContentObject */,
             ]
         },
-
-        /**
-         * Event: article-object-clicked
-         * Emitted when a URI to another article page is clicked.
-         * Passes the <ArticleObjectModel> object of that URI.
-         */
-        'article-object-clicked': {
-            param_types: [
-                EosKnowledgeSearch.ArticleObjectModel.$gtype /* ArticleObject */
-            ]
-        }
     },
 
     // Duration of animated scroll from section to section in the page.
@@ -129,7 +106,6 @@ const ArticlePresenter = new GObject.Class({
      *   ready - optional, a function to call when the view is ready for display
      */
     load_article: function (model, animation_type, ready) {
-        model.fetch_all(this.engine);
         if (ready === undefined)
             ready = function () {};
 
@@ -292,39 +268,14 @@ const ArticlePresenter = new GObject.Class({
                 return false;
 
             let [baseURI, hash] = decision.request.uri.split('#');
-            let _resources = this._article_model.get_resources();
-            let resource_ekn_ids = _resources.map(function (model) {
-                return model.ekn_id;
-            });
 
             if (baseURI === this._BOGUS_URI) {
                 // If this check is true, then we are navigating to the current
                 // page or an anchor on the current page.
                 decision.use();
                 return false;
-            } else if (resource_ekn_ids.indexOf(decision.request.uri) !== -1) {
-                // Else, if the request corresponds to a media object in the
-                // resources array, emit the bat signal!
-                let lightbox = _resources.filter(function (resource) {
-                    return decision.request.uri === resource.ekn_id;
-                });
-                this.emit('media-object-clicked', lightbox[0], true);
-
-                decision.ignore();
-                return true;
             } else {
-                this.engine.get_object_by_id(baseURI, function (err, model) {
-                    if (typeof err === 'undefined') {
-                        if (model instanceof EosKnowledgeSearch.MediaObjectModel) {
-                            this.emit('media-object-clicked', model, false);
-                        } else {
-                            this.emit('article-object-clicked', model);
-                        }
-                    } else {
-                        printerr(err);
-                        printerr(err.stack);
-                    }
-                }.bind(this));
+                this.emit('ekn-link-clicked', baseURI);
                 return true;
             }
         }.bind(this));

--- a/overrides/presenter.js
+++ b/overrides/presenter.js
@@ -123,7 +123,6 @@ const Presenter = new Lang.Class({
         props.engine = props.engine || EosKnowledgeSearch.Engine.get_default();
         props.article_presenter = props.article_presenter || new ArticlePresenter.ArticlePresenter({
                 article_view: props.view.article_page,
-                engine: props.engine,
                 template_type: this._template_type,
         });
         this.parent(props);
@@ -138,6 +137,7 @@ const Presenter = new Lang.Class({
             visible: true
         });
         this.view.lightbox.content_widget = this._previewer;
+        this._loading_new_lightbox = false;
 
         // Keeps track of the broad query that led to an individual article.
         this._latest_origin_query = '{}';
@@ -174,8 +174,7 @@ const Presenter = new Lang.Class({
         this.view.section_page.connect('load-more-results', this._on_load_more_results.bind(this));
 
         this.view.home_page.connect('show-categories', this._on_categories_button_clicked.bind(this));
-        this.article_presenter.connect('media-object-clicked', this._on_media_object_clicked.bind(this));
-        this.article_presenter.connect('article-object-clicked', this._on_article_object_clicked.bind(this));
+        this.article_presenter.connect('ekn-link-clicked', this._on_ekn_link_clicked.bind(this));
         this.view.categories_page.connect('show-home', this._on_home_button_clicked.bind(this));
         this._original_page = this.view.home_page;
         this._search_origin_page = this.view.home_page;
@@ -512,44 +511,52 @@ const Presenter = new Lang.Class({
         });
     },
 
-    _on_media_object_clicked: function (article_presenter, media_object, is_resource) {
-        if (is_resource) {
-            let resources = this.article_presenter._article_model.get_resources();
-            let current_index = resources.indexOf(media_object);
-            // Checks whether forward/back arrows should be displayed.
-            this._preview_media_object(media_object, current_index > 0, current_index < resources.length - 1);
-        } else {
-            this._preview_media_object(media_object, false, false);
-        }
-    },
+    _on_ekn_link_clicked: function (article_presenter, ekn_id) {
+        this.engine.get_object_by_id(ekn_id, function (err, model) {
+            if (typeof err === 'undefined') {
+                if (model instanceof EosKnowledgeSearch.MediaObjectModel) {
+                    let resources = this.article_presenter._article_model.get_resources();
+                    // Checks whether forward/back arrows should be displayed.
+                    let current_index = resources.indexOf(ekn_id);
+                    if (current_index > -1)
+                        this._preview_media_object(model, current_index > 0, current_index < resources.length - 1);
+                } else {
+                    this._add_history_object_for_article_page(model);
+                    this.article_presenter.load_article(model, EosKnowledge.LoadingAnimationType.FORWARDS_NAVIGATION);
 
-    _on_article_object_clicked: function (article_presenter, model) {
-        this._add_history_object_for_article_page(model);
-        this.article_presenter.load_article(model, EosKnowledge.LoadingAnimationType.FORWARDS_NAVIGATION);
-
-        if (this._template_type === 'B')
-            this.view.section_page.highlight_card_with_name(model.title, this._latest_article_card_title);
+                    if (this._template_type === 'B')
+                        this.view.section_page.highlight_card_with_name(model.title, this._latest_article_card_title);
+                }
+            } else {
+                printerr(err);
+                printerr(err.stack);
+            }
+        }.bind(this));
     },
 
     _on_lightbox_previous_clicked: function (view, lightbox) {
-        let media_object = lightbox.media_object;
-        let resources = this.article_presenter._article_model.get_resources();
-        let current_index = resources.indexOf(media_object);
-        if (current_index > -1) {
-            let new_index = current_index - 1;
-            // If the previous object is not the first, the back arrow should be displayed.
-            this._preview_media_object(resources[new_index], new_index > 0, true); 
-        }
+        this._lightbox_shift_image(lightbox, -1);
     },
 
     _on_lightbox_next_clicked: function (view, lightbox) {
-        let media_object = lightbox.media_object;
+        this._lightbox_shift_image(lightbox, 1);
+    },
+
+    _lightbox_shift_image: function (lightbox, delta) {
         let resources = this.article_presenter._article_model.get_resources();
-        let current_index = resources.indexOf(media_object);
-        if (current_index > -1) {
-            let new_index = current_index + 1;
-            // If the next object is not the last, the forward arrow should be displayed.
-            this._preview_media_object(resources[new_index], true, new_index < resources.length - 1);
+        let current_index = resources.indexOf(lightbox.media_object.ekn_id);
+        if (current_index > -1 && !this._loading_new_lightbox) {
+            this._loading_new_lightbox = true;
+            let new_index = current_index + delta;
+            this.engine.get_object_by_id(resources[new_index], (err, object) => {
+                this._loading_new_lightbox = false;
+                if (err !== undefined) {
+                    printerr(err);
+                    printerr(err.stack);
+                } else {
+                    this._preview_media_object(object, new_index > 0, new_index < resources.length - 1);
+                }
+            });
         }
     },
 

--- a/tests/eosknowledge/testArticlePresenter.js
+++ b/tests/eosknowledge/testArticlePresenter.js
@@ -8,22 +8,6 @@ const Lang = imports.lang;
 const TESTDIR = Endless.getCurrentFileDir() + '/..';
 const MOCK_ARTICLE_PATH = TESTDIR + '/test-content/mexico.jsonld';
 
-const MockEngine = new Lang.Class({
-    Name: 'MockEngine',
-    Extends: GObject.Object,
-
-    _init: function () {
-        this.parent();
-        this.host = 'localhost';
-        this.port = 3003;
-        this.language = '';
-    },
-
-    get_object_by_id: function () {},
-    get_ekn_id: function () {},
-    get_objects_by_query: function () {},
-});
-
 const MockView = new Lang.Class({
     Name: 'MockView',
     Extends: GObject.Object,
@@ -48,7 +32,6 @@ describe('Article Presenter', function () {
     let view;
     let mockArticleData;
     let articleObject;
-    let engine;
     let webview;
 
     beforeEach(function (done) {
@@ -62,12 +45,8 @@ describe('Article Presenter', function () {
         view = new MockView();
         view.connect_after('new-view-transitioned', done);
 
-        engine = new MockEngine();
-        spyOn(engine, 'get_object_by_id');
-
         presenter = new EosKnowledge.ArticlePresenter({
             article_view: view,
-            engine: engine
         });
         presenter.load_article(articleObject, EosKnowledge.LoadingAnimationType.NONE);
     });
@@ -86,33 +65,5 @@ describe('Article Presenter', function () {
             }
         }
         expect(view.toc.section_list).toEqual(labels);
-    });
-
-    it('emits signal when webview navigates to media object', function (done) {
-        let dummy_page = '<html><body><p>Frango frango frango</p></body></html>';
-        presenter.connect('media-object-clicked', function (widget, media_object) {
-            expect(media_object.ekn_id).toEqual('mock_model_id');
-            done();
-        }.bind());
-        engine.get_object_by_id.and.callFake(function (i, callback) {
-            callback(undefined, new EosKnowledgeSearch.MediaObjectModel({
-                ekn_id: 'mock_model_id'
-            }));
-        });
-        presenter._webview.load_html(dummy_page, null);
-    });
-
-    it('emits signal when webview navigates to article object', function (done) {
-        let dummy_page = '<html><body><p>Frango frango frango</p></body></html>';
-        presenter.connect('article-object-clicked', function (widget, article_object) {
-            expect(article_object.ekn_id).toEqual('mock_model_id');
-            done();
-        }.bind());
-        engine.get_object_by_id.and.callFake(function (i, callback) {
-            callback(undefined, new EosKnowledgeSearch.ArticleObjectModel({
-                ekn_id: 'mock_model_id'
-            }));
-        });
-        presenter._webview.load_html(dummy_page, null);
     });
 });

--- a/tests/eosknowledgesearch/testArticleObjectModel.js
+++ b/tests/eosknowledgesearch/testArticleObjectModel.js
@@ -29,17 +29,6 @@ describe ('Article Object Model', function () {
             expect(articleObject.get_resources()).toBeDefined();
         });
 
-        it ('should marhsal its resources like a ContentObject', function () {
-            let contentURIs = articleObject.get_resources().map(function (v) {
-                return v.content_uri;
-            });
-            let expectedURIs = mockArticleData.resources.map(function (v) {
-                return 'file://' + mockMediaDir + '/' + v.contentURL;
-            });
-            expect(articleObject.get_resources()[0]).toBeA(EosKnowledgeSearch.MediaObjectModel);
-            expect(contentURIs).toEqual(expectedURIs);
-        });
-
         it ('should marshal a GtkTreeStore from JSON-LD TreeNodes', function () {
             expect(articleObject.table_of_contents).toBeA(Gtk.TreeStore);
         });

--- a/tests/eosknowledgesearch/testContentObjectModel.js
+++ b/tests/eosknowledgesearch/testContentObjectModel.js
@@ -11,11 +11,10 @@ describe ("Content Object Model", function () {
 
     describe ("Constructor", function () {
         it ("successfully creates new object from properties", function () {
-            let image = EosKnowledgeSearch.ImageObjectModel.new_from_json_ld(mockContentData.thumbnail);
             contentObject = new EosKnowledgeSearch.ContentObjectModel({
                 ekn_id : mockContentData["@id"],
                 title : mockContentData.title,
-                thumbnail : image,
+                thumbnail_id : mockContentData.thumbnail,
                 language : mockContentData.language,
                 copyright_holder : mockContentData.copyrightHolder,
                 source_uri : mockContentData.sourceURL,
@@ -44,7 +43,6 @@ describe ("Content Object Model", function () {
     describe ("Properties", function () {
         beforeEach (function() {
             contentObject = EosKnowledgeSearch.ContentObjectModel.new_from_json_ld(mockContentData);
-            contentObject.set_resources(mockContentData.resources);
             contentObject.set_tags(mockContentData.tags);
         });
 
@@ -74,6 +72,10 @@ describe ("Content Object Model", function () {
 
         it ("should have a license", function () {
             expect(contentObject.license).toEqual(mockContentData["license"]);
+        });
+
+        it ("should have a thumbnail-id", function () {
+            expect(contentObject.thumbnail_id).toEqual(mockContentData["thumbnail"]);
         });
 
         it ("should have resources", function () {

--- a/tests/test-content/emacs.jsonld
+++ b/tests/test-content/emacs.jsonld
@@ -38,27 +38,10 @@
     "license": "Creative-Commons",
     "copyrightHolder": "Wikimedia Foundation",
     "sourceURL": "http://en.wikipedia.org/wiki/Emacs",
-    "thumbnail": {
-        "@id": "ekn:text_editors/Stallman.jpg",
-        "contentURL": "file://path/to/stallman.jpg"
-    },
+    "thumbnail": "ekn://text_editors/Stallman.jpg",
     "resources": [
-        {
-            "@id": "ekn:text_editors/stallman_the_bard",
-            "@type": "ekv:ImageObject",
-            "contentUrl": "ekn:_media/stallman.jpg",
-            "caption": "Stallman drinks a beer while coding",
-            "contentSize": "60KB",
-            "encodingFormat": "jpeg"
-        },
-        {
-            "@id": "ekn:text_editors/emacs_screenshot",
-            "@type": "ekv:ImageObject",
-            "contentUrl": "ekn:_media/emacs.jpg",
-            "caption": "A screenshot of the emacs program",
-            "contentSize": "32KB",
-            "encodingFormat": "jpeg"
-        }
+        "ekn://text_editors/stallman_the_bard",
+        "ekn://text_editors/emacs_screenshot"
     ],
     "tableOfContents": [
         {

--- a/tests/test-content/greyjoy-article.jsonld
+++ b/tests/test-content/greyjoy-article.jsonld
@@ -25,22 +25,8 @@
     "synopsis": "We Do Not Sow",
     "articleBody": "lame",
     "resources": [
-        {
-            "@id": "ekn://squids/squid_people.jpg",
-            "@type": "ekv:ImageObject",
-            "contentURL": "squid_people.jpg",
-            "caption": "Taste like squid, talk like people",
-            "contentSize": "60KB",
-            "encodingFormat": "jpeg"
-        },
-        {
-            "@id": "ekn://jerks/Theon.jpg",
-            "@type": "ekv:ImageObject",
-            "contentURL": "Theon.jpg",
-            "caption": "What a jerk",
-            "contentSize": "32KB",
-            "encodingFormat": "jpeg"
-        }
+        "ekn://squids/squid_people.jpg",
+        "ekn://jerks/Theon.jpg"
     ],
     "tableOfContents": [
         {

--- a/tests/test-content/mexico.jsonld
+++ b/tests/test-content/mexico.jsonld
@@ -704,13 +704,6 @@
     "tags": [
         "M\u00e9xico"
     ],
-    "thumbnail": {
-        "@context": "ekn://_context/ImageObject",
-        "@id": "ekn://general-es/0b314c5cc68c5997",
-        "@type": "ekv:ImageObject",
-        "contentURL": "file:///endless/share/ekn/data/general-es/media/0b314c5cc68c5997.jpeg",
-        "encodingFormat": "image/jpeg",
-        "sourceURI": "http://upload.wikimedia.org/wikipedia/commons/thumb/d/d7/Ciudad.de.Mexico.City.Distrito.Federal.DF.Paseo.Reforma.Skyline.jpg/100px-Ciudad.de.Mexico.City.Distrito.Federal.DF.Paseo.Reforma.Skyline.jpg"
-    },
+    "thumbnail": "ekn://general-es/0b314c5cc68c5997",
     "title": "M\u00e9xico"
 }


### PR DESCRIPTION
Gets rid of all the complex code to handle deferred loading of
certain property in the model. In the new world order after this
commit, the json+ld for each model will always contain everything
needed to fully instantiate the model.

We used to do all the deferred loading to prefetch all the image
models we would need to render the page. With the new stateless
ekn:// uri handler, this wasn't happening anyway. And with the
knowledge engine out of the picture, queries to our database
take much less time.
[endlessm/eos-sdk#2700]
