### PR TITLE
Use the right DPI value as reference: 96 DPI

### DIFF
--- a/overrides/eknWebview.js
+++ b/overrides/eknWebview.js
@@ -36,8 +36,8 @@ const EknWebview = new Lang.Class({
         this._defaultFontSize = this._webKitSettings.default_font_size;
         this._defaultMonospaceFontSize = this._webKitSettings.default_monospace_font_size;
 
-        let screen = Gdk.Screen.get_default()
-        this._gtkSettings = Gtk.Settings.get_for_screen(screen)
+        let screen = Gdk.Screen.get_default();
+        this._gtkSettings = Gtk.Settings.get_for_screen(screen);
         this._updateFontSizeFromGtkSettings(this._gtkSettings);
 
         this.connect('context-menu', this._load_context_menu.bind(this));


### PR DESCRIPTION
Also, ensure we consider that value on startup, so that we don't need to wait for a DPI change to happen.

[endlessm/eos-sdk#2769]
