### PR TITLE
Eliminate transparent gap while sliding in article

### DIFF
--- a/data/endless_knowledge.css
+++ b/data/endless_knowledge.css
@@ -541,6 +541,11 @@ scrollbars, style the GTK scrollbars to look slightly more like them */
     background-color: transparent;
 }
 
+.article-page WebKitWebView {
+    background-color: #ececec;
+    background-image: url('templates/images/noise.png');
+}
+
 .article-page-switcher-frame {
     padding: 20px 0px;
 }


### PR DESCRIPTION
On template B, when an article slides in, the app background is visible
through a gap. This eliminates that gap, replacing it with a gray
background that matches the article background.

[endlessm/eos-sdk#2723]
