### PR TITLE
Make article snippets on overview page clickable

### DIFF
--- a/overrides/EosKnowledge.js
+++ b/overrides/EosKnowledge.js
@@ -141,6 +141,7 @@ function _init() {
      */
     EosKnowledge.Reader = {
         ArticlePage: ReaderArticlePage.ArticlePage,
+        ArticleSnippet: ReaderOverviewPage.ArticleSnippet,
         DonePage: ReaderDonePage.DonePage,
         OverviewPage: ReaderOverviewPage.OverviewPage,
         Presenter: ReaderPresenter.Presenter,

--- a/overrides/reader/overviewPage.js
+++ b/overrides/reader/overviewPage.js
@@ -117,9 +117,8 @@ const OverviewPage = new Lang.Class({
       optional field, 'style_variant'. This function creates an <ArticleSnippet>
       widget for each snippet model and adds it to the snippets grid.
     */
-    set_article_snippets: function (snippets) {
-        snippets.forEach((props) => {
-            let snippet = new ArticleSnippet(props);
+    set_article_snippets: function (snippets, callback) {
+        snippets.forEach((snippet) => {
             this._snippets_grid.add(snippet);
         });
     },
@@ -138,7 +137,7 @@ const OverviewPage = new Lang.Class({
 const ArticleSnippet = new Lang.Class({
     Name: 'ArticleSnippet',
     GTypeName: 'EknArticleSnippet',
-    Extends: Gtk.Grid,
+    Extends: Gtk.Button,
     Properties: {
         /**
          * Property: title
@@ -171,8 +170,6 @@ const ArticleSnippet = new Lang.Class({
 
     _init: function (props) {
         props = props || {};
-        props.orientation = Gtk.Orientation.VERTICAL;
-        props.expand = true;
 
         this._title_label = new Gtk.Label({
             hexpand: true,
@@ -205,8 +202,14 @@ const ArticleSnippet = new Lang.Class({
         if (this.style_variant >= 0)
             context.add_class('snippet' + this.style_variant);
 
-        this.add(this._title_label);
-        this.add(this._synopsis_label);
+        let grid = new Gtk.Grid({
+            orientation: Gtk.Orientation.VERTICAL,
+            expand: true,
+        });
+
+        grid.add(this._title_label);
+        grid.add(this._synopsis_label);
+        this.add(grid);
 
         this.show_all();
     },

--- a/overrides/reader/presenter.js
+++ b/overrides/reader/presenter.js
@@ -16,6 +16,7 @@ const Config = imports.config;
 const EknWebview = imports.eknWebview;
 const Engine = imports.engine;
 const Launcher = imports.launcher;
+const OverviewPage = imports.reader.overviewPage;
 const Previewer = imports.previewer;
 const UserSettingsModel = imports.reader.userSettingsModel;
 const Utils = imports.utils;
@@ -617,12 +618,19 @@ const Presenter = new Lang.Class({
     },
 
     _load_overview_snippets_from_articles: function () {
-        let snippets = this._article_models.slice(0, NUM_OVERVIEW_SNIPPETS).map((snippet, ix) => {
-            return {
-                title: snippet.title,
-                synopsis: snippet.synopsis,
+        let snippets = this._article_models.slice(0, NUM_OVERVIEW_SNIPPETS).map((model, ix) => {
+            let snippet = new OverviewPage.ArticleSnippet({
+                title: model.title,
+                synopsis: model.synopsis,
                 style_variant: ix % NUM_SNIPPET_STYLES,
-            };
+            });
+            snippet.connect('clicked', function () {
+                // idx is the article model index so need to add one (account
+                // for overview page) to get the corresponding article page index.
+                this._go_to_page(ix + 1);
+            }.bind(this));
+            Utils.set_hand_cursor_on_widget(snippet);
+            return snippet;
         });
         this.view.overview_page.set_article_snippets(snippets);
     },

--- a/tests/eosknowledge/reader/testOverviewPage.js
+++ b/tests/eosknowledge/reader/testOverviewPage.js
@@ -11,7 +11,7 @@ describe('Overview page widget', function () {
     beforeEach(function () {
         jasmine.addMatchers(CssClassMatcher.customMatchers);
         jasmine.addMatchers(InstanceOfMatcher.customMatchers);
-        snippets = [
+        let snippet_data = [
             {
                 title: 'Title 1',
                 synopsis: 'Secrets on how to cook frango',
@@ -23,6 +23,10 @@ describe('Overview page widget', function () {
                 style_variant: 1,
             }
         ]
+
+        snippets = snippet_data.map((props) => {
+            return new EosKnowledge.Reader.ArticleSnippet(props);
+        });
         page = new EosKnowledge.Reader.OverviewPage();
     });
 
@@ -44,20 +48,24 @@ describe('Overview page widget', function () {
     });
 
     it('does not set a style variant class for style variant -1', function () {
-        page.set_article_snippets([{
-            title: 'Frango',
-            synopsis: 'Frango tikka masala, yum',
-            style_variant: -1,
-        }]);
+        page.set_article_snippets([
+            new EosKnowledge.Reader.ArticleSnippet ({
+                title: 'Frango',
+                synopsis: 'Frango tikka masala, yum',
+                style_variant: -1,
+            })
+        ]);
         expect(page).not.toHaveDescendantWithCssClass('snippet-1');
         expect(page).not.toHaveDescendantWithCssClass('snippet0');
     });
 
     it('uses 0 as the default style variant', function () {
-        page.set_article_snippets([{
-            title: 'Frango',
-            synopsis: 'Frango tikka masala, yum',
-        }]);
+        page.set_article_snippets([
+            new EosKnowledge.Reader.ArticleSnippet ({
+                title: 'Frango',
+                synopsis: 'Frango tikka masala, yum',
+            })
+        ]);
         expect(page).toHaveDescendantWithCssClass('snippet0');
     });
 });

--- a/tests/eosknowledge/reader/testPresenter.js
+++ b/tests/eosknowledge/reader/testPresenter.js
@@ -145,6 +145,7 @@ describe('Reader presenter', function () {
     const MOCK_RESULTS = MOCK_DATA.map((data, ix) => {
         return {
             title: data[0],
+            synopsis: "Some text",
             ekn_id: 'about:blank',
             get_authors: jasmine.createSpy('get_authors').and.returnValue(data[1]),
             published: data[2],


### PR DESCRIPTION
As per UX design, the snippets on the front
page should be clickable, and should take you
to the corresponding article in the magazine.

[endlessm/eos-sdk#2890]
