### PR TITLE
Update-timestamp uses ISO string

### DIFF
--- a/overrides/reader/presenter.js
+++ b/overrides/reader/presenter.js
@@ -307,13 +307,15 @@ const Presenter = new Lang.Class({
     },
 
     _check_for_content_update: function() {
-        if (Date.now() - this.settings.update_timestamp >= UPDATE_INTERVAL_MS) {
+        let now = new Date();
+        let last_update = new Date(this.settings.update_timestamp);
+        if (now - last_update >= UPDATE_INTERVAL_MS) {
             this._update_content();
         }
     },
 
     _update_content: function () {
-        this.settings.update_timestamp = Date.now();
+        this.settings.update_timestamp = new Date().toISOString();
         this.settings.start_article = this.settings.highest_article_read;
         this.settings.bookmark_page = 0;
     },

--- a/overrides/reader/userSettingsModel.js
+++ b/overrides/reader/userSettingsModel.js
@@ -88,15 +88,14 @@ const UserSettingsModel = new Lang.Class({
          * Property: update-timestamp
          * Update Timestamp
          *
-         * The last time that the readable content was updated, in milliseconds.
+         * The last time that the readable content was updated, in ISO date format.
          *
          * Default value:
-         *  0
+         *  ''
          */
-        'update-timestamp': GObject.ParamSpec.uint64('update-timestamp', 'Last Update Time',
+        'update-timestamp': GObject.ParamSpec.string('update-timestamp', 'Last Update Time',
             'Last time content was updated',
-            GObject.ParamFlags.READWRITE,
-            0, GLib.MAXINT64, 0),
+            GObject.ParamFlags.READWRITE, ''),
     },
 
     _init: function (props) {
@@ -105,7 +104,7 @@ const UserSettingsModel = new Lang.Class({
         this._bookmark_page = 0;
         this._highest_article_read = 0;
         this._start_article = 0;
-        this._update_timestamp = 0;
+        this._update_timestamp = '';
         this._pending_operation = null;
 
         this._load_user_settings_from_file();
@@ -181,7 +180,7 @@ const UserSettingsModel = new Lang.Class({
     get update_timestamp() {
         if (this._update_timestamp)
             return this._update_timestamp;
-        return 0;
+        return '';
     },
 
     set update_timestamp(v) {

--- a/tests/eosknowledge/reader/testPresenter.js
+++ b/tests/eosknowledge/reader/testPresenter.js
@@ -24,10 +24,9 @@ const MockUserSettingsModel = new Lang.Class({
         'bookmark-page': GObject.ParamSpec.uint('bookmark-page', '', '',
             GObject.ParamFlags.READWRITE | GObject.ParamFlags.CONSTRUCT,
             0, GLib.MAXUINT32, 0),
-        'update-timestamp': GObject.ParamSpec.uint64('update-timestamp', 'Last Update Time',
+        'update-timestamp': GObject.ParamSpec.string('update-timestamp', 'Last Update Time',
             'Last time content was updated',
-            GObject.ParamFlags.READWRITE,
-            0, GLib.MAXINT64, 0),
+            GObject.ParamFlags.READWRITE, ''),
     },
 });
 
@@ -168,10 +167,8 @@ describe('Reader presenter', function () {
             highest_article_read: 0,
             bookmark_page: 0,
             start_article: 0,
+            update_timestamp: new Date().toISOString(),
         });
-        // 64-bit int construct properties don't work in GJS; they have to be
-        // set after construction.
-        settings.update_timestamp = GLib.MAXINT64;
         spyOn(engine, 'get_objects_by_query');
 
         presenter = new EosKnowledge.Reader.Presenter(TEST_JSON, {
@@ -248,7 +245,7 @@ describe('Reader presenter', function () {
     });
 
     describe('object', function () {
-        let current_time = Date.now();
+        let current_time = new Date().toISOString();
 
         beforeEach(function () {
             engine.get_objects_by_query.and.callFake(function (q, callback) {
@@ -378,14 +375,16 @@ describe('Reader presenter', function () {
         });
 
         it('updates the content after enough time has passed since the last update', function () {
-            settings.update_timestamp = Date.now() - UPDATE_INTERVAL_MS - 1000;
+            let old_date = new Date(Date.now() - UPDATE_INTERVAL_MS - 1000);
+            settings.update_timestamp = old_date.toISOString();
             spyOn(presenter, '_update_content');
             presenter._check_for_content_update();
             expect(presenter._update_content).toHaveBeenCalled();
         });
 
         it('does not update the content if very little time has passed since the last update', function () {
-            settings.update_timestamp = Date.now() - (UPDATE_INTERVAL_MS / 2);
+            let old_date = new Date(Date.now() - UPDATE_INTERVAL_MS / 2);
+            settings.update_timestamp = old_date.toISOString();
             spyOn(presenter, '_update_content');
             presenter._check_for_content_update();
             expect(presenter._update_content).not.toHaveBeenCalled();

--- a/tests/eosknowledge/reader/testUserSettingsModel.js
+++ b/tests/eosknowledge/reader/testUserSettingsModel.js
@@ -5,7 +5,7 @@ const GLib = imports.gi.GLib;
 
 describe('Reader user settings model', function () {
     let user_settings_file;
-    let current_time = Date.now();
+    let current_time = new Date().toISOString();
 
     beforeEach(function () {
         user_settings_file = Gio.File.new_tmp(null)[0];
@@ -44,7 +44,7 @@ describe('Reader user settings model', function () {
             expect(settings.start_article).toBe(0);
             expect(settings.bookmark_page).toBe(0);
             expect(settings.highest_article_read).toBe(0);
-            expect(settings.update_timestamp).toBe(0);
+            expect(settings.update_timestamp).toBe('');
         });
 
         it('gracefully handles case where settings file does not exist', function () {
@@ -54,7 +54,7 @@ describe('Reader user settings model', function () {
             expect(settings.start_article).toBe(0);
             expect(settings.bookmark_page).toBe(0);
             expect(settings.highest_article_read).toBe(0);
-            expect(settings.update_timestamp).toBe(0);
+            expect(settings.update_timestamp).toBe('');
         });
     });
 
@@ -83,11 +83,6 @@ describe('Reader user settings model', function () {
             expect(settings.highest_article_read).not.toBe(9);
             settings.bookmark_page = 9;
             expect(settings.highest_article_read).toBe(9);
-        });
-
-        it('has enough bits to correctly store timestamps in milliseconds', function () {
-            settings.update_timestamp = 1424989289681;
-            expect(settings.update_timestamp).toEqual(1424989289681);
         });
     });
 });


### PR DESCRIPTION
gjs has problems rendering 64-bit ints
(see https://bugzilla.gnome.org/show_bug.cgi?id=745560 )
so instead we store the timestamp as an ISO
string.

[endlessm/eos-sdk#2842]
