### PR TITLE
Remove all-around padding from overview page

### DIFF
--- a/data/endless_reader.css
+++ b/data/endless_reader.css
@@ -45,10 +45,6 @@ overridden by app specific CSS */
     background-position: center;
 }
 
-.overview-page {
-    padding: 100px;
-}
-
 .done-page .headline {
     font-size: 2em;
     color: #fce94f;

--- a/overrides/reader/overviewPage.js
+++ b/overrides/reader/overviewPage.js
@@ -12,6 +12,10 @@ const ImagePreviewer = imports.imagePreviewer;
 
 GObject.ParamFlags.READWRITE = GObject.ParamFlags.READABLE | GObject.ParamFlags.WRITABLE;
 
+const _LOGO_TOP_MARGIN = 50;
+const _LOGO_LEFT_MARGIN = 75;
+const _SUBTITLE_LEFT_MARGIN = 125;
+
 /**
  * Class: Reader.OverviewPage
  * Splash Page shown in the reader when the app opens
@@ -60,6 +64,8 @@ const OverviewPage = new Lang.Class({
 
         this._title_image = new ImagePreviewer.ImagePreviewer({
             halign: Gtk.Align.START,
+            margin_top: _LOGO_TOP_MARGIN,
+            margin_start: _LOGO_LEFT_MARGIN,
         });
 
         this._title_image_uri = null;
@@ -74,6 +80,9 @@ const OverviewPage = new Lang.Class({
             vexpand: true,
             valign: Gtk.Align.START,
             use_markup: true,
+            // FIXME: This looks reasonable until we get better instructions
+            // from design.
+            margin_start: _SUBTITLE_LEFT_MARGIN,
         });
 
         this._snippets_grid = new EosKnowledge.SpaceContainer({


### PR DESCRIPTION
This is incorrect according to the flats; instead, the logo and subtitle
should receive their own padding.

This makes the article snippets quite ugly, but that will be fixed in
endlessm/eos-sdk#2823.

[endlessm/eos-sdk#2878]
