### PR TITLE
searchProvider: limit descriptions to 200 characters

### DIFF
--- a/js/search/searchProvider.js
+++ b/js/search/searchProvider.js
@@ -90,6 +90,7 @@ const AppSearchProvider = Lang.Class({
     },
 
     NUM_RESULTS: 5,
+    MAX_DESCRIPTION_LENGTH: 200,
 
     _init: function(args) {
         this.parent(args);
@@ -191,7 +192,8 @@ const AppSearchProvider = Lang.Class({
                 };
 
                 if (typeof obj.synopsis !== 'undefined') {
-                    let displayDesc = GLib.markup_escape_text(obj.synopsis, -1);
+                    let desc = obj.synopsis.substring(0, this.MAX_DESCRIPTION_LENGTH);
+                    let displayDesc = GLib.markup_escape_text(desc, -1);
                     result.description = new GLib.Variant('s', displayDesc);
                 }
                 result_gvariants.push(result);


### PR DESCRIPTION
We can only show ~100 on the shell, but we'll send 200 to be safe.
We were often sending far more than that (1000+ characters) over the
bus, which was pretty inefficient.
[endlessm/eos-sdk#2772]
