### PR TITLE
articleObjectModel: Load HTML from disk

### DIFF
--- a/js/search/articleObjectModel.js
+++ b/js/search/articleObjectModel.js
@@ -1,5 +1,6 @@
 // Copyright 2014 Endless Mobile, Inc.
 const GLib = imports.gi.GLib;
+const Gio = imports.gi.Gio;
 const GObject = imports.gi.GObject;
 const Gtk = imports.gi.Gtk;
 const Lang = imports.lang;
@@ -125,7 +126,26 @@ const ArticleObjectModel = new Lang.Class({
                 params.license = 'Owner permission';
         }
 
+        if (params.html) {
+            this._html = params.html;
+            delete params.html;
+        }
+
         this.parent(params);
+    },
+
+    get html() {
+        if (!this._html) {
+            if (this.content_uri) {
+                let file = Gio.File.new_for_uri(this.content_uri);
+                let [success, html, etag] = file.load_contents(null);
+                this._html = html.toString();
+            } else {
+                this._html = '';
+            }
+        }
+
+        return this._html;
     },
 
     set_authors: function (v) {


### PR DESCRIPTION
Our new databases have the HTML separated out from the Xapian database
so that we can read the metadata during search without loading the
entire blob, which will hopefully minimize seek times a lot more.

To keep compatibility, we insert a fancy new "html" getter which will
properly return the articleBody contents if it exists, and fall back
to reading the content URI if it does not.

[endlessm/eos-sdk#2917]
