### PR TITLE
Fix configure.ac so that it doesn't break jenkins

### DIFF
--- a/overrides/Makefile.am.inc
+++ b/overrides/Makefile.am.inc
@@ -74,3 +74,5 @@ subst = $(SED) -e 's,%pkglibdir%,$(pkglibdir),g'
 overrides/config.js: overrides/config.js.in Makefile
 	$(MKDIR_P) overrides
 	$(AM_V_GEN)$(subst) $< > $@
+
+CLEANFILES += overrides/config.js


### PR DESCRIPTION
We were leaving a `configure` script dropping off the list to be removed
during distclean.

[endlessm/eos-sdk#2744]
