### PR TITLE
Force version use of WebKit2 version 3.0

### DIFF
--- a/overrides/EosKnowledge.js
+++ b/overrides/EosKnowledge.js
@@ -1,3 +1,5 @@
+imports.gi.versions.WebKit2 = '3.0';
+
 const ClutterGst = imports.gi.ClutterGst;
 const Endless = imports.gi.Endless;
 const GtkClutter = imports.gi.GtkClutter;


### PR DESCRIPTION
Due to parallel installable versions of WebKit2, gjs will choose a version of
WebKit to load when running EosKnowledge. However, gjs may select a conflicting
version of WebKit2 when loading another module, which can cause a crash.

This commit forces the use of WebKit2 version 3.0.

[endlessm/eos-sdk#2924]
