### PR TITLE
ProgressLabel numbers are padded with zeroes

### DIFF
--- a/overrides/reader/progressLabel.js
+++ b/overrides/reader/progressLabel.js
@@ -79,6 +79,6 @@ const ProgressLabel = new Lang.Class({
         // The string below may need to be localized if it needs to be displayed
         // differently in some locales; for example, maybe a punctuation mark
         // other than 'slash' would be used.
-        this.label = '<span font_weight="heavy">%d</span> / %d'.format(this._current_page, this._total_pages);
+        this.label = '<span font_weight="heavy">%02d</span> / %d'.format(this._current_page, this._total_pages);
     },
 });


### PR DESCRIPTION
According to the design specs, the numerator in the progressLabel widget
is to be padded with zeroes, so that it always takes two digits.

[endlessm/eos-sdk#2887]
