### PR TITLE
Ensure only one of infobar or archive notice is shown

### DIFF
--- a/overrides/reader/presenter.js
+++ b/overrides/reader/presenter.js
@@ -383,13 +383,12 @@ const Presenter = new Lang.Class({
             }
 
             if (this._is_archived(model)) {
-                this.view.standalone_page.infobar.show();
-                this.view.standalone_page.archive_notice.hide();
-                this._load_standalone_article(model);
                 // FIXME Here we should load the rest of the content in the
                 // background; but as there currently isn't a way to get from
                 // the standalone page to the regular content, we don't.
                 this.view.show_all();
+                this._load_standalone_article(model);
+                this.view.show_global_search_standalone_page();
                 this.view.present_with_time(timestamp);
                 return;
             }
@@ -557,9 +556,8 @@ const Presenter = new Lang.Class({
 
     _go_to_article: function (model, animation_type) {
         if (this._is_archived(model)) {
-            this.view.standalone_page.infobar.hide();
-            this.view.standalone_page.archive_notice.show();
             this._load_standalone_article(model);
+            this.view.show_in_app_standalone_page();
         } else {
             this._go_to_page(model.article_number + 1, animation_type);
         }
@@ -982,7 +980,6 @@ const Presenter = new Lang.Class({
         this.view.standalone_page.article_page.title_view.attribution =
             this._format_attribution_for_metadata(model.get_authors(), model.published);
         this.view.standalone_page.article_page.get_style_context().add_class('article-page0');
-        this.view.show_standalone_page();
     },
 
     /*

--- a/overrides/reader/standalonePage.js
+++ b/overrides/reader/standalonePage.js
@@ -234,7 +234,6 @@ const StandalonePage = new Lang.Class({
         this.add(this.archive_notice);
         this.add(this.infobar);
         this.add(this.article_page);
-        this.show_all();
     },
 
     set app_name (v) {

--- a/overrides/reader/window.js
+++ b/overrides/reader/window.js
@@ -296,13 +296,24 @@ const Window = new Lang.Class({
         pages.forEach(this.remove_article_page, this);
     },
 
-    show_standalone_page: function () {
+    _show_standalone_page: function () {
         this.standalone_page.show();
-        this.standalone_page.article_page.progress_label.hide();
         this._stack.set_transition_type(Gtk.StackTransitionType.NONE);
         this._stack.set_visible_child(this.standalone_page);
         this.nav_buttons.back_visible = false;
         this.nav_buttons.forward_visible = false;
+    },
+
+    show_global_search_standalone_page: function () {
+        this.standalone_page.archive_notice.hide();
+        this.standalone_page.infobar.show();
+        this._show_standalone_page();
+    },
+
+    show_in_app_standalone_page: function () {
+        this.standalone_page.archive_notice.show();
+        this.standalone_page.infobar.hide();
+        this._show_standalone_page();
     },
 
     show_search_results_page: function () {

--- a/tests/eosknowledge/reader/testPresenter.js
+++ b/tests/eosknowledge/reader/testPresenter.js
@@ -162,7 +162,8 @@ const MockView = new Lang.Class({
     show_article_page: function () {},
     show_overview_page: function () {},
     show_done_page: function () {},
-    show_standalone_page: function () {},
+    show_global_search_standalone_page: function () {},
+    show_in_app_standalone_page: function () {},
     show_search_results_page: function () {},
     append_article_page: function (page) {
         this._article_pages.push(page);
@@ -273,11 +274,11 @@ describe('Reader presenter', function () {
             spyOn(engine, 'get_object_by_id').and.callFake(function (id, callback) {
                 callback(undefined, model);
             });
-            spyOn(view, 'show_standalone_page');
+            spyOn(view, 'show_global_search_standalone_page');
             presenter.activate_search_result(0, MOCK_ID, 'fake query');
             expect(engine.get_object_by_id).toHaveBeenCalledWith(MOCK_ID,
                 jasmine.any(Function));
-            expect(view.show_standalone_page).toHaveBeenCalled();
+            expect(view.show_global_search_standalone_page).toHaveBeenCalled();
         });
 
         it('starts at the right page when search result is in this issue', function () {

--- a/tests/eosknowledge/reader/testWindow.js
+++ b/tests/eosknowledge/reader/testWindow.js
@@ -89,7 +89,7 @@ describe('Window widget', function () {
     it('ensures visible page updates with show_*_page functions', function () {
         view.show_article_page(1);
         expect(view.article_pages_visible()).toBe(true);
-        view.show_standalone_page();
+        view.show_in_app_standalone_page();
         expect(view.article_pages_visible()).toBe(false);
     });
 });


### PR DESCRIPTION
THe standalone page has two different incarnations:
global search version and in app version. This adds
two separate functions for those different versions
so that we ensure that only either the global
search infobar or the in app archive notice is
shown at one time.

[endlessm/eos-sdk#2933]
