### PR TITLE
Allow ekn ids with multi-word app names

### DIFF
--- a/js/search/xapianQuery.js
+++ b/js/search/xapianQuery.js
@@ -155,7 +155,7 @@ function xapian_not_tag_clause (tags) {
 function xapian_ids_clause (ids) {
     let id_clauses = ids.map((id) => {
         // Verify that ekn id is of the right form
-        let ekn_matcher = /^ekn:\/\/(api\/)?[A-Z]+-?[A-Z]*\/[A-Z0-9]+$/i
+        let ekn_matcher = /^ekn:\/\/(api\/)?[A-Z-]+\/[A-Z0-9]+$/i
         if (!ekn_matcher.test(id))
             throw new Error("Received invalid ekn uri " + id)
 

--- a/tests/eosknowledgesearch/testXapianQuery.js
+++ b/tests/eosknowledgesearch/testXapianQuery.js
@@ -131,6 +131,14 @@ describe('Xapian Query Module', function () {
                     expect(function(){ xq.xapian_ids_clause([bad_id])}).toThrow(new Error('Received invalid ekn uri ' + bad_id));
                 });
             });
+
+            it('should not throw error if receives valid ekn id', function () {
+                let good_ids = ['ekn://travel-es/foo', 'ekn://mental-health-es/bar'];
+
+                good_ids.forEach(function (good_id) {
+                    expect(function(){ xq.xapian_ids_clause([good_id])}).not.toThrow(new Error('Received invalid ekn uri ' + good_id));
+                });
+            });
         });
     });
 });


### PR DESCRIPTION
Don't restrict the number of dashes in an
app name to 1.

[endlessm/eos-sdk#2960]
