### PR TITLE
Add gir1.2-eosmetrics-0 dependency

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -4,6 +4,7 @@ Maintainer: Philip Chimento <philip@endlessm.com>
 Build-Depends: autotools-dev,
                debhelper (>= 8.0.0),
                eos-sdk-0-dev,
+               gir1.2-eosmetrics-0,
                gir1.2-gtkclutter-1.0,
                gir1.2-clutter-gst-2.0,
                gir1.2-endless-0,


### PR DESCRIPTION
This is needed for recording search metrics.

[endlessm/eos-sdk#1946]
