### PR TITLE
Use private importer for EosKnowledge modules

### DIFF
--- a/overrides/EosKnowledge.js
+++ b/overrides/EosKnowledge.js
@@ -1,3 +1,5 @@
+/* global private_imports */
+
 imports.gi.versions.WebKit2 = '3.0';
 
 const ClutterGst = imports.gi.ClutterGst;
@@ -7,60 +9,60 @@ const Lang = imports.lang;
 
 let EosKnowledge;
 
-// Make a backup copy of the array
-let _oldSearchPath = imports.searchPath.slice(0);
-imports.searchPath.unshift(Endless.getCurrentFileDir());
+// Create a separate private importer so that client code can't import our
+// private modules by mistake.
+window.private_imports = imports['.'];
+private_imports.searchPath.unshift(Endless.getCurrentFileDir());
 
-const ArticleCard = imports.articleCard;
-const ArticleHTMLRenderer = imports.articleHTMLRenderer;
-const ArticlePage = imports.articlePage;
-const ArticlePresenter = imports.articlePresenter;
-const Card = imports.card;
-const CardA = imports.cardA;
-const CardB = imports.cardB;
-const CategoriesPage = imports.categoriesPage;
-const EknWebview = imports.eknWebview;
-const HomePage = imports.homePage;
-const HomePageA = imports.homePageA;
-const HomePageB = imports.homePageB;
-const Launcher = imports.launcher;
-const LessonCard = imports.lessonCard;
-const Lightbox = imports.lightbox;
-const ListCard = imports.listCard;
-const MediaInfobox = imports.mediaInfobox;
-const NavButtonOverlay = imports.navButtonOverlay;
-const NoSearchResultsPage = imports.noSearchResultsPage;
-const PdfCard = imports.pdfCard;
-const PDFView = imports.PDFView;
-const Presenter = imports.presenter;
-const PresenterLoader = imports.presenterLoader;
-const Previewer = imports.previewer;
-const ProgressCard = imports.progressCard;
-const SectionArticlePage = imports.sectionArticlePage;
-const SectionPage = imports.sectionPage;
-const SectionPageA = imports.sectionPageA;
-const SectionPageB = imports.sectionPageB;
-const SpaceContainer = imports.spaceContainer;
-const TableOfContents = imports.tableOfContents;
-const TextCard = imports.textCard;
-const TreeNode = imports.treeNode;
-const WebkitURIHandlers = imports.webkitURIHandlers;
-const Window = imports.window;
+const ArticleCard = private_imports.articleCard;
+const ArticleHTMLRenderer = private_imports.articleHTMLRenderer;
+const ArticlePage = private_imports.articlePage;
+const ArticlePresenter = private_imports.articlePresenter;
+const Card = private_imports.card;
+const CardA = private_imports.cardA;
+const CardB = private_imports.cardB;
+const CategoriesPage = private_imports.categoriesPage;
+const EknWebview = private_imports.eknWebview;
+const HomePage = private_imports.homePage;
+const HomePageA = private_imports.homePageA;
+const HomePageB = private_imports.homePageB;
+const Launcher = private_imports.launcher;
+const LessonCard = private_imports.lessonCard;
+const Lightbox = private_imports.lightbox;
+const ListCard = private_imports.listCard;
+const MediaInfobox = private_imports.mediaInfobox;
+const NavButtonOverlay = private_imports.navButtonOverlay;
+const NoSearchResultsPage = private_imports.noSearchResultsPage;
+const PdfCard = private_imports.pdfCard;
+const PDFView = private_imports.PDFView;
+const Presenter = private_imports.presenter;
+const PresenterLoader = private_imports.presenterLoader;
+const Previewer = private_imports.previewer;
+const ProgressCard = private_imports.progressCard;
+const SectionArticlePage = private_imports.sectionArticlePage;
+const SectionPage = private_imports.sectionPage;
+const SectionPageA = private_imports.sectionPageA;
+const SectionPageB = private_imports.sectionPageB;
+const SpaceContainer = private_imports.spaceContainer;
+const TableOfContents = private_imports.tableOfContents;
+const TextCard = private_imports.textCard;
+const WebkitURIHandlers = private_imports.webkitURIHandlers;
+const Window = private_imports.window;
 
-const ReaderArticlePage = imports.reader.articlePage;
-const ReaderCard = imports.reader.card;
-const ReaderDonePage = imports.reader.donePage;
-const ReaderOverviewPage = imports.reader.overviewPage;
-const ReaderPresenter = imports.reader.presenter;
-const ReaderProgressLabel = imports.reader.progressLabel;
-const ReaderSearchResultsPage = imports.reader.searchResultsPage;
-const ReaderStandalonePage = imports.reader.standalonePage;
-const ReaderTitleView = imports.reader.titleView;
-const ReaderUserSettingsModel = imports.reader.userSettingsModel;
-const ReaderWebviewTooltip = imports.reader.webviewTooltip;
-const ReaderWindow = imports.reader.window;
+const ReaderArticlePage = private_imports.reader.articlePage;
+const ReaderCard = private_imports.reader.card;
+const ReaderDonePage = private_imports.reader.donePage;
+const ReaderOverviewPage = private_imports.reader.overviewPage;
+const ReaderPresenter = private_imports.reader.presenter;
+const ReaderProgressLabel = private_imports.reader.progressLabel;
+const ReaderSearchResultsPage = private_imports.reader.searchResultsPage;
+const ReaderStandalonePage = private_imports.reader.standalonePage;
+const ReaderTitleView = private_imports.reader.titleView;
+const ReaderUserSettingsModel = private_imports.reader.userSettingsModel;
+const ReaderWebviewTooltip = private_imports.reader.webviewTooltip;
+const ReaderWindow = private_imports.reader.window;
 
-imports.searchPath = _oldSearchPath;
+delete window.private_imports;
 
 function _init() {
     // "this" is imports.gi.EosKnowledge

--- a/overrides/articleCard.js
+++ b/overrides/articleCard.js
@@ -1,9 +1,11 @@
 // Copyright 2014 Endless Mobile, Inc.
 
+/* global private_imports */
+
 const Gtk = imports.gi.Gtk;
 const Lang = imports.lang;
 
-const CardA = imports.cardA;
+const CardA = private_imports.cardA;
 
 /**
  * Class: ArticleCard

--- a/overrides/articleHTMLRenderer.js
+++ b/overrides/articleHTMLRenderer.js
@@ -1,11 +1,13 @@
+/* global private_imports */
+
 const Gettext = imports.gettext;
 const Gio = imports.gi.Gio;
 const GObject = imports.gi.GObject;
 const Lang = imports.lang;
-const Mustache = imports.mustache.Mustache;
 
-const Config = imports.config;
-const Licenses = imports.licenses;
+const Config = private_imports.config;
+const Mustache = private_imports.mustache.Mustache;
+const Licenses = private_imports.licenses;
 
 let _ = Gettext.dgettext.bind(null, Config.GETTEXT_PACKAGE);
 

--- a/overrides/articlePage.js
+++ b/overrides/articlePage.js
@@ -1,5 +1,7 @@
 // Copyright 2014 Endless Mobile, Inc.
 
+/* global private_imports */
+
 const Endless = imports.gi.Endless;
 const EosKnowledge = imports.gi.EosKnowledge;
 const GObject = imports.gi.GObject;
@@ -8,7 +10,7 @@ const Lang = imports.lang;
 const Pango = imports.gi.Pango;
 const Cairo = imports.gi.cairo;
 
-const TableOfContents = imports.tableOfContents;
+const TableOfContents = private_imports.tableOfContents;
 
 /**
  * Class: ArticlePage

--- a/overrides/articlePresenter.js
+++ b/overrides/articlePresenter.js
@@ -1,3 +1,5 @@
+/* global private_imports */
+
 const EosKnowledgeSearch = imports.EosKnowledgeSearch;
 const EosKnowledge = imports.gi.EosKnowledge;
 const GLib = imports.gi.GLib;
@@ -7,11 +9,11 @@ const Gtk = imports.gi.Gtk;
 const Lang = imports.lang;
 const WebKit2 = imports.gi.WebKit2;
 
-const ArticlePage = imports.articlePage;
-const ArticleHTMLRenderer = imports.articleHTMLRenderer;
-const EknWebview = imports.eknWebview;
-const PDFView = imports.PDFView;
-const Utils = imports.utils;
+const ArticlePage = private_imports.articlePage;
+const ArticleHTMLRenderer = private_imports.articleHTMLRenderer;
+const EknWebview = private_imports.eknWebview;
+const PDFView = private_imports.PDFView;
+const Utils = private_imports.utils;
 
 GObject.ParamFlags.READWRITE = GObject.ParamFlags.READABLE | GObject.ParamFlags.WRITABLE;
 

--- a/overrides/card.js
+++ b/overrides/card.js
@@ -1,5 +1,7 @@
 // Copyright 2014 Endless Mobile, Inc.
 
+/* global private_imports */
+
 const EosKnowledge = imports.gi.EosKnowledge;
 const Gtk = imports.gi.Gtk;
 const GObject = imports.gi.GObject;
@@ -7,8 +9,8 @@ const Lang = imports.lang;
 const Mainloop = imports.mainloop;
 const Pango = imports.gi.Pango;
 
-const CompositeButton = imports.compositeButton;
-const Utils = imports.utils;
+const CompositeButton = private_imports.compositeButton;
+const Utils = private_imports.utils;
 
 GObject.ParamFlags.READWRITE = GObject.ParamFlags.READABLE | GObject.ParamFlags.WRITABLE;
 

--- a/overrides/cardA.js
+++ b/overrides/cardA.js
@@ -1,11 +1,12 @@
 // Copyright 2014 Endless Mobile, Inc.
 
+/* global private_imports */
+
 const EosKnowledge = imports.gi.EosKnowledge;
 const Gtk = imports.gi.Gtk;
 const Lang = imports.lang;
 
-const Card = imports.card;
-
+const Card = private_imports.card;
 
 /**
  * Class: CardA

--- a/overrides/cardB.js
+++ b/overrides/cardB.js
@@ -1,11 +1,12 @@
 // Copyright 2014 Endless Mobile, Inc.
 
+/* global private_imports */
+
 const EosKnowledge = imports.gi.EosKnowledge;
 const Gtk = imports.gi.Gtk;
 const Lang = imports.lang;
 
-const Card = imports.card;
-
+const Card = private_imports.card;
 
 /**
  * Class: CardB

--- a/overrides/categoriesPage.js
+++ b/overrides/categoriesPage.js
@@ -1,13 +1,15 @@
 // Copyright 2014 Endless Mobile, Inc.
 
+/* global private_imports */
+
 const Endless = imports.gi.Endless;
 const Gettext = imports.gettext;
 const GObject = imports.gi.GObject;
 const Gtk = imports.gi.Gtk;
 const Lang = imports.lang;
 
-const Config = imports.config;
-const TabButton = imports.tabButton;
+const Config = private_imports.config;
+const TabButton = private_imports.tabButton;
 
 let _ = Gettext.dgettext.bind(null, Config.GETTEXT_PACKAGE);
 

--- a/overrides/compositeButton.js
+++ b/overrides/compositeButton.js
@@ -1,7 +1,9 @@
+/* global private_imports */
+
 const Gtk = imports.gi.Gtk;
 const Lang = imports.lang;
 
-const MarginButton = imports.marginButton;
+const MarginButton = private_imports.marginButton;
 
 // Class for buttons whose :hover and :active CSS pseudoclass states should be
 // inherited by some of their child widgets, since as of GTK 3.10 these flags no

--- a/overrides/eknWebview.js
+++ b/overrides/eknWebview.js
@@ -1,3 +1,5 @@
+/* global private_imports */
+
 const Gdk = imports.gi.Gdk;
 const GLib = imports.gi.GLib;
 const Gio = imports.gi.Gio;
@@ -5,7 +7,7 @@ const Gtk = imports.gi.Gtk;
 const Lang = imports.lang;
 const WebKit2 = imports.gi.WebKit2;
 
-const Config = imports.config;
+const Config = private_imports.config;
 
 /**
  * Class: EknWebview

--- a/overrides/homePage.js
+++ b/overrides/homePage.js
@@ -1,5 +1,7 @@
 // Copyright 2014 Endless Mobile, Inc.
 
+/* global private_imports */
+
 const Endless = imports.gi.Endless;
 const EosKnowledge = imports.gi.EosKnowledge;
 const GdkPixbuf = imports.gi.GdkPixbuf;
@@ -10,7 +12,7 @@ const Lang = imports.lang;
 
 GObject.ParamFlags.READWRITE = GObject.ParamFlags.READABLE | GObject.ParamFlags.WRITABLE;
 
-const ImagePreviewer = imports.imagePreviewer;
+const ImagePreviewer = private_imports.imagePreviewer;
 
 /**
  * Class: HomePage

--- a/overrides/homePageA.js
+++ b/overrides/homePageA.js
@@ -1,5 +1,7 @@
 // Copyright 2014 Endless Mobile, Inc.
 
+/* global private_imports */
+
 const Endless = imports.gi.Endless;
 const EosKnowledge = imports.gi.EosKnowledge;
 const Gettext = imports.gettext;
@@ -7,10 +9,10 @@ const GObject = imports.gi.GObject;
 const Gtk = imports.gi.Gtk;
 const Lang = imports.lang;
 
-const Config = imports.config;
-const HomePage = imports.homePage;
-const SpaceContainer = imports.spaceContainer;
-const TabButton = imports.tabButton;
+const Config = private_imports.config;
+const HomePage = private_imports.homePage;
+const SpaceContainer = private_imports.spaceContainer;
+const TabButton = private_imports.tabButton;
 
 let _ = Gettext.dgettext.bind(null, Config.GETTEXT_PACKAGE);
 

--- a/overrides/homePageB.js
+++ b/overrides/homePageB.js
@@ -1,13 +1,15 @@
 // Copyright 2014 Endless Mobile, Inc.
 
+/* global private_imports */
+
 const Endless = imports.gi.Endless;
 const EosKnowledge = imports.gi.EosKnowledge;
 const GObject = imports.gi.GObject;
 const Gtk = imports.gi.Gtk;
 const Lang = imports.lang;
 
-const HomePage = imports.homePage;
-const Config = imports.config;
+const HomePage = private_imports.homePage;
+const Config = private_imports.config;
 
 /**
  * Class: HomePageB

--- a/overrides/lessonCard.js
+++ b/overrides/lessonCard.js
@@ -1,5 +1,7 @@
 // Copyright 2014 Endless Mobile, Inc.
 
+/* global private_imports */
+
 const EosKnowledge = imports.gi.EosKnowledge;
 const Format = imports.format;
 const Gettext = imports.gettext;
@@ -8,8 +10,8 @@ const GObject = imports.gi.GObject;
 const Gtk = imports.gi.Gtk;
 const Lang = imports.lang;
 
-const CardA = imports.cardA;
-const Config = imports.config;
+const CardA = private_imports.cardA;
+const Config = private_imports.config;
 
 String.prototype.format = Format.format;
 let _ = Gettext.dgettext.bind(null, Config.GETTEXT_PACKAGE);

--- a/overrides/licenses.js
+++ b/overrides/licenses.js
@@ -1,6 +1,8 @@
+/* global private_imports */
+
 const Gettext = imports.gettext;
 
-const Config = imports.config;
+const Config = private_imports.config;
 
 let _ = Gettext.dgettext.bind(null, Config.GETTEXT_PACKAGE);
 

--- a/overrides/lightbox.js
+++ b/overrides/lightbox.js
@@ -1,3 +1,5 @@
+/* global private_imports */
+
 const Cairo = imports.gi.cairo;
 const Endless = imports.gi.Endless;
 const EosKnowledge = imports.gi.EosKnowledge;
@@ -9,8 +11,8 @@ const GObject = imports.gi.GObject;
 const Gtk = imports.gi.Gtk;
 const Lang = imports.lang;
 
-const CompositeButton = imports.compositeButton;
-const Utils = imports.utils;
+const CompositeButton = private_imports.compositeButton;
+const Utils = private_imports.utils;
 
 GObject.ParamFlags.READWRITE = GObject.ParamFlags.READABLE | GObject.ParamFlags.WRITABLE;
 

--- a/overrides/listCard.js
+++ b/overrides/listCard.js
@@ -1,8 +1,10 @@
 // Copyright 2014 Endless Mobile, Inc.
 
+/* global private_imports */
+
 const Lang = imports.lang;
 
-const CardA = imports.cardA;
+const CardA = private_imports.cardA;
 
 /**
  * Class: ListCard

--- a/overrides/mediaInfobox.js
+++ b/overrides/mediaInfobox.js
@@ -1,3 +1,5 @@
+/* global private_imports */
+
 const Gtk = imports.gi.Gtk;
 const Gio = imports.gi.Gio;
 const GObject = imports.gi.GObject;
@@ -5,9 +7,9 @@ const EosKnowledge = imports.gi.EosKnowledge;
 const Lang = imports.lang;
 const Pango = imports.gi.Pango;
 
-const CompositeButton = imports.compositeButton;
-const Config = imports.config;
-const Utils = imports.utils;
+const CompositeButton = private_imports.compositeButton;
+const Config = private_imports.config;
+const Utils = private_imports.utils;
 
 /** Class: MediaInfobox
  *

--- a/overrides/navButtonOverlay.js
+++ b/overrides/navButtonOverlay.js
@@ -1,5 +1,7 @@
 // Copyright 2014 Endless Mobile, Inc.
 
+/* global private_imports */
+
 const EosKnowledge = imports.gi.EosKnowledge;
 const GObject = imports.gi.GObject;
 const GLib = imports.gi.GLib;
@@ -7,7 +9,7 @@ const Gio = imports.gi.Gio;
 const Gtk = imports.gi.Gtk;
 const Lang = imports.lang;
 
-const Utils = imports.utils;
+const Utils = private_imports.utils;
 
 const _ARROW_SIZE = 20;
 const _SCROLLBAR_MARGIN_PX = 13;  // FIXME should be dynamic

--- a/overrides/noSearchResultsPage.js
+++ b/overrides/noSearchResultsPage.js
@@ -1,6 +1,7 @@
 // Copyright 2014 Endless Mobile, Inc.
 
-const Config = imports.config;
+/* global private_imports */
+
 const EosKnowledge = imports.gi.EosKnowledge;
 const Gettext = imports.gettext;
 const GObject = imports.gi.GObject;
@@ -8,7 +9,8 @@ const Gtk = imports.gi.Gtk;
 const Lang = imports.lang;
 const Pango = imports.gi.Pango;
 
-const NavButtonOverlay = imports.navButtonOverlay;
+const Config = private_imports.config;
+const NavButtonOverlay = private_imports.navButtonOverlay;
 
 let _ = Gettext.dgettext.bind(null, Config.GETTEXT_PACKAGE);
 

--- a/overrides/pdfCard.js
+++ b/overrides/pdfCard.js
@@ -1,13 +1,15 @@
 // Copyright 2014 Endless Mobile, Inc.
 
+/* global private_imports */
+
 const EosKnowledge = imports.gi.EosKnowledge;
 const Gettext = imports.gettext;
 const Gtk = imports.gi.Gtk;
 const Lang = imports.lang;
 const Pango = imports.gi.Pango;
 
-const Config = imports.config;
-const CardA = imports.cardA;
+const Config = private_imports.config;
+const CardA = private_imports.cardA;
 
 let _ = Gettext.dgettext.bind(null, Config.GETTEXT_PACKAGE);
 

--- a/overrides/presenter.js
+++ b/overrides/presenter.js
@@ -1,3 +1,5 @@
+/* global private_imports */
+
 const EosKnowledge = imports.gi.EosKnowledge;
 const EosKnowledgeSearch = imports.EosKnowledgeSearch;
 const Endless = imports.gi.Endless;
@@ -8,21 +10,20 @@ const GObject = imports.gi.GObject;
 const Gtk = imports.gi.Gtk;
 const Lang = imports.lang;
 
-const ArticleCard = imports.articleCard;
-const ArticlePresenter = imports.articlePresenter;
-const CardA = imports.cardA;
-const CardB = imports.cardB;
-const Config = imports.config;
-const Engine = imports.engine;
-const Launcher = imports.launcher;
-const HistoryItem = imports.historyItem;
-const MediaInfobox = imports.mediaInfobox;
-const PdfCard = imports.pdfCard;
-const Previewer = imports.previewer;
-const TextCard = imports.textCard;
-const WebkitURIHandlers = imports.webkitURIHandlers;
-const Window = imports.window;
-const Utils = imports.utils;
+const ArticleCard = private_imports.articleCard;
+const ArticlePresenter = private_imports.articlePresenter;
+const CardA = private_imports.cardA;
+const CardB = private_imports.cardB;
+const Config = private_imports.config;
+const Launcher = private_imports.launcher;
+const HistoryItem = private_imports.historyItem;
+const MediaInfobox = private_imports.mediaInfobox;
+const PdfCard = private_imports.pdfCard;
+const Previewer = private_imports.previewer;
+const TextCard = private_imports.textCard;
+const WebkitURIHandlers = private_imports.webkitURIHandlers;
+const Window = private_imports.window;
+const Utils = private_imports.utils;
 
 String.prototype.format = Format.format;
 let _ = Gettext.dgettext.bind(null, Config.GETTEXT_PACKAGE);

--- a/overrides/presenterLoader.js
+++ b/overrides/presenterLoader.js
@@ -1,10 +1,12 @@
+/* global private_imports */
+
 const Gio = imports.gi.Gio;
 const Gtk = imports.gi.Gtk;
 const System = imports.system;
 
-const Presenter = imports.presenter;
-const ReaderPresenter = imports.reader.presenter;
-const Utils = imports.utils;
+const Presenter = private_imports.presenter;
+const ReaderPresenter = private_imports.reader.presenter;
+const Utils = private_imports.utils;
 
 let get_presenter_for_resource = function (application, resource_path) {
     let resource = Gio.Resource.load(resource_path);

--- a/overrides/previewer.js
+++ b/overrides/previewer.js
@@ -1,11 +1,13 @@
+/* global private_imports */
+
 const EosKnowledge = imports.gi.EosKnowledge;
 const Gio = imports.gi.Gio;
 const GObject = imports.gi.GObject;
 const Gtk = imports.gi.Gtk;
 const Lang = imports.lang;
 
-const ImagePreviewer = imports.imagePreviewer;
-const VideoPreviewer = imports.videoPreviewer;
+const ImagePreviewer = private_imports.imagePreviewer;
+const VideoPreviewer = private_imports.videoPreviewer;
 
 GObject.ParamFlags.READWRITE = GObject.ParamFlags.READABLE | GObject.ParamFlags.WRITABLE;
 

--- a/overrides/progressCard.js
+++ b/overrides/progressCard.js
@@ -1,5 +1,7 @@
 // Copyright 2014 Endless Mobile, Inc.
 
+/* global private_imports */
+
 const EosKnowledge = imports.gi.EosKnowledge;
 const Format = imports.format;
 const Gettext = imports.gettext;
@@ -8,8 +10,8 @@ const GObject = imports.gi.GObject;
 const Gtk = imports.gi.Gtk;
 const Lang = imports.lang;
 
-const ListCard = imports.listCard;
-const Config = imports.config;
+const ListCard = private_imports.listCard;
+const Config = private_imports.config;
 
 String.prototype.format = Format.format;
 let _ = Gettext.dgettext.bind(null, Config.GETTEXT_PACKAGE);

--- a/overrides/reader/articlePage.js
+++ b/overrides/reader/articlePage.js
@@ -1,13 +1,15 @@
 // Copyright 2014 Endless Mobile, Inc.
 
+/* global private_imports */
+
 const EosKnowledge = imports.gi.EosKnowledge;
 const Gettext = imports.gettext;
 const GObject = imports.gi.GObject;
 const Gtk = imports.gi.Gtk;
 const Lang = imports.lang;
 
-const ProgressLabel = imports.reader.progressLabel;
-const TitleView = imports.reader.titleView;
+const ProgressLabel = private_imports.reader.progressLabel;
+const TitleView = private_imports.reader.titleView;
 
 const _TITLE_VIEW_LEFT_MARGIN_PX = 60;
 const _CONTENT_VIEW_TOP_MARGIN_PX = 40;

--- a/overrides/reader/card.js
+++ b/overrides/reader/card.js
@@ -1,5 +1,7 @@
 // Copyright 2015 Endless Mobile, Inc.
 
+/* global private_imports */
+
 const Endless = imports.gi.Endless;
 const EosKnowledge = imports.gi.EosKnowledge;
 const GLib = imports.gi.GLib;
@@ -10,8 +12,8 @@ const Gtk = imports.gi.Gtk;
 const Lang = imports.lang;
 const Pango = imports.gi.Pango;
 
-const EknCard = imports.card;
-const Config = imports.config;
+const EknCard = private_imports.card;
+const Config = private_imports.config;
 
 let _ = Gettext.dgettext.bind(null, Config.GETTEXT_PACKAGE);
 

--- a/overrides/reader/donePage.js
+++ b/overrides/reader/donePage.js
@@ -1,13 +1,15 @@
 // Copyright 2014 Endless Mobile, Inc.
 
+/* global private_imports */
+
 const EosKnowledge = imports.gi.EosKnowledge;
 const Gettext = imports.gettext;
 const GObject = imports.gi.GObject;
 const Gtk = imports.gi.Gtk;
 const Lang = imports.lang;
 
-const Config = imports.config;
-const ProgressLabel = imports.reader.progressLabel;
+const Config = private_imports.config;
+const ProgressLabel = private_imports.reader.progressLabel;
 
 let _ = Gettext.dgettext.bind(null, Config.GETTEXT_PACKAGE);
 

--- a/overrides/reader/overviewPage.js
+++ b/overrides/reader/overviewPage.js
@@ -1,5 +1,7 @@
 // Copyright 2014 Endless Mobile, Inc.
 
+/* global private_imports */
+
 const EosKnowledge = imports.gi.EosKnowledge;
 const Gio = imports.gi.Gio;
 const GLib = imports.gi.GLib;
@@ -8,7 +10,7 @@ const Gtk = imports.gi.Gtk;
 const Lang = imports.lang;
 const Pango = imports.gi.Pango;
 
-const ImagePreviewer = imports.imagePreviewer;
+const ImagePreviewer = private_imports.imagePreviewer;
 
 GObject.ParamFlags.READWRITE = GObject.ParamFlags.READABLE | GObject.ParamFlags.WRITABLE;
 

--- a/overrides/reader/presenter.js
+++ b/overrides/reader/presenter.js
@@ -1,3 +1,5 @@
+/* global private_imports */
+
 const cairo = imports.gi.cairo;  // note: GI module, not native GJS module
 const EosKnowledge = imports.gi.EosKnowledge;
 const EosKnowledgeSearch = imports.EosKnowledgeSearch;
@@ -11,21 +13,20 @@ const Gtk = imports.gi.Gtk;
 const Lang = imports.lang;
 const WebKit2 = imports.gi.WebKit2;
 
-const ArticleHTMLRenderer = imports.articleHTMLRenderer;
-const ArticlePage = imports.reader.articlePage;
-const Config = imports.config;
-const EknWebview = imports.eknWebview;
-const Engine = imports.engine;
-const HistoryItem = imports.historyItem;
-const Launcher = imports.launcher;
-const OverviewPage = imports.reader.overviewPage;
-const Previewer = imports.previewer;
-const ReaderCard = imports.reader.card;
-const UserSettingsModel = imports.reader.userSettingsModel;
-const Utils = imports.utils;
-const WebkitURIHandlers = imports.webkitURIHandlers;
-const WebviewTooltip = imports.reader.webviewTooltip;
-const Window = imports.reader.window;
+const ArticleHTMLRenderer = private_imports.articleHTMLRenderer;
+const ArticlePage = private_imports.reader.articlePage;
+const Config = private_imports.config;
+const EknWebview = private_imports.eknWebview;
+const HistoryItem = private_imports.historyItem;
+const Launcher = private_imports.launcher;
+const OverviewPage = private_imports.reader.overviewPage;
+const Previewer = private_imports.previewer;
+const ReaderCard = private_imports.reader.card;
+const UserSettingsModel = private_imports.reader.userSettingsModel;
+const Utils = private_imports.utils;
+const WebkitURIHandlers = private_imports.webkitURIHandlers;
+const WebviewTooltip = private_imports.reader.webviewTooltip;
+const Window = private_imports.reader.window;
 
 String.prototype.format = Format.format;
 let _ = Gettext.dgettext.bind(null, Config.GETTEXT_PACKAGE);

--- a/overrides/reader/searchResultsPage.js
+++ b/overrides/reader/searchResultsPage.js
@@ -1,13 +1,15 @@
 // Copyright 2015 Endless Mobile, Inc.
 
+/* global private_imports */
+
 const EosKnowledge = imports.gi.EosKnowledge;
 const Gettext = imports.gettext;
 const GObject = imports.gi.GObject;
 const Gtk = imports.gi.Gtk;
 const Lang = imports.lang;
 
-const Config = imports.config;
-const InfiniteScrolledWindow = imports.infiniteScrolledWindow;
+const Config = private_imports.config;
+const InfiniteScrolledWindow = private_imports.infiniteScrolledWindow;
 
 let _ = Gettext.dgettext.bind(null, Config.GETTEXT_PACKAGE);
 

--- a/overrides/reader/standalonePage.js
+++ b/overrides/reader/standalonePage.js
@@ -1,5 +1,7 @@
 // Copyright 2015 Endless Mobile, Inc.
 
+/* global private_imports */
+
 const EosKnowledge = imports.gi.EosKnowledge;
 const Gettext = imports.gettext;
 const Gio = imports.gi.Gio;
@@ -7,11 +9,11 @@ const GObject = imports.gi.GObject;
 const Gtk = imports.gi.Gtk;
 const Lang = imports.lang;
 
-const ArticlePage = imports.reader.articlePage;
-const CompositeButton = imports.compositeButton;
-const Config = imports.config;
-const ImagePreviewer = imports.imagePreviewer;
-const Utils = imports.utils;
+const ArticlePage = private_imports.reader.articlePage;
+const CompositeButton = private_imports.compositeButton;
+const Config = private_imports.config;
+const ImagePreviewer = private_imports.imagePreviewer;
+const Utils = private_imports.utils;
 
 let _ = Gettext.dgettext.bind(null, Config.GETTEXT_PACKAGE);
 

--- a/overrides/reader/userSettingsModel.js
+++ b/overrides/reader/userSettingsModel.js
@@ -1,12 +1,14 @@
 // Copyright 2014 Endless Mobile, Inc.
 
+/* global private_imports */
+
 const Gio = imports.gi.Gio;
 const GLib = imports.gi.GLib;
 const GObject = imports.gi.GObject;
 const Gtk = imports.gi.Gtk;
 const Lang = imports.lang;
 
-const Utils = imports.utils;
+const Utils = private_imports.utils;
 
 GObject.ParamFlags.READWRITE = GObject.ParamFlags.READABLE | GObject.ParamFlags.WRITABLE;
 

--- a/overrides/reader/webviewTooltip.js
+++ b/overrides/reader/webviewTooltip.js
@@ -1,5 +1,7 @@
 // Copyright 2015 Endless Mobile, Inc.
 
+/* global private_imports */
+
 const EosKnowledge = imports.gi.EosKnowledge;
 const Gettext = imports.gettext;
 const GLib = imports.gi.GLib;
@@ -8,7 +10,7 @@ const Gtk = imports.gi.Gtk;
 const Lang = imports.lang;
 const Pango = imports.gi.Pango;
 
-const Config = imports.config;
+const Config = private_imports.config;
 
 GObject.ParamFlags.READWRITE = GObject.ParamFlags.READABLE | GObject.ParamFlags.WRITABLE;
 

--- a/overrides/reader/window.js
+++ b/overrides/reader/window.js
@@ -1,5 +1,7 @@
 // Copyright 2014 Endless Mobile, Inc.
 
+/* global private_imports */
+
 const Endless = imports.gi.Endless;
 const EosKnowledge = imports.gi.EosKnowledge;
 const Gdk = imports.gi.Gdk;
@@ -9,13 +11,13 @@ const GObject = imports.gi.GObject;
 const Gtk = imports.gi.Gtk;
 const Lang = imports.lang;
 
-const StandalonePage = imports.reader.standalonePage;
-const DonePage = imports.reader.donePage;
-const Lightbox = imports.lightbox;
-const NavButtonOverlay = imports.navButtonOverlay;
-const OverviewPage = imports.reader.overviewPage;
-const ProgressLabel = imports.reader.progressLabel;
-const SearchResultsPage = imports.reader.searchResultsPage;
+const StandalonePage = private_imports.reader.standalonePage;
+const DonePage = private_imports.reader.donePage;
+const Lightbox = private_imports.lightbox;
+const NavButtonOverlay = private_imports.navButtonOverlay;
+const OverviewPage = private_imports.reader.overviewPage;
+const ProgressLabel = private_imports.reader.progressLabel;
+const SearchResultsPage = private_imports.reader.searchResultsPage;
 
 /**
  * Class: Reader.Window

--- a/overrides/sectionArticlePage.js
+++ b/overrides/sectionArticlePage.js
@@ -1,5 +1,7 @@
 // Copyright 2014 Endless Mobile, Inc.
 
+/* global private_imports */
+
 const Endless = imports.gi.Endless;
 const EosKnowledge = imports.gi.EosKnowledge;
 const GLib = imports.gi.GLib;
@@ -7,10 +9,10 @@ const GObject = imports.gi.GObject;
 const Gtk = imports.gi.Gtk;
 const Lang = imports.lang;
 
-const NavButtonOverlay = imports.navButtonOverlay;
-const SectionPageA = imports.sectionPageA;
-const SectionPageB = imports.sectionPageB;
-const ArticlePage = imports.articlePage;
+const NavButtonOverlay = private_imports.navButtonOverlay;
+const SectionPageA = private_imports.sectionPageA;
+const SectionPageB = private_imports.sectionPageB;
+const ArticlePage = private_imports.articlePage;
 
 GObject.ParamFlags.READWRITE = GObject.ParamFlags.READABLE | GObject.ParamFlags.WRITABLE;
 

--- a/overrides/sectionPageA.js
+++ b/overrides/sectionPageA.js
@@ -1,12 +1,14 @@
 // Copyright 2014 Endless Mobile, Inc.
 
+/* global private_imports */
+
 const EosKnowledge = imports.gi.EosKnowledge;
 const GObject = imports.gi.GObject;
 const Gtk = imports.gi.Gtk;
 const Lang = imports.lang;
 
-const InfiniteScrolledWindow = imports.infiniteScrolledWindow;
-const SectionPage = imports.sectionPage;
+const InfiniteScrolledWindow = private_imports.infiniteScrolledWindow;
+const SectionPage = private_imports.sectionPage;
 
 /**
  * Class: SectionPageA

--- a/overrides/sectionPageB.js
+++ b/overrides/sectionPageB.js
@@ -1,5 +1,7 @@
 // Copyright 2014 Endless Mobile, Inc.
 
+/* global private_imports */
+
 const Cairo = imports.gi.cairo;
 const Endless = imports.gi.Endless;
 const EosKnowledge = imports.gi.EosKnowledge;
@@ -9,8 +11,8 @@ const Gtk = imports.gi.Gtk;
 const Lang = imports.lang;
 const Pango = imports.gi.Pango;
 
-const InfiniteScrolledWindow = imports.infiniteScrolledWindow;
-const SectionPage = imports.sectionPage;
+const InfiniteScrolledWindow = private_imports.infiniteScrolledWindow;
+const SectionPage = private_imports.sectionPage;
 
 /**
  * Class: SectionPageB

--- a/overrides/tableOfContents.js
+++ b/overrides/tableOfContents.js
@@ -1,5 +1,7 @@
 // Copyright 2014 Endless Mobile, Inc.
 
+/* global private_imports */
+
 const Endless = imports.gi.Endless;
 const EosKnowledge = imports.gi.EosKnowledge;
 const GLib = imports.gi.GLib;
@@ -10,8 +12,8 @@ const Lang = imports.lang;
 const Mainloop = imports.mainloop;
 const Pango = imports.gi.Pango;
 
-const MarginButton = imports.marginButton;
-const Utils = imports.utils;
+const MarginButton = private_imports.marginButton;
+const Utils = private_imports.utils;
 
 GObject.ParamFlags.READWRITE = GObject.ParamFlags.READABLE | GObject.ParamFlags.WRITABLE;
 

--- a/overrides/textCard.js
+++ b/overrides/textCard.js
@@ -1,11 +1,13 @@
 // Copyright 2014 Endless Mobile, Inc.
 
+/* global private_imports */
+
 const EosKnowledge = imports.gi.EosKnowledge;
 const Gtk = imports.gi.Gtk;
 const GObject = imports.gi.GObject;
 const Lang = imports.lang;
 
-const Card = imports.card;
+const Card = private_imports.card;
 
 /**
  * Class: TextCard

--- a/overrides/window.js
+++ b/overrides/window.js
@@ -1,5 +1,7 @@
 // Copyright 2014 Endless Mobile, Inc.
 
+/* global private_imports */
+
 const Endless = imports.gi.Endless;
 const EosKnowledge = imports.gi.EosKnowledge;
 const GdkPixbuf = imports.gi.GdkPixbuf;
@@ -8,15 +10,15 @@ const Gdk = imports.gi.Gdk;
 const Gtk = imports.gi.Gtk;
 const Lang = imports.lang;
 
-const ArticlePage = imports.articlePage;
-const CategoriesPage = imports.categoriesPage;
-const HomePage = imports.homePage;
-const HomePageA = imports.homePageA;
-const HomePageB = imports.homePageB;
-const Lightbox = imports.lightbox;
-const NoSearchResultsPage = imports.noSearchResultsPage;
-const SectionPage = imports.sectionPage;
-const SectionArticlePage = imports.sectionArticlePage;
+const ArticlePage = private_imports.articlePage;
+const CategoriesPage = private_imports.categoriesPage;
+const HomePage = private_imports.homePage;
+const HomePageA = private_imports.homePageA;
+const HomePageB = private_imports.homePageB;
+const Lightbox = private_imports.lightbox;
+const NoSearchResultsPage = private_imports.noSearchResultsPage;
+const SectionPage = private_imports.sectionPage;
+const SectionArticlePage = private_imports.sectionArticlePage;
 
 GObject.ParamFlags.READWRITE = GObject.ParamFlags.READABLE | GObject.ParamFlags.WRITABLE;
 


### PR DESCRIPTION
Instead of adding a search path and removing it after importing all the
internal modules, create a separate private importer. This is necessary
because otherwise EosKnowledge will import other modules' config.js if
it was imported before EosKnowledge.

[endlessm/eos-sdk#2961]
