### PR TITLE
Remove opacity from nav button images

### DIFF
--- a/data/endless_reader.css
+++ b/data/endless_reader.css
@@ -111,8 +111,7 @@ overridden by app specific CSS */
 
 .nav-back-button, .nav-forward-button {
     color: white;
-    background-color: black;
-    opacity: 0.3;
+    background-color: alpha(black, 0.3);
     padding: 16px; /* (55px (button width) - 23px (icon width)) / 2 */
     transition: padding 500ms ease-in-out;
 }


### PR DESCRIPTION
The opacity should only apply to the
black background.

[endlessm/eos-sdk#2987]
