### PR TITLE
Makefile: always use utf-8 as default locale when compiling sass

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -70,7 +70,7 @@ $(scss_targets): $(scss_partials)
 
 # scss build rule
 .scss.css:
-	$(scss_verbose) $(MKDIR_P) $(dir $@) && scss --compass --stop-on-error --sourcemap=none $< $@
+	$(scss_verbose) $(MKDIR_P) $(dir $@) && scss --compass -E utf-8 --stop-on-error --sourcemap=none $< $@
 
 EXTRA_DIST += $(scss_toplevels) $(scss_partials)
 CLEANFILES += $(scss_targets)


### PR DESCRIPTION
When building on our ci we use C as our locale, we need to specify
utf-8 as the default there
[endlessm/eos-sdk#2980]
