### PR TITLE
Add fade out transition for nav buttons

### DIFF
--- a/data/endless_reader.css
+++ b/data/endless_reader.css
@@ -114,6 +114,8 @@ overridden by app specific CSS */
     background-color: alpha(black, 0.3);
     padding: 16px; /* (55px (button width) - 23px (icon width)) / 2 */
     transition: padding 500ms ease-in-out;
+    opacity: 1.0;
+    transition: opacity 400ms;
 }
 
 .nav-back-button GtkImage, .nav-forward-button GtkImage {
@@ -136,6 +138,11 @@ overridden by app specific CSS */
 
 .nav-forward-button:hover {
     padding-right: 24px;
+}
+
+.animating .nav-forward-button, .animating .nav-back-button {
+    opacity: 0;
+    transition: opacity 400ms;
 }
 
 .overview-page .scrollbar.trough {

--- a/overrides/reader/window.js
+++ b/overrides/reader/window.js
@@ -245,6 +245,14 @@ const Window = new Lang.Class({
         });
         this.overview_page.show_all();
         this._stack.set_visible_child(this.overview_page);
+
+        this._stack.connect('notify::transition-running', () => {
+            if (this._stack.transition_running) {
+                this.get_style_context().add_class(EosKnowledge.STYLE_CLASS_ANIMATING);
+            } else {
+                this.get_style_context().remove_class(EosKnowledge.STYLE_CLASS_ANIMATING);
+            }
+        });
     },
 
     _update_progress_labels: function () {


### PR DESCRIPTION
When page manager is transitioning between
pages, fade out the nav buttons, as per
design request.

[endlessm/eos-sdk#2993]
