### PR TITLE
Escape text before using it as markup

### DIFF
--- a/overrides/reader/overviewPage.js
+++ b/overrides/reader/overviewPage.js
@@ -154,7 +154,7 @@ const OverviewPage = new Lang.Class({
         this._subtitle_label_text = v;
         /* 758 = 0.74 px * 1024 Pango units / px */
         this._subtitle_label.label = ('<span letter_spacing="758">' +
-            this._subtitle_label_text.toLocaleUpperCase() + '</span>');
+            GLib.markup_escape_text(this._subtitle_label_text.toLocaleUpperCase(), -1) + '</span>');
         this._subtitle_label.visible = (v && v.length !== 0);
         this.notify('subtitle');
     },

--- a/overrides/reader/titleView.js
+++ b/overrides/reader/titleView.js
@@ -106,7 +106,7 @@ const TitleView = new Lang.Class({
         if (this._title_text === value)
             return;
         this._title_text = value;
-        this._title_label.label = this._title_text.toLocaleUpperCase();
+        this._title_label.label = GLib.markup_escape_text(this._title_text.toLocaleUpperCase(), -1);
         this.notify('title');
     },
 
@@ -158,7 +158,7 @@ const TitleView = new Lang.Class({
         if (this.style_variant === 1 || this.style_variant === 2)
             markup_label = markup_label.toLocaleUpperCase();
         if (this.style_variant === 1)
-            markup_label = '<span letter_spacing="1362">' + markup_label + '</span>';
+            markup_label = '<span letter_spacing="1362">' + GLib.markup_escape_text(markup_label, -1) + '</span>';
         // 1362 = 1.33px * 1024 Pango units/px
 
         this._attribution_label.label = markup_label;

--- a/overrides/tableOfContents.js
+++ b/overrides/tableOfContents.js
@@ -434,7 +434,7 @@ const SectionButton = new Lang.Class({
         });
         this.title_label.get_style_context().add_class(EosKnowledge.STYLE_CLASS_TOC_ENTRY_TITLE);
         this._title_bold = new Gtk.Label({
-            label: "<b>" + section_title + "</b>",
+            label: "<b>" + GLib.markup_escape_text(section_title, -1) + "</b>",
             use_markup: true,
             ellipsize: Pango.EllipsizeMode.END,
             width_chars: this._MIN_CHARS, // Demand some characters before ellipsis


### PR DESCRIPTION
If there are unescaped symbols
in the text, it will not display
on screen.

[endlessm/eos-sdk#2967]
