### PR TITLE
Fail early if no SCSS compiler

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -70,7 +70,7 @@ $(scss_targets): $(scss_partials)
 
 # scss build rule
 .scss.css:
-	$(scss_verbose) $(MKDIR_P) $(dir $@) && scss --compass -E utf-8 --stop-on-error --sourcemap=none $< $@
+	$(scss_verbose) $(MKDIR_P) $(dir $@) && $(SCSS) --compass -E utf-8 --stop-on-error --sourcemap=none $< $@
 
 EXTRA_DIST += $(scss_toplevels) $(scss_partials)
 CLEANFILES += $(scss_targets)

--- a/configure.ac
+++ b/configure.ac
@@ -121,6 +121,14 @@ AC_ARG_VAR([YELPBUILD], [Path to yelp-build])
 AC_PATH_PROG([NATURALDOCS], [naturaldocs], [notfound])
 AC_ARG_VAR([NATURALDOCS], [Path to naturaldocs])
 AC_SUBST([GLIB_COMPILE_RESOURCES], [`$PKG_CONFIG --variable glib_compile_resources gio-2.0`])
+AC_PATH_PROG([SCSS], [scss], [notfound])
+AS_IF([test x$SCSS = xnotfound], [AC_MSG_ERROR([SCSS compiler not found.
+Try installing the "sass" Ruby gem or its equivalent package.])])
+AC_ARG_VAR([SCSS], [Path to SCSS compiler])
+AC_MSG_CHECKING([whether SCSS compiler supports compass])
+AS_IF([scss --compass], [AC_MSG_RESULT([yes])],
+    [AC_MSG_ERROR([SCSS compiler does not have Compass support.
+Try installing the "compass" Ruby gem or its equivalent package.])])
 
 AC_CACHE_SAVE
 


### PR DESCRIPTION
This also allows detecting the path to the SCSS compiler and overriding
it if desired.

[endlessm/eos-sdk#3063]
