### PR TITLE
Fix EknImagePreviewer:aspect type

### DIFF
--- a/overrides/imagePreviewer.js
+++ b/overrides/imagePreviewer.js
@@ -30,12 +30,12 @@ const ImagePreviewer = Lang.Class({
         /**
          * Property: aspect
          *
-         * The aspect aspect the previewer widget should display at
+         * The aspect the previewer widget should display at
          */
-        'aspect': GObject.ParamSpec.float('aspect', 'Aspect',
+        'aspect': GObject.ParamSpec.double('aspect', 'Aspect',
             'Aspect ratio of previewer content',
             GObject.ParamFlags.READABLE,
-            false),
+            0.0, 100.0, 1.0),
 
         /**
          * Property: enforce-minimum-size


### PR DESCRIPTION
The parameter doesn't need to be a float, it can be a regular double;
the arguments were incorrect, which newer GJS doesn't like; and I fixed
a typo in the documentation.

[endlessm/eos-sdk#3069]
