### PR TITLE
webkitURIHandlers: squash bug when loading images for old article

### DIFF
--- a/overrides/webkitURIHandlers.js
+++ b/overrides/webkitURIHandlers.js
@@ -17,7 +17,16 @@ function register_webkit_uri_handlers (article_render_callback) {
 
 function _load_ekn_assets (req, article_render_callback) {
     try {
+        // FIXME: If our webview is gone, just return.
+        // Might be masking a bug in webkit here. Rushing this fix out for 2.3.
+        if (!req.get_web_view())
+            return;
+        let page_uri = req.get_web_view().get_uri();
         EosKnowledgeSearch.Engine.get_default().get_object_by_id(req.get_uri(), function (err, model) {
+            // FIXME: If our webview is gone, or it has moved on to a new page, just return.
+            // Might be masking a bug in webkit here. Rushing this fix out for 2.3.
+            if (!req.get_web_view() || req.get_web_view().get_uri() !== page_uri)
+                return;
             if (model instanceof EosKnowledgeSearch.ArticleObjectModel) {
                 let html = article_render_callback(model);
                 let bytes = ByteArray.fromString(html).toGBytes();


### PR DESCRIPTION
We were hitting a segfault when finishing async uri requests for
images in an article that we are no longer viewing.

To be honest not sure we have the full picture here, rushing this
out. But it seems to fix things to ignore uri request for a webview
that has been destroyed or has since navigated to a new page.
[endlessm/eos-sdk#3078]
