### PR TITLE
CC Licenses load local files

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -272,7 +272,8 @@ reader_overrides = \
 readeroverridesdir = $(pkgoverridesdir)/reader
 dist_readeroverrides_DATA = $(reader_overrides)
 
-subst = $(SED) -e 's,%pkglibdir%,$(pkglibdir),g'
+subst = $(SED) -e 's,%pkglibdir%,$(pkglibdir),g' \
+	-e 's,%datadir%,$(datadir),g'
 overrides/config.js: overrides/config.js.in Makefile
 	$(MKDIR_P) overrides
 	$(AM_V_GEN)$(subst) $< > $@

--- a/overrides/config.js.in.in
+++ b/overrides/config.js.in.in
@@ -4,3 +4,4 @@ const inspector_enabled = @inspector@;
 const mathjax_path = '@MATHJAXDIR@';
 // Substituted at make time rather than configure time
 const PKGLIBDIR = '%pkglibdir%';
+const DATADIR = '%datadir%';

--- a/tests/eosknowledge/testArticleHTMLRenderer.js
+++ b/tests/eosknowledge/testArticleHTMLRenderer.js
@@ -64,7 +64,7 @@ describe('Article HTML Renderer', function () {
 
     it('links to creative commons license on wikimedia pages', function () {
         let html = renderer.render(wikibooks_model);
-        expect(html).toMatch('creativecommons.org');
+        expect(html).toMatch('creativecommons');
     });
 
     it('links to original wikihow articles', function () {
@@ -106,7 +106,7 @@ describe('Article HTML Renderer', function () {
 
     it('links to the license in embedly articles', function () {
         let html = renderer.render(embedly_model);
-        expect(html).toMatch('creativecommons.org');
+        expect(html).toMatch('creativecommons');
     });
 
     it('renders wikihow and wiki articles properly with EOS 2.2 DB information', function () {


### PR DESCRIPTION
Now that we include local copies of the Creative Commons licenses, we link to
them in the articles and show them in an external browser when clicked.

[endlessm/eos-sdk#3025]
