### PR TITLE
Fixed ReaderPresenter smoke test

### DIFF
--- a/tests/smoke-tests/readerPresenterSmokeTest.js
+++ b/tests/smoke-tests/readerPresenterSmokeTest.js
@@ -4,74 +4,72 @@ const EosKnowledgeSearch = imports.EosKnowledgeSearch;
 const Gio = imports.gi.Gio;
 const Lang = imports.lang;
 
+const ARTICLE_MODELS = [
+    {
+        ekn_id: 'ekn://diy-es/0000000000000001',
+        title: 'Article One',
+        authors: ['plward11'],
+        published: 'September 30, 2014',
+        articleNumber: 0,
+        html: '<a href="http://www.google.com">Google</a>'
+    },
+    {
+        ekn_id: 'ekn://diy-es/0000000000000002',
+        title: 'Article Two',
+        authors: ['ffarfan'],
+        articleNumber: 1,
+        html: '<a href="ekn://diy-es/0000000000000003">This is an in-issue link</a>. You should see the tooltip pointing to Page 4.',
+    },
+    {
+        ekn_id: 'ekn://diy-es/0000000000000003',
+        title: 'Article Three',
+        published: 'September 30, 2014',
+        articleNumber: 2,
+        html: '<a href="ekn://diy-es/0000000000000f00">To the archive!</a>. This tooltip should show the "ARCHIVE" legend.',
+    },
+    {
+        ekn_id: 'ekn://diy-es/0000000000000004',
+        title: 'Article Four (Cheese)',
+        published: 'February 13, 2015',
+        synopsis: 'Cheese is really expensive in Canada...',
+        authors: ['ptomato'],
+        articleNumber: 3,
+    },
+    {
+        ekn_id: 'ekn://diy-es/0000000000000f00',
+        articleNumber: 42,
+        title: 'Article Forty Two',
+        published: 'April 2, 1979',
+        authors: ['Douglas Adams'],
+        html: 'Time is an illusion. Lunchtime doubly so.',
+    }
+];
+
 // Load and register the GResource which has content for this app
 let resource = Gio.Resource.load('tests/test-content/test-content.gresource');
 resource._register();
 let resource_path = Gio.File.new_for_uri('resource:///com/endlessm/thrones');
 
 // Mock out the engine so that we aren't looking for an eos-thrones database
-let mock_engine = new EosKnowledgeSearch.Engine();
+let mock_engine = new EosKnowledgeSearch.Engine.get_default();
 mock_engine.get_object_by_id = function (ekn_id, callback) {
-    let props;
-    if (ekn_id === 'ekn://article-foo/') {
-        props = {
-            ekn_id: 'ekn://article-foo/',
-            articleNumber: 42,
-            title: 'Article Forty Two',
-            published: 'April 2, 1979',
-            authors: ['Douglas Adams'],
-            html: 'Time is an illusion. Lunchtime doubly so.',
-        };
-    } else if (ekn_id === 'ekn://article3/') {
-        props = {
-            ekn_id: 'ekn://article3/',
-            articleNumber: 2,
-            title: 'Article Three',
-            published: 'September 30, 2014',
-            html: '<a href="ekn://article-foo/">To the archive!</a>. This tooltip should show the "ARCHIVE" legend.',
-        };
+    let props = ARTICLE_MODELS.filter((obj) => {
+        return obj.ekn_id === ekn_id;
+    })[0];
+
+    let authors;
+    if (props.hasOwnProperty('authors')) {
+        authors = props.authors;
+        delete props.authors;
     }
-    let authors = props.authors;
-    delete props.authors;
     let article = new EosKnowledgeSearch.ArticleObjectModel(props);
     if (authors)
         article.set_authors(authors);
     callback(undefined, article);
 };
 mock_engine.get_objects_by_query = function (query, callback) {
-    const OBJECTS = [
-        {
-            title: 'Article One',
-            authors: ['Plward11'],
-            published: 'September 30, 2014',
-            ekn_id: 'ekn://article1/',
-            articleNumber: 0,
-            html: '<a href="http://www.google.com">Google</a>'
-        },
-        {
-            title: 'Article Two',
-            authors: ['Ffarfan'],
-            ekn_id: 'ekn://article2/',
-            articleNumber: 1,
-            html: '<a href="ekn://article3/">This is an in-issue link</a>. You should see the tooltip pointing to Page 4.',
-        },
-        {
-            title: 'Article Three',
-            published: 'September 30, 2014',
-            ekn_id: 'ekn://article3/',
-            articleNumber: 2,
-            html: '<a href="ekn://article-foo/">To the archive!</a>. This tooltip should show the "ARCHIVE" legend.',
-        },
-        {
-            title: 'Article Four (Cheese)',
-            published: 'February 13, 2015',
-            synopsis: 'Cheese is really expensive in Canada...',
-            authors: ['Ptomato'],
-            ekn_id: 'ekn://article4/',
-            articleNumber: 3,
-        }
-    ];
-    callback(undefined, OBJECTS.slice(0, query.limit).map((props) => {
+    // We slice the global ARTICLE_MODELS array to bring only the first four articles.
+    callback(undefined, ARTICLE_MODELS.slice(0, 3).map((props) => {
         let authors = props.authors;
         delete props.authors;
         let model = new EosKnowledgeSearch.ArticleObjectModel(props);


### PR DESCRIPTION
Now that Xapian query validates the format and validity of EKN Id's, the Reader
Presenter smoke test needed to be fixed.

[endlessm/eos-sdk#3059]
