### PR TITLE
Remove unnecessary flags.

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -14,7 +14,7 @@
 
 # Build our documentation as well
 override_dh_auto_configure:
-	dh_auto_configure -- --enable-gtk-doc --enable-gir-doc --enable-js-doc
+	dh_auto_configure -- --enable-gtk-doc
 
 # Keep our tests from running when building the debian. This is because our
 # test need a valid display out for running gtk_init. In the future we should


### PR DESCRIPTION
GIR docs and JS docs are now enabled by default, so there's no longer
any need to enable them explicitly.

[endlessm/eos-sdk#1981]
