### PR TITLE
Refactor reader css into separate file

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -55,6 +55,7 @@ scss_verbose_0 = @echo "  SCSS $@";
 
 scss_toplevels = \
 	$(srcdir)/data/templates/css/embedly.scss \
+	$(srcdir)/data/templates/css/reader.scss \
 	$(srcdir)/data/templates/css/wikihow.scss \
 	$(srcdir)/data/templates/css/wikimedia.scss \
 	$(NULL)

--- a/data/eos-knowledge-library.gresource.xml
+++ b/data/eos-knowledge-library.gresource.xml
@@ -15,6 +15,7 @@
     <file preprocess="xml-stripblanks">reader/standalone_arrow.svg</file>
     <file>templates/article.mst</file>
     <file>templates/css/embedly.css</file>
+    <file>templates/css/reader.css</file>
     <file>templates/css/wikihow.css</file>
     <file>templates/css/wikimedia.css</file>
     <file>templates/images/noise.png</file>

--- a/data/templates/css/embedly.scss
+++ b/data/templates/css/embedly.scss
@@ -4,7 +4,6 @@
 
 html, body {
     height: 100%;
-    margin-right: 40px;
 }
 
 html {
@@ -12,18 +11,6 @@ html {
 }
 
 #inside-content {
-    margin: 15px;
-    padding-top: 80px;
-    &:before {
-        background: #efefef;
-        content: "";
-        display: block;
-        position: fixed;
-        height: 80px;
-        top: 0;
-        left: 0;
-        right: 0;
-    }
     h1 {
         color: #333333;
         font-family: Lato;

--- a/data/templates/css/reader.scss
+++ b/data/templates/css/reader.scss
@@ -1,0 +1,18 @@
+html, body {
+    margin-right: 40px;
+}
+
+#inside-content {
+    margin: 15px;
+    padding-top: 80px;
+    &:before {
+        background: #efefef;
+        content: "";
+        display: block;
+        position: fixed;
+        height: 80px;
+        top: 0;
+        left: 0;
+        right: 0;
+    }
+}

--- a/overrides/articleHTMLRenderer.js
+++ b/overrides/articleHTMLRenderer.js
@@ -117,14 +117,16 @@ const ArticleHTMLRenderer = new Lang.Class({
         return javascript_files;
     },
 
-    render: function (model) {
+    render: function (model, custom_css_files=[], custom_js_files=[]) {
+        let css_files = this._get_css_files(model).concat(custom_css_files);
+        let js_files = this._get_javascript_files(model).concat(custom_js_files);
         return Mustache.render(this._template, {
             'title': this.show_title ? model.title : false,
             'body-html': this._strip_tags(model.get_html()),
             'disclaimer': this._get_disclaimer(model),
             'copy-button-text': _("Copy"),
-            'css-files': this._get_css_files(model),
-            'javascript-files': this._get_javascript_files(model),
+            'css-files': css_files,
+            'javascript-files': js_files,
             'include-mathjax': true,
             'mathjax-path': Config.mathjax_path,
         });

--- a/overrides/reader/presenter.js
+++ b/overrides/reader/presenter.js
@@ -885,7 +885,7 @@ const Presenter = new Lang.Class({
     },
 
     _article_render_callback: function (article_model) {
-        return this._article_renderer.render(article_model);
+        return this._article_renderer.render(article_model, ['reader.css']);
     },
 
     _load_webview_content_callback: function (page, view, error) {


### PR DESCRIPTION
Certain style rules in the embedly.scss
file were specific to the reader app. This
moves those rules into a separate file.

[endlessm/eos-sdk#3093]
