### PR TITLE
debian/control: add epak runtime dependency

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -59,7 +59,8 @@ Description: EndlessOS Knowledge Library API documentation
 Package: gir1.2-eosknowledge-0
 Section: non-free/introspection
 Architecture: any
-Depends: libjs-mathjax (>= 2.2),
+Depends: gir1.2-epak-0,
+         libjs-mathjax (>= 2.2),
          xapian-bridge,
          ${gir:Depends},
          ${misc:Depends}


### PR DESCRIPTION
We need it at runtime too
[endlessm/eos-sdk#2917]
