### PR TITLE
Correct broken read_stream method

### DIFF
--- a/js/search/searchUtils.js
+++ b/js/search/searchUtils.js
@@ -89,7 +89,7 @@ function read_stream (stream, cancellable = null) {
         let total_read = '';
 
         let buffer = stream.read_bytes(CHUNK_SIZE, cancellable);
-        while (buffer.get_size() === CHUNK_SIZE) {
+        while (buffer.get_size() !== 0) {
             total_read += buffer.get_data().toString();
             buffer = stream.read_bytes(CHUNK_SIZE, cancellable);
         }


### PR DESCRIPTION
According to the docs, g_input_stream_read can return any number of
bytes up to what was requested (except 0) and still be readable.

[endlessm/eos-sdk#2917]
