### PR TITLE
homePage: use stream api for imagePreviewer

### DIFF
--- a/overrides/homePage.js
+++ b/overrides/homePage.js
@@ -152,7 +152,8 @@ const HomePage = new Lang.Class({
     set title_image_uri (v) {
         if (this._title_image_uri === v) return;
 
-        this._title_image.file = Gio.File.new_for_uri(v);
+        let stream = Gio.File.new_for_uri(v).read(null);
+        this._title_image.set_content(stream);
 
         // only actually set the image URI if we successfully set the image
         this._title_image_uri = v;

--- a/overrides/imagePreviewer.js
+++ b/overrides/imagePreviewer.js
@@ -58,7 +58,6 @@ const ImagePreviewer = Lang.Class({
         this.set_has_window(false);
 
         this._stream = null;
-        this._content_type = null;
         this._animation = null;
         this._animation_iter = null;
         this._animation_callback_source = 0;
@@ -87,7 +86,7 @@ const ImagePreviewer = Lang.Class({
         return this._supported_types.indexOf(type) != -1;
     },
 
-    set_content: function (stream, content_type) {
+    set_content: function (stream) {
         if (stream === this._stream)
             return;
         this._stream = stream;

--- a/overrides/previewer.js
+++ b/overrides/previewer.js
@@ -59,7 +59,7 @@ const Previewer = new Lang.Class({
         if (this._stream === null) return;
 
         if (this._image_previewer.supports_type(content_type)) {
-            this._image_previewer.set_content(stream, content_type);
+            this._image_previewer.set_content(stream);
             this.add(this._image_previewer);
         } else {
             throw new Error('Previewer does not support type ' + content_type);


### PR DESCRIPTION
The home page uses the imagePreviewer for showing title images
(somewhat questionably). But we didn't port it to new stream api,
so we had broken all title images.
[endlessm/eos-sdk#2917]
