### PR TITLE
render() becomes a stateless function call

### DIFF
--- a/js/app/articlePresenter.js
+++ b/js/app/articlePresenter.js
@@ -81,10 +81,7 @@ const ArticlePresenter = new GObject.Class({
         this._article_model = null;
         this._webview = null;
         this._webview_load_id = 0;
-        this._renderer = new ArticleHTMLRenderer.ArticleHTMLRenderer({
-            show_title: this.template_type !== 'A',
-            enable_scroll_manager: this.template_type === 'A',
-        });
+        this._renderer = new ArticleHTMLRenderer.ArticleHTMLRenderer();
 
         this._connect_toc_widget();
         this.article_view.connect('new-view-transitioned', this._update_title_and_toc.bind(this));
@@ -155,7 +152,10 @@ const ArticlePresenter = new GObject.Class({
     },
 
     _article_render_callback: function (article_model) {
-        return this._renderer.render(article_model);
+        return this._renderer.render(article_model, {
+            enable_scroll_manager: this.template_type === 'A',
+            show_title: this.template_type !== 'A',
+        });
     },
 
     // Cancels any currently loading offscreen views. Right now just the

--- a/js/app/encyclopedia/presenter.js
+++ b/js/app/encyclopedia/presenter.js
@@ -36,10 +36,7 @@ const EncyclopediaPresenter = new Lang.Class({
         WebkitContextSetup.register_webkit_uri_handlers(this._article_render_callback.bind(this));
         this._engine = Engine.Engine.get_default();
 
-        this._renderer = new ArticleHTMLRenderer.ArticleHTMLRenderer({
-            enable_scroll_manager: false,
-            show_title: true,
-        });
+        this._renderer = new ArticleHTMLRenderer.ArticleHTMLRenderer();
 
         for (let page of [this._view.home_page, this._view.content_page]) {
             page.search_box.connect('activate',
@@ -191,7 +188,9 @@ const EncyclopediaPresenter = new Lang.Class({
     },
 
     _article_render_callback: function (article) {
-        return this._renderer.render(article);
+        return this._renderer.render(article, {
+            show_title: true,
+        });
     },
 
     _on_article_selected: function (search_entry, ekn_id) {

--- a/js/app/reader/presenter.js
+++ b/js/app/reader/presenter.js
@@ -879,7 +879,9 @@ const Presenter = new Lang.Class({
     },
 
     _article_render_callback: function (article_model) {
-        return this._article_renderer.render(article_model, ['reader.css']);
+        return this._article_renderer.render(article_model, {
+            custom_css_files: ['reader.css'],
+        });
     },
 
     _load_webview_content_callback: function (page, view, error) {

--- a/tests/js/app/testArticleHTMLRenderer.js
+++ b/tests/js/app/testArticleHTMLRenderer.js
@@ -60,9 +60,9 @@ describe('Article HTML Renderer', function () {
     });
 
     it('shows a title only when told to', function () {
-        renderer.show_title = true;
-        let html_with_title = renderer.render(embedly_model);
-        renderer.show_title = false;
+        let html_with_title = renderer.render(embedly_model, {
+            show_title: true,
+        });
         let html_no_title = renderer.render(embedly_model);
         expect(html_with_title).toMatch('Embedly title');
         expect(html_no_title).not.toMatch('Embedly title');
@@ -84,6 +84,15 @@ describe('Article HTML Renderer', function () {
         expect(renderer.render(embedly_model)).toMatch('embedly.css');
     });
 
+    it('links to the custom css only when told to', function () {
+        let html = renderer.render(embedly_model, {
+            custom_css_files: ['reader.css'],
+        });
+        expect(html).toMatch('reader.css');
+        let no_reader_html = renderer.render(embedly_model);
+        expect(no_reader_html).not.toMatch('reader.css');
+    });
+
     it('escapes html special characters in title', function () {
         let html = renderer.render(wikihow_model);
         expect(html).toMatch('Wikihow &amp; title');
@@ -95,9 +104,9 @@ describe('Article HTML Renderer', function () {
     });
 
     it('includes scroll_manager.js only when told to', function () {
-        renderer.enable_scroll_manager = true;
-        let html_with_scroll_manager = renderer.render(embedly_model);
-        renderer.enable_scroll_manager = false;
+        let html_with_scroll_manager = renderer.render(embedly_model, {
+            enable_scroll_manager: true,
+        });
         let html_without_scroll_manager = renderer.render(embedly_model);
 
         expect(html_with_scroll_manager).toMatch('scroll-manager.js');


### PR DESCRIPTION
Previously the render class was part stateful
and part stateless. Now, it is entirely stateless,
taking all the information it needs to render
a page in the .render method. Specifically, it
takes an article model object and a dictionary
of optional extra parameters.

[endlessm/eos-sdk#3093]
