### PR TITLE
Search terms exert no undue influence on history

### DIFF
--- a/js/app/presenter.js
+++ b/js/app/presenter.js
@@ -434,9 +434,6 @@ const Presenter = new Lang.Class({
         }
         this._get_more_results = this._get_more_results_from_search;
 
-        this._latest_origin_query_obj = new QueryObject.QueryObject({
-            query: this._latest_search_text,
-        });
         // If template B, we need to set the autocomplete results as the cards on the
         // section page
         if (this._template_type === 'B') {


### PR DESCRIPTION
Search terms now are only added to the history model when a user
explicitly enters a search. If they just click on an autocompleted
term, then the history model will store what the page looked like
before they clicked on that term.

[endlessm/eos-sdk#3160]
