### PR TITLE
Makefile: fix gresource.xml name in EXTRA_DIST

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -98,7 +98,7 @@ pkgdata_DATA += data/eos-knowledge.gresource
 
 EXTRA_DIST += \
 	$(filter-out $(scss_targets),$(resource_files)) \
-	data/eos-knowledge-library.gresource.xml \
+	data/eos-knowledge.gresource.xml \
 	$(NULL)
 CLEANFILES += \
 	data/eos-knowledge.gresource \


### PR DESCRIPTION
Forgot to change to the new filename
[endlessm/eos-sdk#3004]
