### PR TITLE
Generate XML reports when running on Jenkins

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -431,7 +431,7 @@ TEST_EXTENSIONS = .js
 JS_LOG_DRIVER = env AM_TAP_AWK='$(AWK)' $(SHELL) $(top_srcdir)/tap-driver.sh
 JS_LOG_DRIVER_FLAGS = --comments
 JS_LOG_COMPILER = jasmine
-AM_JS_LOG_FLAGS = --tap --no-config
+AM_JS_LOG_FLAGS = --tap --no-config @JASMINE_REPORT_ARGUMENT@
 
 # Use locally built versions of EosKnowledgePrivate-1.0.gir, JS modules, and
 # libraries. We clobber GJS_PATH and include the js directory and the

--- a/configure.ac
+++ b/configure.ac
@@ -191,6 +191,16 @@ else
     AC_MSG_ERROR([Cannot find mathjax package])
 fi
 
+# JASMINE_JUNIT_REPORTS_DIR: Where to put test reports
+AC_MSG_CHECKING([where to put test reports])
+AC_ARG_VAR([JASMINE_JUNIT_REPORTS_DIR], [Where to put test reports])
+AS_IF([test -n "$JASMINE_JUNIT_REPORTS_DIR"],
+    [JASMINE_REPORT_ARGUMENT="--junit $JASMINE_JUNIT_REPORTS_DIR/\$\${log/%.log/.js.xml}"
+    AC_MSG_RESULT([in $JASMINE_JUNIT_REPORTS_DIR])],
+    [JASMINE_REPORT_ARGUMENT=
+    AC_MSG_RESULT([nowhere])])
+AC_SUBST([JASMINE_REPORT_ARGUMENT])
+
 # Required libraries
 # ------------------
 # Update these whenever you use a function that requires a certain API version


### PR DESCRIPTION
If we detect a Jenkins environment using the environment variable
JASMINE_JUNIT_REPORTS_DIR that we set in the job's configuration, then
generate XML test reports for each Jasmine unit test.

[endlessm/eos-sdk#3172]
