### PR TITLE
queryObject: split terms on semi colons

### DIFF
--- a/js/search/queryObject.js
+++ b/js/search/queryObject.js
@@ -34,7 +34,7 @@ const _MATCH_SYNOPSIS_CUTOFF = 20;
 // Matches any contiguous whitespace
 const _WHITESPACE_REGEX = /\s+/;
 // Matches any delimiter which indicates a separate Xapian term
-const _TERM_DELIMITER_REGEX = /[\s\-]+/;
+const _TERM_DELIMITER_REGEX = /[\s\-;]+/;
 
 /**
  * Enum: QueryObjectType

--- a/tests/js/search/testQueryObject.js
+++ b/tests/js/search/testQueryObject.js
@@ -139,6 +139,16 @@ describe('QueryObject', function () {
             expect(result).toContain('title:man');
         });
 
+        it('should treat semi colons as whitespace', function () {
+            let query_obj = new QueryObject.QueryObject({
+                query: 'whoa;man',
+            });
+            let result = query_obj.get_query_parser_string(query_obj);
+            expect(result).toContain('exact_title:Whoa_Man');
+            expect(result).toContain('title:whoa');
+            expect(result).toContain('title:man');
+        });
+
         it('should lowercase xapian operator terms', function () {
             let query_obj = new QueryObject.QueryObject({
                 query: 'PENN AND tELLER',


### PR DESCRIPTION
Xapian was interpreting semi colons poorly and not considering any
text before a semi colon in a query. We should just consider words
joined by a semicolon separate terms in our search.
[endlessm/eos-sdk#3200]
