### PR TITLE
History models skip empty searches

### DIFF
--- a/overrides/historyItem.js
+++ b/overrides/historyItem.js
@@ -81,6 +81,6 @@ const HistoryItem = new Lang.Class({
          */
         'empty': GObject.ParamSpec.boolean('empty', 'Empty',
             'A boolean value that stores whether or not a history item contains a query that returns 0 results',
-            GObject.ParamFlags.READWRITE | GObject.ParamFlags.CONSTRUCT_ONLY, false),
+            GObject.ParamFlags.READWRITE, false),
     }
 });

--- a/overrides/presenter.js
+++ b/overrides/presenter.js
@@ -225,7 +225,10 @@ const Presenter = new Lang.Class({
      */
     _on_topbar_back_clicked: function () {
         this.view.lightbox.reveal_overlays = false;
-        this._history_model.go_back();
+        // Skip over history items with no results.
+        do {
+            this._history_model.go_back();
+        } while (this._history_model.current_item.empty && this._history_model.can_go_back);
         this._replicate_history_state(EosKnowledge.LoadingAnimationType.BACKWARDS_NAVIGATION);
     },
 
@@ -235,7 +238,10 @@ const Presenter = new Lang.Class({
      */
     _on_topbar_forward_clicked: function () {
         this.view.lightbox.reveal_overlays = false;
-        this._history_model.go_forward();
+        // Skip over history items with no results.
+        do {
+            this._history_model.go_forward();
+        } while (this._history_model.current_item.empty && this._history_model.can_go_forward);
         this._replicate_history_state(EosKnowledge.LoadingAnimationType.FORWARDS_NAVIGATION);
     },
 
@@ -641,6 +647,7 @@ const Presenter = new Lang.Class({
             printerr(err);
             printerr(err.stack);
         } else if (results.length === 0) {
+            this._history_model.current_item.empty = true;
             this.view.no_search_results_page.query = this._search_query;
             this._search_origin_page = this.view.section_page;
             this.view.unlock_ui();

--- a/overrides/reader/presenter.js
+++ b/overrides/reader/presenter.js
@@ -541,6 +541,7 @@ const Presenter = new Lang.Class({
             printerr(err);
             printerr(err.stack);
         } else if (results.length === 0) {
+            this.history_model.current_item.empty = true;
             this.view.search_results_page.clear_search_results();
             this.view.search_results_page.no_results_label.show();
             this.view.show_search_results_page();
@@ -1102,7 +1103,10 @@ const Presenter = new Lang.Class({
      * history object for information to replicate that previous page's query.
      */
     _on_topbar_back_clicked: function () {
-        this.history_model.go_back();
+        // Skip over history items with no results.
+        do {
+            this.history_model.go_back();
+        } while (this.history_model.current_item.empty && this.history_model.can_go_back);
         this._replicate_history_state(EosKnowledge.LoadingAnimationType.BACKWARDS_NAVIGATION);
     },
 
@@ -1111,7 +1115,10 @@ const Presenter = new Lang.Class({
      * history object for information to replicate that next page's query.
      */
     _on_topbar_forward_clicked: function () {
-        this.history_model.go_forward();
+        // Skip over history items with no results.
+        do {
+            this.history_model.go_forward();
+        } while (this.history_model.current_item.empty && this.history_model.can_go_forward);
         this._replicate_history_state(EosKnowledge.LoadingAnimationType.FORWARDS_NAVIGATION);
     },
 


### PR DESCRIPTION
History items for searches that returned no
results will be skipped over when users
navigate back or forwards with history
buttons.

[endlessm/eos-sdk#2979]
