### PR TITLE
searchProvider: fix call to engine.get_object_by_query_finish

### DIFF
--- a/js/search/searchProvider.js
+++ b/js/search/searchProvider.js
@@ -147,7 +147,7 @@ const AppSearchProvider = Lang.Class({
                                           this._cancellable,
                                           (engine, query_task) => {
             try {
-                let results = engine.get_objects_by_query_finish(query_task);
+                let [results, get_more_results_query] = engine.get_objects_by_query_finish(query_task);
                 this._add_results_to_cache(results);
                 let ids = results.map(function (result) { return result.ekn_id; });
                 invocation.return_value(new GLib.Variant('(as)', [ids]));
@@ -155,7 +155,7 @@ const AppSearchProvider = Lang.Class({
                 if (!error.matches(Gio.IOErrorEnum, Gio.IOErrorEnum.CANCELLED)) {
                     logError(error);
                 }
-                invocation.return_error_literal(this._search_provider_domain, SearchProviderErrors.RetrievalError, 'Error retrieving results: ' + err);
+                invocation.return_error_literal(this._search_provider_domain, SearchProviderErrors.RetrievalError, 'Error retrieving results: ' + error);
             }
             app.release();
         });


### PR DESCRIPTION
It returns a list of results and a query object to get the next set
of results.

[endlessm/eos-sdk#2855]
