### PR TITLE
Fix resource paths in credits.json

### DIFF
--- a/data/credits.json
+++ b/data/credits.json
@@ -1,353 +1,353 @@
 [
   {
-    "resource_path": "/com/endlessm/encyclopedia/assets/background-home.jpg",
+    "resource_path": "/com/endlessm/knowledge/images/background-home.jpg",
     "uri": "http://commons.wikimedia.org/wiki/File:Rembrandt_Harmensz._van_Rijn_007.jpg",
     "license": "Public domain"
   },
   {
-    "resource_path": "/com/endlessm/encyclopedia/assets/background-home.jpg",
+    "resource_path": "/com/endlessm/knowledge/images/background-home.jpg",
     "uri": "http://unsplash.com/",
     "license": "CC0 1.0"
   },
   {
     "credit": "Superfamous Studios",
     "credit_uri": "http://superfamous.com/",
-    "resource_path": "/com/endlessm/encyclopedia/assets/background-home.jpg",
+    "resource_path": "/com/endlessm/knowledge/images/background-home.jpg",
     "uri": "http://superfamous.com/",
     "license": "CC BY 3.0"
   },
   {
     "credit": "Superfamous Studios",
     "credit_uri": "http://superfamous.com/",
-    "resource_path": "/com/endlessm/encyclopedia/assets/background-result.jpg",
+    "resource_path": "/com/endlessm/knowledge/images/background-result.jpg",
     "uri": "http://superfamous.com/",
     "license": "CC BY 3.0"
   },
   {
     "credit": "PollyDot",
     "credit_uri": "http://pixabay.com/en/users/PollyDot-160618/",
-    "resource_path": "/com/endlessm/encyclopedia/assets/background-home.jpg",
+    "resource_path": "/com/endlessm/knowledge/images/background-home.jpg",
     "uri": "http://pixabay.com/en/bees-on-frame-honey-honey-bees-351566/",
     "license": "CC0 1.0"
   },
   {
     "credit": "Josch13",
     "credit_uri": "http://pixabay.com/en/users/Josch13-48777/",
-    "resource_path": "/com/endlessm/encyclopedia/assets/background-home.jpg",
+    "resource_path": "/com/endlessm/knowledge/images/background-home.jpg",
     "uri": "http://pixabay.com/en/drop-of-water-drip-blade-of-grass-351778/",
     "license": "CC0 1.0"
   },
   {
     "credit": "Josch13",
     "credit_uri": "http://pixabay.com/en/users/Josch13-48777/",
-    "resource_path": "/com/endlessm/encyclopedia/assets/background-result.jpg",
+    "resource_path": "/com/endlessm/knowledge/images/background-result.jpg",
     "uri": "http://pixabay.com/en/drop-of-water-drip-blade-of-grass-351778/",
     "license": "CC0 1.0"
   },
   {
     "credit": "Boston Public Library",
     "credit_uri": "https://www.flickr.com/photos/boston_public_library/",
-    "resource_path": "/com/endlessm/encyclopedia/assets/background-home.jpg",
+    "resource_path": "/com/endlessm/knowledge/images/background-home.jpg",
     "uri": "http://www.flickr.com/photos/boston_public_library/8009657518/",
     "license": "CC BY 2.0"
   },
   {
     "credit": "hom26",
     "credit_uri": "https://www.flickr.com/photos/hom26/",
-    "resource_path": "/com/endlessm/encyclopedia/assets/background-home.jpg",
+    "resource_path": "/com/endlessm/knowledge/images/background-home.jpg",
     "uri": "https://www.flickr.com/photos/hom26/7072126329/in/photostream/",
     "license": "CC BY 2.0"
   },
   {
     "credit": "Oleg",
     "credit_uri": "https://www.flickr.com/photos/olegshpyrko/",
-    "resource_path": "/com/endlessm/encyclopedia/assets/background-home.jpg",
+    "resource_path": "/com/endlessm/knowledge/images/background-home.jpg",
     "uri": "http://www.flickr.com/photos/olegshpyrko/5555301720/",
     "license": "CC BY 2.0"
   },
   {
     "credit": "Twice25",
     "credit_uri": "http://commons.wikimedia.org/wiki/User:Twice25",
-    "resource_path": "/com/endlessm/encyclopedia/assets/background-home.jpg",
+    "resource_path": "/com/endlessm/knowledge/images/background-home.jpg",
     "uri": "http://commons.wikimedia.org/wiki/File:Biella-artigianato_orientale.jpg",
     "license": "CC BY-SA 3.0"
   },
   {
     "credit": "Witizia",
     "credit_uri": "http://pixabay.com/en/users/Witizia-261998/",
-    "resource_path": "/com/endlessm/encyclopedia/assets/background-home.jpg",
+    "resource_path": "/com/endlessm/knowledge/images/background-home.jpg",
     "uri": "http://pixabay.com/en/pyrenees-mountains-snow-zenith-351266/",
     "license": "CC0 1.0"
   },
   {
     "credit": "Anja Osenberg",
     "credit_uri": "http://pixabay.com/en/users/cocoparisienne-127419/",
-    "resource_path": "/com/endlessm/encyclopedia/assets/background-home.jpg",
+    "resource_path": "/com/endlessm/knowledge/images/background-home.jpg",
     "uri": "http://pixabay.com/en/dandelion-plant-close-summer-macro-302129/",
     "license": "CC0 1.0"
   },
   {
     "credit": "skeeze",
     "credit_uri": "http://pixabay.com/en/users/skeeze-272447/",
-    "resource_path": "/com/endlessm/encyclopedia/assets/background-home.jpg",
+    "resource_path": "/com/endlessm/knowledge/images/background-home.jpg",
     "uri": "http://pixabay.com/en/lightning-strike-night-storm-bolt-583713/",
     "license": "CC0 1.0"
   },
   {
     "credit": "WikiImages",
     "credit_uri": "http://pixabay.com/en/users/WikiImages-1897/",
-    "resource_path": "/com/endlessm/encyclopedia/assets/background-home.jpg",
+    "resource_path": "/com/endlessm/knowledge/images/background-home.jpg",
     "uri": "http://pixabay.com/en/star-clusters-galaxy-star-ngc-602-74052/",
     "license": "CC0 1.0"
   },
   {
     "credit": "WikiImages",
     "credit_uri": "http://pixabay.com/en/users/WikiImages-1897/",
-    "resource_path": "/com/endlessm/encyclopedia/assets/background-result.jpg",
+    "resource_path": "/com/endlessm/knowledge/images/background-result.jpg",
     "uri": "http://pixabay.com/en/star-clusters-galaxy-star-ngc-602-74052/",
     "license": "CC0 1.0"
   },
   {
     "credit": "70154",
     "credit_uri": "http://pixabay.com/en/users/70154-70154/",
-    "resource_path": "/com/endlessm/encyclopedia/assets/background-home.jpg",
+    "resource_path": "/com/endlessm/knowledge/images/background-home.jpg",
     "uri": "http://pixabay.com/en/golden-pheasant-bird-exotic-317503/",
     "license": "CC0 1.0"
   },
   {
     "credit": "70154",
     "credit_uri": "http://pixabay.com/en/users/70154-70154/",
-    "resource_path": "/com/endlessm/encyclopedia/assets/background-result.jpg",
+    "resource_path": "/com/endlessm/knowledge/images/background-result.jpg",
     "uri": "http://pixabay.com/en/golden-pheasant-bird-exotic-317503/",
     "license": "CC0 1.0"
   },
   {
     "credit": "Josch13",
     "credit_uri": "http://pixabay.com/en/users/Josch13-48777/",
-    "resource_path": "/com/endlessm/encyclopedia/assets/background-home.jpg",
+    "resource_path": "/com/endlessm/knowledge/images/background-home.jpg",
     "uri": "http://pixabay.com/en/spring-bird-feather-turkey-feather-289527/",
     "license": "CC0 1.0"
   },
   {
     "credit": "fdecomite",
     "credit_uri": "https://www.flickr.com/photos/fdecomite/",
-    "resource_path": "/com/endlessm/encyclopedia/assets/background-home.jpg",
+    "resource_path": "/com/endlessm/knowledge/images/background-home.jpg",
     "uri": "https://www.flickr.com/photos/fdecomite/3533153558/",
     "license": "CC BY 2.0"
   },
   {
     "credit": "Jialiang Gao",
     "credit_uri": "http://www.peace-on-earth.org/",
-    "resource_path": "/com/endlessm/encyclopedia/assets/background-home.jpg",
+    "resource_path": "/com/endlessm/knowledge/images/background-home.jpg",
     "uri": "http://commons.wikimedia.org/wiki/File:Terrace_field_yunnan_china_denoised.jpg",
     "license": "CC BY-SA 3.0"
   },
   {
     "credit": "David Mark",
     "credit_uri": "http://pixabay.com/en/users/tpsdave-12019/",
-    "resource_path": "/com/endlessm/encyclopedia/assets/background-home.jpg",
+    "resource_path": "/com/endlessm/knowledge/images/background-home.jpg",
     "uri": "http://pixabay.com/en/hawaii-volcano-hot-fire-night-142138/",
     "license": "CC0 1.0"
   },
   {
     "credit": "Martin Str",
     "credit_uri": "http://pixabay.com/en/users/MartinStr-108372/",
-    "resource_path": "/com/endlessm/encyclopedia/assets/background-home.jpg",
+    "resource_path": "/com/endlessm/knowledge/images/background-home.jpg",
     "uri": "http://pixabay.com/en/northern-lights-sweden-lapland-225452/",
     "license": "CC0 1.0"
   },
   {
     "credit": "Martin Str",
     "credit_uri": "http://pixabay.com/en/users/MartinStr-108372/",
-    "resource_path": "/com/endlessm/encyclopedia/assets/background-result.jpg",
+    "resource_path": "/com/endlessm/knowledge/images/background-result.jpg",
     "uri": "http://pixabay.com/en/northern-lights-sweden-lapland-225452/",
     "license": "CC0 1.0"
   },
   {
     "credit": "Imaresz",
     "credit_uri": "http://pixabay.com/en/users/lmaresz-23602/",
-    "resource_path": "/com/endlessm/encyclopedia/assets/background-home.jpg",
+    "resource_path": "/com/endlessm/knowledge/images/background-home.jpg",
     "uri": "http://pixabay.com/en/cloud-sky-yellow-radius-sunshine-143152/",
     "license": "CC0 1.0"
   },
   {
     "comment": "No known copyright restrictions.",
-    "resource_path": "/com/endlessm/encyclopedia/assets/background-home.jpg",
+    "resource_path": "/com/endlessm/knowledge/images/background-home.jpg",
     "uri": "http://nos.twnsnd.co/post/86801471586/nansen-bushu-bankoku-shoka-no-zu",
     "license": "Public domain"
   },
   {
     "credit": "Vicki Burton",
     "credit_uri": "https://www.flickr.com/photos/vicki_burton/",
-    "resource_path": "/com/endlessm/encyclopedia/assets/background-home.jpg",
+    "resource_path": "/com/endlessm/knowledge/images/background-home.jpg",
     "uri": "https://www.flickr.com/photos/vicki_burton/9583958046",
     "license": "CC BY-SA 2.0"
   },
   {
     "credit": "Justin Jensen",
     "credit_uri": "https://www.flickr.com/photos/justinjensen/",
-    "resource_path": "/com/endlessm/encyclopedia/assets/background-home.jpg",
+    "resource_path": "/com/endlessm/knowledge/images/background-home.jpg",
     "uri": "https://www.flickr.com/photos/justinjensen/5321285316",
     "license": "CC BY 2.0"
   },
   {
     "credit": "Josch13",
     "credit_uri": "http://pixabay.com/en/users/Josch13-48777/",
-    "resource_path": "/com/endlessm/encyclopedia/assets/background-home.jpg",
+    "resource_path": "/com/endlessm/knowledge/images/background-home.jpg",
     "uri": "http://pixabay.com/en/journal-leaves-jack-fruit-leaf-299931/",
     "license": "CC0 1.0"
   },
   {
     "credit": "Josch13",
     "credit_uri": "http://pixabay.com/en/users/Josch13-48777",
-    "resource_path": "/com/endlessm/encyclopedia/assets/background-result.jpg",
+    "resource_path": "/com/endlessm/knowledge/images/background-result.jpg",
     "uri": "http://pixabay.com/en/journal-leaves-jack-fruit-leaf-299931/",
     "license": "CC0 1.0"
   },
   {
     "credit": "Matt Kieffer",
     "credit_uri": "https://www.flickr.com/photos/mattkieffer/",
-    "resource_path": "/com/endlessm/encyclopedia/assets/background-home.jpg",
+    "resource_path": "/com/endlessm/knowledge/images/background-home.jpg",
     "uri": "https://www.flickr.com/photos/mattkieffer/3625966781",
     "license": "CC BY-SA 2.0"
   },
   {
     "credit": "John Smith",
     "credit_uri": "https://www.flickr.com/photos/61287964@N00/",
-    "resource_path": "/com/endlessm/encyclopedia/assets/background-home.jpg",
+    "resource_path": "/com/endlessm/knowledge/images/background-home.jpg",
     "uri": "https://www.flickr.com/photos/61287964@N00/6083485009",
     "license": "CC BY 2.0"
   },
   {
     "comment": "No known copyright restrictions.",
-    "resource_path": "/com/endlessm/encyclopedia/assets/background-home.jpg",
+    "resource_path": "/com/endlessm/knowledge/images/background-home.jpg",
     "uri": "http://nos.twnsnd.co/post/87209061729/torus-construction",
     "license": "Public domain"
   },
   {
     "credit": "Anja Osenberg",
     "credit_uri": "http://pixabay.com/en/users/cocoparisienne-127419/",
-    "resource_path": "/com/endlessm/encyclopedia/assets/background-home.jpg",
+    "resource_path": "/com/endlessm/knowledge/images/background-home.jpg",
     "uri": "http://pixabay.com/en/elephant-skin-elephant-245071/",
     "license": "CC0 1.0"
   },
   {
     "credit": "Emmanuel DYAN",
     "credit_uri": "https://www.flickr.com/photos/emmanueldyan/",
-    "resource_path": "/com/endlessm/encyclopedia/assets/background-home.jpg",
+    "resource_path": "/com/endlessm/knowledge/images/background-home.jpg",
     "uri": "https://www.flickr.com/photos/emmanueldyan/4286675528",
     "license": "CC BY 2.0"
   },
   {
     "credit": "Giani Pralea",
     "credit_uri": "http://pixabay.com/en/users/giani-1202/",
-    "resource_path": "/com/endlessm/encyclopedia/assets/background-home.jpg",
+    "resource_path": "/com/endlessm/knowledge/images/background-home.jpg",
     "uri": "http://pixabay.com/en/sunset-birds-clouds-sky-colourfull-100367/",
     "license": "CC0 1.0"
   },
   {
     "credit": "Giani Pralea",
     "credit_uri": "http://pixabay.com/en/users/giani-1202/",
-    "resource_path": "/com/endlessm/encyclopedia/assets/background-result.jpg",
+    "resource_path": "/com/endlessm/knowledge/images/background-result.jpg",
     "uri": "http://pixabay.com/en/sunset-birds-clouds-sky-colourfull-100367/",
     "license": "CC0 1.0"
   },
   {
-    "resource_path": "/com/endlessm/encyclopedia/assets/background-home.jpg",
+    "resource_path": "/com/endlessm/knowledge/images/background-home.jpg",
     "uri": "http://commons.wikimedia.org/wiki/File:Sandro_Botticelli_-_La_nascita_di_Venere_-_Google_Art_Project_-_edited.jpg",
     "license": "Public domain"
   },
   {
     "credit": "Robert Ramsay",
     "credit_uri": "http://pixabay.com/en/users/RobertR-161173/",
-    "resource_path": "/com/endlessm/encyclopedia/assets/background-home.jpg",
+    "resource_path": "/com/endlessm/knowledge/images/background-home.jpg",
     "uri": "http://pixabay.com/en/druse-geode-gem-gemstone-284144/",
     "license": "CC0 1.0"
   },
   {
     "credit": "Robert Ramsay",
     "credit_uri": "http://pixabay.com/en/users/RobertR-161173/",
-    "resource_path": "/com/endlessm/encyclopedia/assets/background-result.jpg",
+    "resource_path": "/com/endlessm/knowledge/images/background-result.jpg",
     "uri": "http://pixabay.com/en/druse-geode-gem-gemstone-284144/",
     "license": "CC0 1.0"
   },
   {
     "credit": "185053",
     "credit_uri": "http://pixabay.com/en/users/185053-185053/",
-    "resource_path": "/com/endlessm/encyclopedia/assets/background-home.jpg",
+    "resource_path": "/com/endlessm/knowledge/images/background-home.jpg",
     "uri": "http://pixabay.com/en/moon-half-moon-light-silhouette-322222/",
     "license": "CC0 1.0"
   },
   {
     "credit": "185053",
     "credit_uri": "http://pixabay.com/en/users/185053-185053/",
-    "resource_path": "/com/endlessm/encyclopedia/assets/background-result.jpg",
+    "resource_path": "/com/endlessm/knowledge/images/background-result.jpg",
     "uri": "http://pixabay.com/en/moon-half-moon-light-silhouette-322222/",
     "license": "CC0 1.0"
   },
   {
-    "resource_path": "/com/endlessm/encyclopedia/assets/background-home.jpg",
+    "resource_path": "/com/endlessm/knowledge/images/background-home.jpg",
     "uri": "http://commons.wikimedia.org/wiki/File:Adam_Eva,_Durer,_1504.jpg",
     "license": "Public domain"
   },
   {
     "credit": "Hans Braxmeier",
     "credit_uri": "http://pixabay.com/en/users/Hans-2/",
-    "resource_path": "/com/endlessm/encyclopedia/assets/background-home.jpg",
+    "resource_path": "/com/endlessm/knowledge/images/background-home.jpg",
     "uri": "http://pixabay.com/en/snow-lane-traces-snow-zig-zag-81156/",
     "license": "CC0 1.0"
   },
   {
     "credit": "Josch13",
     "credit_uri": "http://pixabay.com/en/users/Josch13-48777/",
-    "resource_path": "/com/endlessm/encyclopedia/assets/background-home.jpg",
+    "resource_path": "/com/endlessm/knowledge/images/background-home.jpg",
     "uri": "http://pixabay.com/en/canthigaster-cicada-fulgoromorpha-278721/",
     "license": "CC0 1.0"
   },
   {
     "credit": "Kim Alaniz",
     "credit_uri": "https://www.flickr.com/photos/kimberlyeternal/",
-    "resource_path": "/com/endlessm/encyclopedia/assets/background-home.jpg",
+    "resource_path": "/com/endlessm/knowledge/images/background-home.jpg",
     "uri": "https://www.flickr.com/photos/kimberlyeternal/6377784239",
     "license": "CC BY 2.0"
   },
   {
     "credit": "NASA Goddard Space Flight Center",
     "credit_uri": "https://www.flickr.com/photos/gsfc/",
-    "resource_path": "/com/endlessm/encyclopedia/assets/background-home.jpg",
+    "resource_path": "/com/endlessm/knowledge/images/background-home.jpg",
     "uri": "https://www.flickr.com/photos/gsfc/5637802618/in/photostream/",
     "license": "CC BY 2.0"
   },
   {
     "credit": "Hans Braxmeier",
     "credit_uri": "http://pixabay.com/en/users/Hans-2/",
-    "resource_path": "/com/endlessm/encyclopedia/assets/background-home.jpg",
+    "resource_path": "/com/endlessm/knowledge/images/background-home.jpg",
     "uri": "http://pixabay.com/en/spices-spice-mix-colorful-curry-73770/",
     "license": "CC0 1.0"
   },
   {
-    "resource_path": "/com/endlessm/encyclopedia/assets/background-home.jpg",
+    "resource_path": "/com/endlessm/knowledge/images/background-home.jpg",
     "uri": "http://commons.wikimedia.org/wiki/File:Leonardo_da_Vinci_-_Annunciazione_-_Google_Art_Project.jpg",
     "license": "Public domain"
   },
   {
     "credit": "hexenkueche",
     "credit_uri": "http://pixabay.com/en/users/hexenkueche-8926/",
-    "resource_path": "/com/endlessm/encyclopedia/assets/background-home.jpg",
+    "resource_path": "/com/endlessm/knowledge/images/background-home.jpg",
     "uri": "http://pixabay.com/en/autumn-dahlias-flowers-flower-58882/",
     "license": "CC0 1.0"
   },
   {
     "credit": "PublicDomainPictures",
     "credit_uri": "http://pixabay.com/en/users/PublicDomainPictures-14/",
-    "resource_path": "/com/endlessm/encyclopedia/assets/background-home.jpg",
+    "resource_path": "/com/endlessm/knowledge/images/background-home.jpg",
     "uri": "http://pixabay.com/en/splashing-splash-aqua-water-rain-165192/",
     "license": "CC0 1.0"
   },
   {
     "credit": "Gerd Altmann",
     "credit_uri": "http://pixabay.com/en/users/geralt-9301/",
-    "resource_path": "/com/endlessm/encyclopedia/assets/background-home.jpg",
+    "resource_path": "/com/endlessm/knowledge/images/background-home.jpg",
     "uri": "http://pixabay.com/en/koli-bacteria-escherichia-coli-123081/",
     "license": "CC0 1.0"
   }


### PR DESCRIPTION
These were not updated when we moved the Encyclopedia app into the
knowledge library.

[endlessm/eos-sdk#3244]
