### PR TITLE
Remove licenses.js from list of files to translate

### DIFF
--- a/po/POTFILES.in
+++ b/po/POTFILES.in
@@ -9,7 +9,6 @@ js/app/encyclopedia/presenter.js
 js/app/encyclopedia/view.js
 js/app/homePageA.js
 js/app/lessonCard.js
-js/app/licenses.js
 js/app/noSearchResultsPage.js
 js/app/pdfCard.js
 js/app/presenter.js


### PR DESCRIPTION
Now that we use the SDK's API to serve license information, we do not need the
licenses utility in the knowledge lib, so this file has been removed an no longer
needs to be translated.

[endlessm/eos-sdk#3111]
