### PR TITLE
Always show 'show-more' button when we have >6 categories

### DIFF
--- a/js/app/homePageA.js
+++ b/js/app/homePageA.js
@@ -74,6 +74,8 @@ const HomePageA = new Lang.Class({
 
         this.parent(props);
 
+        this._got_extra_cards = false;
+
         this.get_style_context().add_class(StyleClasses.HOME_PAGE_A);
     },
 
@@ -90,7 +92,7 @@ const HomePageA = new Lang.Class({
     },
 
     _update_button_visibility: function () {
-        if (!this._card_container.all_visible && !this._animating && this.get_mapped()) {
+        if (this._got_extra_cards || (!this._card_container.all_visible && !this._animating && this.get_mapped())) {
             this._show_button();
         } else {
             this._hide_button();
@@ -138,7 +140,11 @@ const HomePageA = new Lang.Class({
             if (b.featured) sortVal++;
             return sortVal;
         });
+        if (sorted_cards.length > MAX_CARDS) {
+            this._got_extra_cards = true;
+        }
         sorted_cards.slice(0, MAX_CARDS).forEach((card) =>
             this._card_container.add(card));
+        this._update_button_visibility();
     }
 });


### PR DESCRIPTION
Previously we would only show the 'show-more' button
when the space container on the home page could
not show all its children. However, now we cap
the number of children we give to the space container
to 6, so it always thinks it can show all its children.
Hence the show-more categories button is never visible.
This fixes it by checking if we have extra categories
to show in pack_cards and setting a flag there
to show the button.

[endlessm/eos-sdk#3214]
