### PR TITLE
css: remove extra box-shadow

### DIFF
--- a/data/css/endless_knowledge.css
+++ b/data/css/endless_knowledge.css
@@ -63,8 +63,6 @@ EknWindow.show-no-search-results-page {
     background-color: white;
     /* FIXME: background-image: need "noise" asset at 2% opacity */
     transition: margin 250ms ease-in-out;
-    /* FIXME: box-shadow outset doesn't currently work in GTK */
-    box-shadow: 0px 0px 10px 0px alpha(black, 0.3);
 }
 
 .card-a:hover {


### PR DESCRIPTION
This used to be ignored by GTK, but now it's supported and we don't
really want that effect as-is.
Remove it for now.

[endlessm/eos-sdk#3223]
