### PR TITLE
css: do not style overshoot/undershoot in PDF view scrolled window

### DIFF
--- a/data/css/endless_knowledge.css
+++ b/data/css/endless_knowledge.css
@@ -585,6 +585,6 @@ scrollbars, style the GTK scrollbars to look slightly more like them */
     padding-right: 15px;
 }
 
-.pdf-view {
+.pdf-view:not(.overshoot):not(.undershoot) {
     background-image: url("../images/pdf-background.png");
 }


### PR DESCRIPTION
Same fix we had for the category list.

[endlessm/eos-sdk#3247]
