### PR TITLE
Synopsis label always uses markup

### DIFF
--- a/data/widgets/articleCard.ui
+++ b/data/widgets/articleCard.ui
@@ -44,6 +44,7 @@
             <property name="lines">8</property>
             <property name="xalign">0</property>
             <property name="yalign">0</property>
+            <property name="use_markup">True</property>
             <style>
               <class name="card-synopsis"/>
             </style>

--- a/data/widgets/cardA.ui
+++ b/data/widgets/cardA.ui
@@ -62,6 +62,7 @@
             <property name="ellipsize">end</property>
             <property name="max_width_chars">1</property>
             <property name="lines">8</property>
+            <property name="use_markup">True</property>
             <style>
               <class name="card-synopsis"/>
             </style>

--- a/js/app/interfaces/card.js
+++ b/js/app/interfaces/card.js
@@ -141,7 +141,7 @@ const Card = new Lang.Interface({
 
         if (this.synopsis_label) {
             this.title_label.no_show_all = true;
-            this.synopsis_label.label = this.model.synopsis;
+            this.synopsis_label.label = GLib.markup_escape_text(this.model.synopsis, -1);
             this.synopsis_label.visible = !!this.model.synopsis;
         }
 


### PR DESCRIPTION
We need to use markup on the article snippet
cards for styling reasons. To keep things
consistent, we here make sure that all
synopsis labels use markup and then escape
the model's synopsis text before adding to
to the synopsis label.

[endlessm/eos-sdk#3364]
