### PR TITLE
HistoryPresenter does not import Window

### DIFF
--- a/js/app/historyPresenter.js
+++ b/js/app/historyPresenter.js
@@ -2,7 +2,6 @@ const EosKnowledgePrivate = imports.gi.EosKnowledgePrivate;
 const GObject = imports.gi.GObject;
 
 const HistoryItem = imports.app.historyItem;
-const Window = imports.app.window;
 
 /**
  * Class: HistoryPresenter
@@ -50,9 +49,6 @@ const HistoryPresenter = new GObject.Class({
 
     _init: function (props={}) {
         props.history_model = props.history_model || new EosKnowledgePrivate.HistoryModel();
-        props.view = props.view || new Window.Window({
-            application: props.application,
-        });
 
         this.parent(props);
 


### PR DESCRIPTION
HistoryPresenter was mistakenly importing the knowledge app's Window class.
This is not actually necessary, since the view widget needs to be set
during construction of the HistoryPresenter object.

[endlessm/eos-sdk#3373]
