### PR TITLE
Pass Endless.TopbarNavButton into HistoryPresenter

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -420,6 +420,7 @@ EXTRA_DIST += \
 	tests/mockEngine.js \
 	tests/mockFactory.js \
 	tests/mockSearchBox.js \
+	tests/mockWidgets.js \
 	tests/utils.js \
 	tests/WidgetDescendantMatcher.js \
 	$(NULL)

--- a/js/app/historyPresenter.js
+++ b/js/app/historyPresenter.js
@@ -1,8 +1,8 @@
+const Endless = imports.gi.Endless;
 const EosKnowledgePrivate = imports.gi.EosKnowledgePrivate;
 const GObject = imports.gi.GObject;
 
 const HistoryItem = imports.app.historyItem;
-const Window = imports.app.window;
 
 /**
  * Class: HistoryPresenter
@@ -32,33 +32,31 @@ const HistoryPresenter = new GObject.Class({
             GObject.Object.$gtype),
 
         /**
-         * Property: view
-         * Knowledge app view
+         * Property: history_buttons
+         * History buttons that operate this presenter
          *
-         * Pass an instance of <Window> to this property.
-         * In particular, this view holds the history buttons that controls
-         * the history navigation.
+         * Pass an instance of <Endless.TopbarNavButton> to this property.
          *
          * Flags:
          *   Construct only
          */
-        'view': GObject.ParamSpec.object('view', 'View',
-            'Knowledge app view',
+        'history-buttons': GObject.ParamSpec.object('history-buttons',
+            'History buttons', 'History buttons in the view',
             GObject.ParamFlags.READWRITE | GObject.ParamFlags.CONSTRUCT_ONLY,
             GObject.Object.$gtype),
     },
 
     _init: function (props={}) {
         props.history_model = props.history_model || new EosKnowledgePrivate.HistoryModel();
-        props.view = props.view || new Window.Window({
-            application: props.application,
-        });
+        props.history_buttons = props.history_buttons || new Endless.TopbarNavButton();
 
         this.parent(props);
 
-        this.history_model.bind_property('can-go-forward', this.view.history_buttons.forward_button, 'sensitive',
+        this.history_model.bind_property('can-go-forward',
+            this.history_buttons.forward_button, 'sensitive',
             GObject.BindingFlags.SYNC_CREATE);
-        this.history_model.bind_property('can-go-back', this.view.history_buttons.back_button, 'sensitive',
+        this.history_model.bind_property('can-go-back',
+            this.history_buttons.back_button, 'sensitive',
             GObject.BindingFlags.SYNC_CREATE);
     },
 

--- a/js/app/presenter.js
+++ b/js/app/presenter.js
@@ -163,7 +163,7 @@ const Presenter = new Lang.Class({
         this._target_page_title = '';
         this._history_presenter = new HistoryPresenter.HistoryPresenter({
             history_model: new EosKnowledgePrivate.HistoryModel(),
-            view: this.view,
+            history_buttons: this.view.history_buttons,
         });
         this._add_history_object_for_home_page();
 

--- a/js/app/reader/presenter.js
+++ b/js/app/reader/presenter.js
@@ -211,7 +211,7 @@ const Presenter = new Lang.Class({
         this.history_model = new EosKnowledgePrivate.HistoryModel();
         this._history_presenter = new HistoryPresenter.HistoryPresenter({
             history_model: this.history_model,
-            view: this.view,
+            history_buttons: this.view.history_buttons,
         });
 
         this._style_knobs = app_json['styles'];

--- a/tests/js/app/reader/testReaderPresenter.js
+++ b/tests/js/app/reader/testReaderPresenter.js
@@ -12,6 +12,7 @@ const ArticleObjectModel = imports.search.articleObjectModel;
 const MockEngine = imports.tests.mockEngine;
 const MockFactory = imports.tests.mockFactory;
 const MockSearchBox = imports.tests.mockSearchBox;
+const MockWidgets = imports.tests.mockWidgets;
 const Presenter = imports.app.reader.presenter;
 const QueryObject = imports.search.queryObject;
 
@@ -75,18 +76,6 @@ const MockNavButtons = new Lang.Class({
     },
 });
 
-const MockButton = new Lang.Class({
-    Name: 'MockButton',
-    Extends: GObject.Object,
-    Properties: {
-        'sensitive': GObject.ParamSpec.boolean('sensitive', '', '',
-            GObject.ParamFlags.READWRITE, true),
-    },
-    Signals: {
-        'clicked': {},
-    },
-});
-
 let get_style_context = function () {
     return {
         add_class: function () {},
@@ -123,15 +112,11 @@ const MockView = new Lang.Class({
         this.nav_buttons = nav_buttons;
         this.search_box = new MockSearchBox.MockSearchBox();
         this.issue_nav_buttons = {
-            back_button: new MockButton(),
-            forward_button: new MockButton(),
+            back_button: new MockWidgets.MockButton(),
+            forward_button: new MockWidgets.MockButton(),
             show: jasmine.createSpy('show'),
         };
-        this.history_buttons = {
-            back_button: new MockButton(),
-            forward_button: new MockButton(),
-            show: jasmine.createSpy('show'),
-        };
+        this.history_buttons = new MockWidgets.MockHistoryButtons();
 
         this.done_page = {
             get_style_context: get_style_context,

--- a/tests/js/app/testHistoryPresenter.js
+++ b/tests/js/app/testHistoryPresenter.js
@@ -3,47 +3,18 @@ const GObject = imports.gi.GObject;
 const Lang = imports.lang;
 
 const HistoryPresenter = imports.app.historyPresenter;
-
-const MockButton = new Lang.Class({
-    Name: 'MockButton',
-    GTypeName: 'MockButton_TestHistoryPresenter',
-    Extends: GObject.Object,
-    Properties: {
-        'sensitive': GObject.ParamSpec.boolean('sensitive', '', '',
-            GObject.ParamFlags.READWRITE, true),
-    },
-    Signals: {
-        'clicked': {},
-    },
-});
-
-const MockView = new Lang.Class({
-    Name: 'MockView',
-    GTypeName: 'MockView_TestHistoryPresenter',
-    Extends: GObject.Object,
-
-    _init: function () {
-        this.parent();
-
-        this.history_buttons = {
-            back_button: new MockButton(),
-            forward_button: new MockButton(),
-        };
-    },
-});
+const MockWidgets = imports.tests.mockWidgets;
 
 describe('History Presenter', function () {
     let history_presenter;
     let history_model;
-    let view;
 
     beforeEach(function () {
-        view = new MockView();
         history_model = new EosKnowledgePrivate.HistoryModel();
 
         history_presenter = new HistoryPresenter.HistoryPresenter({
             history_model: history_model,
-            view: view,
+            history_buttons: new MockWidgets.MockHistoryButtons(),
         });
     });
 

--- a/tests/js/app/testPresenter.js
+++ b/tests/js/app/testPresenter.js
@@ -10,20 +10,12 @@ Utils.register_gresource();
 const MinimalCard = imports.tests.minimalCard;
 const MockEngine = imports.tests.mockEngine;
 const MockFactory = imports.tests.mockFactory;
+const MockWidgets = imports.tests.mockWidgets;
 const Presenter = imports.app.presenter;
 
 Gtk.init(null);
 
 const TEST_CONTENT_DIR = Utils.get_test_content_srcdir();
-
-const MockWidget = new Lang.Class({
-    Name: 'MockWidget',
-    Extends: GObject.Object,
-    Properties: {
-        'sensitive': GObject.ParamSpec.boolean('sensitive', '', '',
-            GObject.ParamFlags.READABLE | GObject.ParamFlags.WRITABLE, true),
-    },
-});
 
 const MockHomePage = new Lang.Class({
     Name: 'MockHomePage',
@@ -71,10 +63,7 @@ const MockView = new Lang.Class({
         this.lightbox = new GObject.Object();
         this.search_box = {};
         this.no_search_results_page = {};
-        this.history_buttons = {
-            forward_button: new MockWidget(),
-            back_button: new MockWidget(),
-        };
+        this.history_buttons = new MockWidgets.MockHistoryButtons();
     },
 
     connect: function (signal, handler) {

--- a/tests/mockWidgets.js
+++ b/tests/mockWidgets.js
@@ -1,0 +1,27 @@
+// Copyright 2015 Endless Mobile, Inc.
+
+const GObject = imports.gi.GObject;
+const Lang = imports.lang;
+
+const MockButton = new Lang.Class({
+    Name: 'MockButton',
+    Extends: GObject.Object,
+    Properties: {
+        'sensitive': GObject.ParamSpec.boolean('sensitive', '', '',
+            GObject.ParamFlags.READWRITE, true),
+    },
+    Signals: {
+        'clicked': {},
+    },
+});
+
+const MockHistoryButtons = new Lang.Class({
+    Name: 'MockHistoryButtons',
+    Extends: GObject.Object,
+
+    _init: function () {
+        this.parent();
+        this.back_button = new MockButton();
+        this.forward_button = new MockButton();
+    },
+});


### PR DESCRIPTION
The HistoryPresenter doesn't need access to the whole window; instead
give it just the history navigation buttons.

[endlessm/eos-sdk#3373]
