### PR TITLE
pdfCard no longer exists, so don't translate it

### DIFF
--- a/po/POTFILES.in
+++ b/po/POTFILES.in
@@ -2,7 +2,6 @@ eosknowledgeprivate/ekn-hello.c
 data/js/error_page.js
 data/js/no_results.js
 data/js/search_results.js
-data/widgets/pdfCard.ui
 data/widgets/readerCard.ui
 js/app/articleHTMLRenderer.js
 js/app/categoriesPage.js


### PR DESCRIPTION
We no longer have a pdfCard class, so its ui class had to be removed from the
list of files to translate.

[endlessm/eos-sdk#3378]
