### PR TITLE
Open all http/https URIs in a browser

### DIFF
--- a/js/app/compat/compat.js
+++ b/js/app/compat/compat.js
@@ -250,3 +250,11 @@ function create_v1_set_models(json, engine) {
         engine.add_runtime_object(id, model);
     });
 }
+
+// External links used to be prepended with 'browser-', this strips them off.
+function normalize_old_browser_urls (url) {
+    let scheme = GLib.uri_parse_scheme(uri);
+    if (scheme !== null && scheme.startsWith('browser-'))
+        uri = uri.slice('browser-'.length);
+    return uri;
+}

--- a/js/app/reader/presenter.js
+++ b/js/app/reader/presenter.js
@@ -13,6 +13,7 @@ const ArchiveNotice = imports.app.reader.archiveNotice;
 const ArticleHTMLRenderer = imports.app.articleHTMLRenderer;
 const ArticleObjectModel = imports.search.articleObjectModel;
 const ArticleSnippetCard = imports.app.modules.articleSnippetCard;
+const Compat = imports.app.compat;
 const Config = imports.app.config;
 const DonePage = imports.app.reader.donePage;
 const Engine = imports.search.engine;
@@ -705,11 +706,7 @@ const Presenter = new Lang.Class({
                 this._remove_link_tooltip();
                 return;
             }
-            let uri = hit_test.link_uri;
-            // This indicates that we open the link in an external viewer, but
-            // don't show it to the user.
-            if (uri.startsWith('browser-'))
-                uri = uri.slice('browser-'.length);
+            let uri = Compat.normalize_old_browser_urls(hit_test.link_uri);
             // Links to images within the database will open in a lightbox
             // instead. This is determined in the HTML by the eos-image-link
             // class, but we don't have access to that information here.


### PR DESCRIPTION
External links are no longer prefaced with 'browser-', so just rely on
the URI scheme.

[endlessm/eos-sdk#3294]
