### PR TITLE
Search results separator in Encyclopedia scales

### DIFF
--- a/data/css/endless_encyclopedia.css
+++ b/data/css/endless_encyclopedia.css
@@ -73,6 +73,12 @@ GtkEntry:selected {
     padding-bottom: 35px;
 }
 
+.separator {
+    background-image: url('resource:///com/endlessm/knowledge/images/separator.png');
+    background-size: 100%;
+    background-repeat: no-repeat;
+}
+
 /* FIXME: move oops block up to 1/3 of the vertical! */
 
 .search-results .oops {

--- a/data/widgets/searchModule.ui
+++ b/data/widgets/searchModule.ui
@@ -9,11 +9,11 @@
       <object class="GtkGrid" id="grid1">
         <property name="visible">True</property>
         <property name="can_focus">False</property>
-        <property name="halign">center</property>
+        <property name="halign">fill</property>
         <property name="margin_start">50</property>
         <property name="margin_end">50</property>
         <property name="margin_top">45</property>
-        <property name="hexpand">False</property>
+        <property name="hexpand">True</property>
         <property name="orientation">vertical</property>
         <property name="row_spacing">22</property>
         <child>
@@ -34,10 +34,11 @@
           </packing>
         </child>
         <child>
-          <object class="GtkImage" id="image1">
+          <object class="GtkFrame" id="separator">
             <property name="visible">True</property>
             <property name="can_focus">False</property>
-            <property name="resource">/com/endlessm/knowledge/images/separator.png</property>
+            <property name="hexpand">True</property>
+            <property name="vexpand">False</property>
             <style>
               <class name="separator"/>
             </style>

--- a/js/app/encyclopedia/contentPage.js
+++ b/js/app/encyclopedia/contentPage.js
@@ -160,7 +160,8 @@ const ContentPage = new Lang.Class({
         this._stack.add(this._search_module);
 
         let grid = new Gtk.Grid({
-            halign: Gtk.Align.CENTER,
+            halign: Gtk.Align.FILL,
+            hexpand: true,
             column_spacing: 150,
         });
         grid.attach(this._logo, 0, 0, 1, 1);


### PR DESCRIPTION
Instead of having the separator in the Search Module be a GtkImage that always
takes up the width of the image asset, we use a frame to let it be resized when
the window is resized as well.

[endlessm/eos-sdk#3379]
