### PR TITLE
window: override factory-name in module

### DIFF
--- a/js/app/modules/window.js
+++ b/js/app/modules/window.js
@@ -44,6 +44,7 @@ const Window = new Lang.Class({
 
     Properties: {
         'factory': GObject.ParamSpec.override('factory', Module.Module),
+        'factory-name': GObject.ParamSpec.override('factory-name', Module.Module),
         /**
          * Property: home-page
          *


### PR DESCRIPTION
Missed this while rebasing over changes to module interface
[endlessm/eos-sdk#3384]
