### PR TITLE
Increase version to stable 0.4 series

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -18,7 +18,7 @@ m4_define([_EKN_API_VERSION_MACRO], [0])
 # Minor and micro versions: increment micro version when making a release. Minor
 # version is even for a stable release and odd for a development release.
 # When making any release, if the API changes, set the interface age to 0.
-m4_define([_EKN_MINOR_VERSION_MACRO], [3])
+m4_define([_EKN_MINOR_VERSION_MACRO], [4])
 m4_define([_EKN_MICRO_VERSION_MACRO], [0])
 m4_define([_EKN_INTERFACE_AGE_MACRO], [0])
 


### PR DESCRIPTION
We're about to release EOS 2.4 and we added API in this release cycle, so
make this a new stable version.

[endlessm/eos-sdk#3398]
