### PR TITLE
sectionArticlePage: always hide forward nav button

### DIFF
--- a/js/app/modules/window.js
+++ b/js/app/modules/window.js
@@ -226,6 +226,7 @@ const Window = new Lang.Class({
             this._home_page = this.factory.create_named_module('home-page-template');
             this._section_article_page = new SectionArticlePage.SectionArticlePageB({
                 factory: this.factory,
+                forward_visible: false,
             });
             this._no_search_results_page = new NoSearchResultsPage.NoSearchResultsPageB();
         } else {
@@ -234,6 +235,7 @@ const Window = new Lang.Class({
             });
             this._section_article_page = new SectionArticlePage.SectionArticlePageA({
                 factory: this.factory,
+                forward_visible: false,
             });
             this._no_search_results_page = new NoSearchResultsPage.NoSearchResultsPageA();
             // Connection so that tab buttons are revealed after page transition

--- a/js/app/sectionArticlePage.js
+++ b/js/app/sectionArticlePage.js
@@ -94,7 +94,6 @@ const SectionArticlePageA = new Lang.Class({
     Extends: SectionArticlePage,
 
     _init: function (props={}) {
-        props.forward_visible = false;
         this.parent(props);
 
         this._section_page = new SectionPageA.SectionPageA({
@@ -164,7 +163,6 @@ const SectionArticlePageB = new Lang.Class({
     _init: function (props={}) {
         this.parent(props);
 
-        props.forward_visible = false;
         this._section_page = new SectionPageB.SectionPageB({
             factory: this.factory,
         });


### PR DESCRIPTION
We'd move a line changing the props object under this.parent()
somehow, but think its easier to just handle that in partent class
constructor
[endlessm/eos-sdk#3407]
