### PR TITLE
mediaCard: fix attribution orange glow

### DIFF
--- a/data/widgets/mediaCard.ui
+++ b/data/widgets/mediaCard.ui
@@ -4,7 +4,6 @@
   <requires lib="gtk+" version="3.12"/>
   <template class="EknMediaCard" parent="GtkFrame">
     <property name="visible">True</property>
-    <property name="sensitive">False</property>
     <property name="can_focus">False</property>
     <property name="label_xalign">0</property>
     <property name="shadow_type">none</property>
@@ -48,7 +47,7 @@
         <child>
           <object class="GtkButton" id="attribution-button">
             <property name="visible">True</property>
-            <property name="can_focus">True</property>
+            <property name="can_focus">False</property>
             <property name="receives_default">False</property>
             <child>
               <object class="GtkLabel" id="attribution-label">
@@ -58,11 +57,11 @@
                 <property name="wrap">True</property>
                 <property name="wrap_mode">word-char</property>
                 <property name="xalign">0</property>
-                <style>
-                  <class name="media-card-attribution-text"/>
-                </style>
               </object>
             </child>
+            <style>
+              <class name="media-card-attribution-text"/>
+            </style>
           </object>
           <packing>
             <property name="left_attach">0</property>


### PR DESCRIPTION
We made the whole card insenstive by accident and were applying
a style class to the wrong widget. With those fixed we have the
orange glow again. Why we have a hover state on a button that's
not clickable, I don't know...
[endlessm/eos-sdk#3410]
