### PR TITLE
presenter: don't double load results when paginating

### DIFF
--- a/js/app/presenter.js
+++ b/js/app/presenter.js
@@ -297,6 +297,10 @@ const Presenter = new Lang.Class({
             }
             this._get_more_results_query = get_more_results_query;
         });
+        // Null the query we just sent to the engine, when results come back
+        // we'll have a new more results query. But this keeps us from double
+        // loading this query.
+        this._get_more_results_query = null;
     },
 
     _on_topbar_back_clicked: function () {


### PR DESCRIPTION
Not exactly sure why, but the infinite scrolled window is sending
us a lot of 'needs-more-results' queries in quick succession. The
infinite scroll signaling code has always been kinda hairy, so maybe
that broke with new gtk?

Regardless, we need to make sure in the presenter we don't double
load the same "page" in our paginated content.
[endlessm/eos-sdk#3411]
