### PR TITLE
Labels on Reader Cards accept markup

### DIFF
--- a/data/widgets/readerCard.ui
+++ b/data/widgets/readerCard.ui
@@ -109,6 +109,7 @@
                         <property name="can_focus">False</property>
                         <property name="hexpand">False</property>
                         <property name="vexpand">False</property>
+                        <property name="use_markup">True</property>
                         <property name="label" translatable="yes">Archive</property>
                         <style>
                           <class name="card-info-title"/>


### PR DESCRIPTION
The labels on the Reader Cards should accept markup, since we set the page
number in the hover state to be bold.

[endlessm/eos-sdk#3416]
