### PR TITLE
contentPage: set background color on stack

### DIFF
--- a/data/css/endless_encyclopedia.css
+++ b/data/css/endless_encyclopedia.css
@@ -10,6 +10,10 @@ Gjs_SearchBox{
     padding: 15px 0 15px 30px;
 }
 
+.content-stack {
+    background-color: #e9e4de;
+}
+
 .entry {
     background: rgba(0,0,0,0.2);
     padding: 0.5em .3em 0.5em .3em;
@@ -59,7 +63,6 @@ GtkEntry:selected {
 
 .search-results {
     color: #464646;
-    background-color: #e9e4de;
 }
 
 .search-results .headline {

--- a/js/app/encyclopedia/contentPage.js
+++ b/js/app/encyclopedia/contentPage.js
@@ -154,6 +154,7 @@ const ContentPage = new Lang.Class({
         // FIXME: this should be on a separate page, instead of all stuffed
         // into a ContentPage
         this._stack = new Gtk.Stack();
+        this._stack.get_style_context().add_class('content-stack');
         this._stack.add(this._search_module);
 
         let grid = new Gtk.Grid({


### PR DESCRIPTION
Instead of on the search results widget inside the stack.

If our webviews come in not rendered, this will keep some
visual continuity while transitioning.
[endlessm/eos-sdk#3380]
