### PR TITLE
Increase margins when resolution is < 1366px

### DIFF
--- a/js/app/reader/overviewPage.js
+++ b/js/app/reader/overviewPage.js
@@ -16,7 +16,7 @@ const _LOGO_LEFT_MARGIN = 75;
 const _SUBTITLE_LEFT_MARGIN = 125;
 const _FRAME_RIGHT_MARGIN = 100;
 const _PAGE_WIDTH_THRESHOLD = 1366;
-const _EXTRA_MARGIN = 50;
+const _MARGIN_DIFF = 50;
 const _MAX_FRAME_WIDTH = 576;
 
 /**
@@ -108,23 +108,23 @@ const OverviewPage = new Lang.Class({
         this.get_style_context().add_class(StyleClasses.READER_OVERVIEW_PAGE);
         this._subtitle_label.get_style_context().add_class(StyleClasses.READER_APP_SUBTITLE);
 
+        grid.connect('size-allocate', (grid, alloc) => {
+            if (alloc.width >= _PAGE_WIDTH_THRESHOLD) {
+                this._app_banner.margin_start = _LOGO_LEFT_MARGIN;
+                this._subtitle_label.margin_start = _SUBTITLE_LEFT_MARGIN;
+                this._snippets_grid.margin_end = _FRAME_RIGHT_MARGIN;
+            } else {
+                this._app_banner.margin_start = _LOGO_LEFT_MARGIN - _MARGIN_DIFF;
+                this._subtitle_label.margin_start = _SUBTITLE_LEFT_MARGIN - _MARGIN_DIFF;
+                this._snippets_grid.margin_end = _FRAME_RIGHT_MARGIN - _MARGIN_DIFF;
+            }
+        });
+
         grid.attach(this._app_banner, 0, 0, 1, 1);
         grid.attach(this._subtitle_label, 0, 1, 1, 1);
         grid.attach(snippets_frame, 1, 0, 1, 2);
 
-        let margin_container = new FlexMarginContainer({
-            width_threshold: _PAGE_WIDTH_THRESHOLD,
-            extra_margin: _EXTRA_MARGIN,
-        });
-        margin_container.set_margin_start_children([
-            this._app_banner,
-            this._subtitle_label,
-        ]);
-        margin_container.set_margin_end_children([
-            this._snippets_grid,
-        ]);
-        margin_container.add(grid);
-        this.add(margin_container);
+        this.add(grid);
     },
 
     get background_image_uri () {
@@ -178,64 +178,6 @@ function get_css_for_module (css_data) {
     let module_data = Utils.get_css_for_submodule('module', css_data);
     return Utils.object_to_css_string(module_data, '.overview-frame');
 }
-
-/**
- * Class: FlexMarginContainer
- *
- * A custom container that adjusts the horizontal margin of its identified
- * children when the width threshold is crossed.
- */
-const FlexMarginContainer = new Lang.Class({
-    Name: 'FlexMarginContainer',
-    GTypeName: 'EknFlexMarginContainer',
-    Extends: Gtk.Bin,
-    Properties: {
-        'width-threshold': GObject.ParamSpec.uint('width-threshold', 'Width Threshold',
-            'Threshold at which the container\'s width should switch from natural margin to minimum margin',
-            GObject.ParamFlags.READWRITE | GObject.ParamFlags.CONSTRUCT_ONLY,
-            0, GLib.MAXUINT32, GLib.MAXUINT32),
-        'extra-margin': GObject.ParamSpec.uint('extra-margin', 'Extra margin',
-            'Additional margin to alter identified children when width threshold is crossed',
-            GObject.ParamFlags.READWRITE | GObject.ParamFlags.CONSTRUCT_ONLY,
-            0, GLib.MAXUINT32, 0),
-    },
-
-    _init: function (props={}) {
-        this.parent(props);
-
-        this._width_crossed_threshold = false;
-    },
-
-    set_margin_start_children: function (children) {
-        this._margin_start_children = children;
-    },
-
-    set_margin_end_children: function (children) {
-        this._margin_end_children = children;
-    },
-
-    _adjust_margins: function (factor) {
-        this._margin_start_children.forEach((child) => {
-            child.margin_start += factor;
-        });
-
-        this._margin_end_children.forEach((child) => {
-            child.margin_end += factor;
-        });
-    },
-
-    vfunc_size_allocate: function (allocation) {
-        if (allocation.width < this.width_threshold && !this._width_crossed_threshold) {
-            this._width_crossed_threshold = true;
-            this._adjust_margins(-1 * this.extra_margin);
-        } else if (allocation.width >= this.width_threshold && this._width_crossed_threshold) {
-            this._width_crossed_threshold = false;
-            this._adjust_margins(this.extra_margin);
-        }
-
-        this.parent(allocation);
-    },
-});
 
 /**
  * Class: MaxWidthFrame


### PR DESCRIPTION
As per Design, if screen width is less than 1366px, we should reduce the margin
on widgets in the Overview page.

[endlessm/eos-sdk#2986]
