### PR TITLE
Scrollbar styling only applies to EosWindow

### DIFF
--- a/data/css/endless_knowledge.css
+++ b/data/css/endless_knowledge.css
@@ -474,12 +474,12 @@ EknWindow.show-no-search-results-page {
 
 /* FIXME: for the time being, until we can properly customize the webkit
 scrollbars, style the GTK scrollbars to look slightly more like them */
-.scrollbar {
+EosWindow .scrollbar {
     -GtkRange-trough-border: 3px;
     -GtkRange-slider-width: 8px;
 }
 
-.scrollbar.slider {
+EosWindow .scrollbar.slider {
     background-color: #333333;
     border-radius: 20px;
 }


### PR DESCRIPTION
We style the GTK scrollbars to look more like the WebKit scrollbars
because we can't style the WebKit scrollbars currently, but it makes the
credits dialog look weird; this code makes the scrollbar styling apply
only to scrollbars inside EosWindow, so that the image credits dialog just
uses the regular GTK scrollbars.
[endlessm/eos-sdk#3443]
