### PR TITLE
Move kermit source to js dir, support 'query' command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@
 /js/app/config.js
 /js/app/config.js.in
 /ekn-app-runner
+/kermit
 /ekn-search-provider
 /eos-encyclopedia
 /data/com.endlessm.EknSearchProvider.service

--- a/Makefile.am
+++ b/Makefile.am
@@ -16,7 +16,6 @@ ACLOCAL_AMFLAGS = -I m4
 
 # Forward declare variables we'll be modifying all over
 bin_SCRIPTS =
-dist_bin_SCRIPTS =
 CLEANFILES =
 dist_noinst_DATA =
 DISTCLEANFILES =
@@ -295,6 +294,7 @@ js_files = \
 	js/search/searchProvider.js \
 	js/search/treeNode.js \
 	js/search/utils.js \
+	js/tools/kermit.js \
 	$(NULL)
 
 jsdir = $(pkgdatadir)/js
@@ -323,6 +323,7 @@ subst_files = \
 	js/app/config.js \
 	ekn-search-provider \
 	ekn-app-runner \
+	kermit \
 	eos-encyclopedia \
 	$(NULL)
 
@@ -333,13 +334,10 @@ $(subst_files): %: %.in Makefile
 CLEANFILES += $(subst_files)
 EXTRA_DIST += $(patsubst %,%.in,$(subst_files))
 
-dist_bin_SCRIPTS += \
-	tools/kermit \
-	$(NULL)
-
 bin_SCRIPTS += \
 	ekn-search-provider \
 	ekn-app-runner \
+	kermit \
 	eos-encyclopedia \
 	$(NULL)
 

--- a/js/tools/kermit.js
+++ b/js/tools/kermit.js
@@ -1,11 +1,13 @@
-#!/usr/bin/gjs
-const Gio = imports.gi.Gio;
+const Engine = imports.search.engine;
 const EosShard = imports.gi.EosShard;
+const Gio = imports.gi.Gio;
+const QueryObject = imports.search.queryObject;
 const System = imports.system;
 
 const USAGE = [
     'usage: kermit grep <shard path> <pattern>',
     '       kermit dump <shard path> <ekn id> [data|metadata]',
+    '       kermit query <domain> "<querystring>"',
     '',
     'kermit is a shard inspection utility for Knowledge Apps.',
 ].join('\n');
@@ -13,19 +15,27 @@ const USAGE = [
 // For those interested in kermit's etymology, it goes roughly like this:
 // EosShard -> Dark Shard -> Dark Crystal -> Jim Hensen -> Kermit
 
+// size of xapian-bridge result batches
+const BATCH_SIZE = 10;
+
 switch (ARGV[0]) {
-case 'grep':
-    if (ARGV.length === 3) {
-        grep(ARGV[1], ARGV[2]);
-        break;
-    }
-case 'dump':
-    if (ARGV.length === 4) {
-        dump(ARGV[1], ARGV[2], ARGV[3]);
-        break;
-    }
-default:
-    fail_with_message(USAGE);
+    case 'grep':
+        if (ARGV.length === 3) {
+            grep(ARGV[1], ARGV[2]);
+            break;
+        }
+    case 'dump':
+        if (ARGV.length === 4) {
+            dump(ARGV[1], ARGV[2], ARGV[3]);
+            break;
+        }
+    case 'query':
+        if (ARGV.length === 3) {
+            query(ARGV[1], ARGV[2]);
+            break;
+        }
+    default:
+        fail_with_message(USAGE);
 }
 
 function grep (path, pattern) {
@@ -36,14 +46,10 @@ function grep (path, pattern) {
         let metadata_text = record.metadata.load_contents().get_data().toString();
 
         if (metadata_text.match(regex) !== null) {
+            let id = record.get_hex_name();
+            let content_type = record.data.get_content_type();
             let title = JSON.parse(metadata_text).title;
-            let output = [
-                record.get_hex_name(),
-                record.data.get_content_type(),
-                // use JSON.stringify to escape title and wrap in quotes
-                JSON.stringify(title),
-            ].join(' - ');
-            print(output);
+            print_result(id, content_type, title);
         }
 
         // Unfortunately, Spidermonkey isn't able to effectively track the
@@ -52,6 +58,51 @@ function grep (path, pattern) {
         if (i%1000 === 0)
             imports.system.gc();
     });
+}
+
+function query (domain, query_string) {
+    let engine = new Engine.Engine();
+    let query_obj = new QueryObject.QueryObject({
+        query: query_string,
+        limit: BATCH_SIZE,
+        domain: domain,
+    });
+    perform_query(engine, query_obj);
+
+    // run the mainloop so we don't exit before our callback fires
+    imports.mainloop.run();
+}
+
+function perform_query (engine, query_obj) {
+    engine.get_objects_by_query(query_obj, null, (engine, task) => {
+        try {
+            let [results, more_results] = engine.get_objects_by_query_finish(task);
+            results.forEach(function (result) {
+                let id = result.ekn_id.split('/').pop();
+                print_result(id, result.content_type, result.title);
+            });
+
+            // if there were fewer than the requested number of results, that
+            // means we're done.
+            if (results.length < BATCH_SIZE) {
+                System.exit(0);
+            } else {
+                perform_query(engine, more_results);
+            }
+        } catch (e) {
+            fail_with_message(e);
+        }
+    });
+}
+
+function print_result (id, content_type, title) {
+    let output = [
+        id,
+        content_type,
+        // use JSON.stringify to escape title and wrap in quotes
+        JSON.stringify(title),
+    ].join(' - ');
+    print(output);
 }
 
 function dump (path, id, data_or_meta) {

--- a/kermit.in
+++ b/kermit.in
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+export GJS_PATH="%jsdir%${GJS_PATH:+:$GJS_PATH}"
+export GI_TYPELIB_PATH="%typelibdir%${GI_TYPELIB_PATH:+:$GI_TYPELIB_PATH}"
+export LD_LIBRARY_PATH="%pkglibdir%${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
+
+if [ "$GJS_DEBUG_OUTPUT" == "" ]; then
+    export GJS_DEBUG_OUTPUT=stderr
+fi
+
+if [ "$GJS_DEBUG_TOPICS" == "" ]; then
+    export GJS_DEBUG_TOPICS="JS ERROR;JS LOG"
+fi
+
+DEBUG_COMMAND=""
+if [ "$RUN_DEBUG" != "" ]; then
+    DEBUG_COMMAND="gdb --args"
+fi
+
+exec $DEBUG_COMMAND gjs %jsdir%/tools/kermit.js $@


### PR DESCRIPTION
Now supports `kermit query <domain> <querystring>`, which will emulate a
user query from within a knowledge app. Results are printed in the same
fashion as `kermit grep`, for easy inspection of result metadata/data.

[endlessm/eos-sdk#3499]
