### PR TITLE
Add carousel arrangement

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -242,6 +242,7 @@ js_files = \
 	js/app/modules/knowledgeDocumentCard.js \
 	js/app/modules/homePageBTemplate.js \
 	js/app/modules/listArrangement.js \
+	js/app/modules/carouselArrangement.js \
 	js/app/modules/mediaCard.js \
 	js/app/modules/readerCard.js \
 	js/app/modules/readerDocumentCard.js \
@@ -359,6 +360,7 @@ javascript_tests = \
 	tests/js/app/modules/testBackCover.js \
 	tests/js/app/modules/testCardA.js \
 	tests/js/app/modules/testCardB.js \
+	tests/js/app/modules/testCarouselArrangement.js \
 	tests/js/app/modules/testKnowledgeDocumentCard.js \
 	tests/js/app/modules/testHomePageBTemplate.js \
 	tests/js/app/modules/testListArrangement.js \

--- a/js/app/compat/compat.js
+++ b/js/app/compat/compat.js
@@ -211,6 +211,9 @@ function transform_v1_description(json) {
         modules['top-bar-search'] = {
             type: 'SearchBox',
         };
+        modules['document-arrangement'] = {
+            type: 'CarouselArrangement',
+        };
         modules['home-card'] = {
             type: 'ArticleSnippetCard',
         };

--- a/js/app/modules/carouselArrangement.js
+++ b/js/app/modules/carouselArrangement.js
@@ -1,0 +1,40 @@
+// Copyright 2015 Endless Mobile, Inc.
+
+/* exported CarouselArrangement */
+
+const GObject = imports.gi.GObject;
+const Gtk = imports.gi.Gtk;
+const Lang = imports.lang;
+
+const Arrangement = imports.app.interfaces.arrangement;
+const Module = imports.app.interfaces.module;
+
+const CarouselArrangement = new Lang.Class({
+    Name: 'CarouselArrangement',
+    GTypeName: 'EknCarouselArrangement',
+    Extends: Gtk.Stack,
+    Implements: [ Module.Module, Arrangement.Arrangement ],
+
+    Properties: {
+        'count': GObject.ParamSpec.override('count', Arrangement.Arrangement),
+        'factory': GObject.ParamSpec.override('factory', Module.Module),
+        'factory-name': GObject.ParamSpec.override('factory-name', Module.Module),
+    },
+
+    _init: function (props={}) {
+        this.parent(props);
+    },
+
+    get count() {
+        return this.get_children().length;
+    },
+
+    add_card: function (widget) {
+        this.add(widget);
+    },
+
+    clear: function () {
+        let children = this.get_children();
+        children.forEach((child) => this.remove(child));
+    },
+});

--- a/tests/js/app/modules/testCarouselArrangement.js
+++ b/tests/js/app/modules/testCarouselArrangement.js
@@ -1,0 +1,49 @@
+const Gtk = imports.gi.Gtk;
+
+const Utils = imports.tests.utils;
+Utils.register_gresource();
+
+const ContentObjectModel = imports.search.contentObjectModel;
+const CarouselArrangement = imports.app.modules.carouselArrangement;
+const Minimal = imports.tests.minimal;
+const WidgetDescendantMatcher = imports.tests.WidgetDescendantMatcher;
+
+Gtk.init(null);
+
+describe('List arrangement', function () {
+    let arrangement, cards;
+
+    beforeEach(function () {
+        jasmine.addMatchers(WidgetDescendantMatcher.customMatchers);
+        arrangement = new CarouselArrangement.CarouselArrangement();
+        cards = [];
+    });
+
+    it('constructs', function () {
+        expect(arrangement).toBeDefined();
+    });
+
+    function add_cards(ncards) {
+        for (let ix = 0; ix < ncards; ix++)
+            cards.push(new Minimal.MinimalCard({
+                model: new ContentObjectModel.ContentObjectModel(),
+            }));
+        cards.forEach(arrangement.add_card, arrangement);
+        Utils.update_gui();
+    }
+
+    it('adds cards to the carousel', function () {
+        add_cards(3);
+        cards.forEach((card) => expect(arrangement).toHaveDescendant(card));
+        expect(arrangement.count).toBe(3);
+    });
+
+    it('removes cards from the carousel', function () {
+        add_cards(3);
+        arrangement.clear();
+        Utils.update_gui();
+
+        cards.forEach((card) => expect(arrangement).not.toHaveDescendant(card));
+        expect(arrangement.count).toBe(0);
+    });
+});

--- a/tests/js/app/modules/testReaderWindow.js
+++ b/tests/js/app/modules/testReaderWindow.js
@@ -40,6 +40,7 @@ describe('Window widget', function () {
         factory = new MockFactory.MockFactory();
         factory.add_named_mock('document-card', Minimal.MinimalDocumentCard);
         factory.add_named_mock('back-cover', Minimal.MinimalBackCover);
+        factory.add_named_mock('document-arrangement', Minimal.MinimalArrangement);
         view = new ReaderWindow.ReaderWindow({
             application: app,
             factory: factory,

--- a/tests/minimal.js
+++ b/tests/minimal.js
@@ -2,6 +2,7 @@
 
 /* exported MinimalArrangement, MinimalCard, MinimalModule, MinimalDocumentCard */
 
+const GLib = imports.gi.GLib;
 const GObject = imports.gi.GObject;
 const Gtk = imports.gi.Gtk;
 const Lang = imports.lang;
@@ -21,6 +22,9 @@ const MinimalArrangement = new Lang.Class({
         'count': GObject.ParamSpec.override('count', Arrangement.Arrangement),
         'factory': GObject.ParamSpec.override('factory', Module.Module),
         'factory-name': GObject.ParamSpec.override('factory-name', Module.Module),
+        'transition-duration': GObject.ParamSpec.uint('transition-duration', '', '',
+            GObject.ParamFlags.READWRITE | GObject.ParamFlags.CONSTRUCT,
+            0, GLib.MAXUINT32, 1),
     },
 
     _init: function (props={}) {
@@ -38,6 +42,22 @@ const MinimalArrangement = new Lang.Class({
 
     clear: function () {
         this._count = 0;
+    },
+
+    set_transition_type: function (type) {
+        this._type = type;
+    },
+
+    get_transition_type: function () {
+        return this._type;
+    },
+
+    set_visible_child: function (child) {
+        this._child = child;
+    },
+
+    get_visible_child: function () {
+        return this._child;
     },
 });
 


### PR DESCRIPTION
This adds an arrangement for document
cards, which show an article's full body
content. It is implemented as a Gtk.Stack
where only one document card is visible at
a time.
Currently, only the reader app uses this
arrangement. This commit refactors its
view to use the arrangement in its main
stack, which retains ownership over
the overview, done, and search results
page.

[endlessm/eos-sdk#3523]
