### PR TITLE
Merge app subtitle into AppBanner module

### DIFF
--- a/data/widgets/appBanner.ui
+++ b/data/widgets/appBanner.ui
@@ -2,9 +2,30 @@
 <!-- Generated with glade 3.18.3 -->
 <interface>
   <requires lib="gtk+" version="3.12"/>
-  <template class="EknAppBanner" parent="EknImagePreviewer">
+  <template class="EknAppBanner" parent="GtkGrid">
     <property name="visible">True</property>
     <property name="can_focus">False</property>
+    <child>
+      <object class="GtkLabel" id="subtitle-label">
+        <property name="visible">True</property>
+        <property name="can_focus">False</property>
+        <property name="halign">start</property>
+        <property name="valign">start</property>
+        <property name="margin_start">50</property>
+        <property name="vexpand">True</property>
+        <property name="use_markup">True</property>
+        <style>
+          <class name="subtitle"/>
+        </style>
+      </object>
+      <packing>
+        <property name="left_attach">0</property>
+        <property name="top_attach">1</property>
+      </packing>
+    </child>
+    <child>
+      <placeholder/>
+    </child>
     <style>
       <class name="app-banner"/>
     </style>

--- a/js/app/compat/compat.js
+++ b/js/app/compat/compat.js
@@ -281,7 +281,6 @@ function transform_v1_description(json) {
             type: 'ReaderWindow',
             properties: {
                 'title': json['appTitle'],
-                'subtitle': json['appSubtitle'],
                 'title-image-uri': json['titleImageURI'],
                 'home-background-uri': json['backgroundHomeURI'],
             },
@@ -290,6 +289,8 @@ function transform_v1_description(json) {
             type: 'AppBanner',
             properties: {
                 'image-uri': json['titleImageURI'],
+                'subtitle': json['appSubtitle'],
+                'subtitle-capitalization': EosKnowledgePrivate.TextTransform.UPPERCASE,
             },
         };
         modules['back-cover'] = {

--- a/js/app/modules/readerWindow.js
+++ b/js/app/modules/readerWindow.js
@@ -145,13 +145,6 @@ const ReaderWindow = new Lang.Class({
             GObject.ParamFlags.READABLE,
             Endless.SearchBox),
         /**
-         * Property: subtitle
-         * A subtitle for the application. Defaults to an empty string.
-         */
-        'subtitle': GObject.ParamSpec.string('subtitle', 'App subtitle',
-            'A subtitle for the app',
-            GObject.ParamFlags.READWRITE | GObject.ParamFlags.CONSTRUCT_ONLY, ''),
-        /**
          * Property: home-background-uri
          * URI of the home page background
          */
@@ -183,7 +176,6 @@ const ReaderWindow = new Lang.Class({
 
         this.overview_page = new OverviewPage.OverviewPage({
             factory: this.factory,
-            subtitle: this.subtitle,
             background_image_uri: this.home_background_uri,
         });
         this.back_cover = this.factory.create_named_module('back-cover');

--- a/js/app/reader/overviewPage.js
+++ b/js/app/reader/overviewPage.js
@@ -13,7 +13,6 @@ GObject.ParamFlags.READWRITE = GObject.ParamFlags.READABLE | GObject.ParamFlags.
 
 const _LOGO_TOP_MARGIN = 50;
 const _LOGO_LEFT_MARGIN = 75;
-const _SUBTITLE_LEFT_MARGIN = 125;
 const _FRAME_RIGHT_MARGIN = 100;
 const _PAGE_WIDTH_THRESHOLD = 1366;
 const _MARGIN_DIFF = 50;
@@ -43,14 +42,6 @@ const OverviewPage = new Lang.Class({
             GObject.Object.$gtype),
 
         /**
-         * Property: subtitle
-         * A subtitle for the application. Defaults to an empty string.
-         */
-        'subtitle': GObject.ParamSpec.string('subtitle', 'App subtitle',
-            'A subtitle for the app',
-            GObject.ParamFlags.READWRITE, ''),
-
-        /**
          * Property: background-image-uri
          *
          * The background image uri for this page.
@@ -64,16 +55,6 @@ const OverviewPage = new Lang.Class({
     _init: function (props) {
         props = props || {};
         props.hexpand = true;
-
-        this._subtitle_label = new Gtk.Label({
-            halign: Gtk.Align.START,
-            vexpand: true,
-            valign: Gtk.Align.START,
-            use_markup: true,
-            // FIXME: This looks reasonable until we get better instructions
-            // from design.
-            margin_start: _SUBTITLE_LEFT_MARGIN,
-        });
 
         this.parent(props);
 
@@ -106,23 +87,19 @@ const OverviewPage = new Lang.Class({
         snippets_frame.add(this._snippets_grid);
 
         this.get_style_context().add_class(StyleClasses.READER_OVERVIEW_PAGE);
-        this._subtitle_label.get_style_context().add_class(StyleClasses.READER_SUBTITLE);
 
         grid.connect('size-allocate', (grid, alloc) => {
             if (alloc.width >= _PAGE_WIDTH_THRESHOLD) {
                 this._app_banner.margin_start = _LOGO_LEFT_MARGIN;
-                this._subtitle_label.margin_start = _SUBTITLE_LEFT_MARGIN;
                 this._snippets_grid.margin_end = _FRAME_RIGHT_MARGIN;
             } else {
                 this._app_banner.margin_start = _LOGO_LEFT_MARGIN - _MARGIN_DIFF;
-                this._subtitle_label.margin_start = _SUBTITLE_LEFT_MARGIN - _MARGIN_DIFF;
                 this._snippets_grid.margin_end = _FRAME_RIGHT_MARGIN - _MARGIN_DIFF;
             }
         });
 
         grid.attach(this._app_banner, 0, 0, 1, 1);
-        grid.attach(this._subtitle_label, 0, 1, 1, 1);
-        grid.attach(snippets_frame, 1, 0, 1, 2);
+        grid.attach(snippets_frame, 1, 0, 1, 1);
 
         this.add(grid);
     },
@@ -142,23 +119,6 @@ const OverviewPage = new Lang.Class({
             let context = this.get_style_context();
             context.add_provider(provider, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION);
         }
-    },
-
-    set subtitle (v) {
-        if (this._subtitle_label_text === v)
-            return;
-        this._subtitle_label_text = v;
-        /* 758 = 0.74 px * 1024 Pango units / px */
-        this._subtitle_label.label = ('<span letter_spacing="758">' +
-            GLib.markup_escape_text(this._subtitle_label_text.toLocaleUpperCase(), -1) + '</span>');
-        this._subtitle_label.visible = (v && v.length !== 0);
-        this.notify('subtitle');
-    },
-
-    get subtitle () {
-        if (this._subtitle_label_text)
-            return this._subtitle_label_text;
-        return '';
     },
 
     set_article_snippets: function (snippets) {

--- a/js/app/styleClasses.js
+++ b/js/app/styleClasses.js
@@ -402,11 +402,10 @@ const READER_OVERVIEW_FRAME = 'overview-frame';
 const READER_ARTICLE_SNIPPET = 'article-snippet';
 
 /**
- * Constant: READER_SUBTITLE
- *
- * Matches app subtitle labels across Reader apps.
+ * Constant: SUBTITLE
+ * Matches subtitle labels.
  */
-const READER_SUBTITLE = 'subtitle';
+const SUBTITLE = 'subtitle';
 
 /**
  * Constant: READER_TITLE

--- a/js/app/utils.js
+++ b/js/app/utils.js
@@ -88,7 +88,7 @@ function format_capitals (string, text_transform) {
     case EosKnowledgePrivate.TextTransform.NONE:
         return string;
     case EosKnowledgePrivate.TextTransform.UPPERCASE:
-        return string.toUpperCase();
+        return string.toLocaleUpperCase();
     }
     throw new RangeError('Not a supported value of TextTransform');
 }

--- a/tests/js/app/modules/testAppBanner.js
+++ b/tests/js/app/modules/testAppBanner.js
@@ -7,6 +7,8 @@ const Utils = imports.tests.utils;
 Utils.register_gresource();
 
 const AppBanner = imports.app.modules.appBanner;
+const CssClassMatcher = imports.tests.CssClassMatcher;
+const StyleClasses = imports.app.styleClasses;
 
 Gtk.init(null);
 
@@ -17,10 +19,27 @@ describe('App banner module', function () {
     let pig_uri = Gio.File.new_for_path(TEST_CONTENT_DIR).get_child('pig1.jpg').get_uri();
 
     beforeEach(function () {
+        jasmine.addMatchers(CssClassMatcher.customMatchers);
+
         app_banner = new AppBanner.AppBanner({
             image_uri: pig_uri,
+            subtitle: 'A Cute Pig',
         });
     });
 
     it('can be constructed', function () {});
+
+    it('displays the subtitle', function () {
+        let subtitle_widget = Gtk.test_find_label(app_banner, 'A Cute Pig');
+        expect(subtitle_widget).not.toBeNull();
+    });
+
+    it('has the app-banner CSS class', function () {
+        expect(app_banner).toHaveCssClass(StyleClasses.APP_BANNER);
+    });
+
+    it('has a subtitle with the subtitle CSS class', function () {
+        let subtitle_widget = Gtk.test_find_label(app_banner, 'A Cute Pig');
+        expect(subtitle_widget).toHaveCssClass(StyleClasses.SUBTITLE);
+    });
 });

--- a/tests/js/app/modules/testBackCover.js
+++ b/tests/js/app/modules/testBackCover.js
@@ -37,6 +37,6 @@ describe('Back cover widget', function () {
     });
 
     it('has a child widget with subtitle CSS class', function () {
-        expect(page).toHaveDescendantWithCssClass(StyleClasses.READER_SUBTITLE);
+        expect(page).toHaveDescendantWithCssClass(StyleClasses.SUBTITLE);
     });
 });


### PR DESCRIPTION
In preparation for modularizing the reader overview page, we move the app
subtitle to be part of the app banner. Most apps don't have a subtitle so
this really only affects the fitness-es app.

[endlessm/eos-sdk#3592]
