### PR TITLE
styleKnobGenerator: add compat theme override for search pages

### DIFF
--- a/js/app/compat/styleKnobGenerator.js
+++ b/js/app/compat/styleKnobGenerator.js
@@ -125,8 +125,6 @@ function selector_to_knob_ka (knobs, props, selector) {
     switch (selector) {
         case '.section-page-title':
             knobs['section_page'] = merge_object_properties(knobs['section_page'], prefix_keys_with(props, 'title-'));
-            break;
-        case '.search-page-title':
             knobs['search_page'] = merge_object_properties(knobs['search_page'], prefix_keys_with(props, 'title-'));
             break;
         case '.no-search-results-page-title':


### PR DESCRIPTION
We killed them when splitting the search and section pages, so
search pages would no longer have the custom app font

[endlessm/eos-sdk#3551]
