### PR TITLE
appBanner: expand image previewer inside grid

### DIFF
--- a/js/app/compat/compat.js
+++ b/js/app/compat/compat.js
@@ -112,6 +112,7 @@ function transform_v1_description(json) {
                 'max-fraction': 0.7,
                 'valign': Gtk.Align.CENTER,
                 'halign': Gtk.Align.CENTER,
+                'expand': false,
             },
         };
         modules['home-page-set-group'] = {

--- a/js/app/modules/appBanner.js
+++ b/js/app/modules/appBanner.js
@@ -95,6 +95,7 @@ const AppBanner = new Lang.Class({
             visible: true,
             min_fraction: this.min_fraction,
             max_fraction: this.max_fraction,
+            expand: true,
         });
         this.attach(this._logo, 0, 0, 1, 1);
 


### PR DESCRIPTION
So it can center itself in the available space when the appBanner
is set to expand and fill.

[endlessm/eos-sdk#3592]
