### PR TITLE
Fix read_stream_async

### DIFF
--- a/js/search/utils.js
+++ b/js/search/utils.js
@@ -72,7 +72,7 @@ function read_stream (stream, cancellable, callback) {
             let bytes = stream.read_bytes_finish(res);
             total_read += bytes.get_data().toString();
 
-            if (bytes.get_size() === CHUNK_SIZE) {
+            if (bytes.get_size() !== 0) {
                 stream.read_bytes_async(CHUNK_SIZE, 0, cancellable, handle_byte_response);
             } else {
                 task.return_value(total_read);


### PR DESCRIPTION
Not sure why I didn't fix this back in 398b7b0, but similar to that fix
we should only stop reading when Gio gives us a 0 size GBytes.
