### PR TITLE
Don't lock_ui and unlock_ui

### DIFF
--- a/js/app/actions.js
+++ b/js/app/actions.js
@@ -35,6 +35,7 @@ const SEARCH_READY = 'search-ready';
 const SEARCH_FAILED = 'search-failed';
 const SET_SEARCH_TEXT = 'set-search-text';
 const SHOW_SET = 'show-set';
+const SET_READY = 'set-ready';
 const SHOW_ARTICLE = 'show-article';
 const SHOW_MEDIA = 'show-media';
 const HIDE_MEDIA = 'hide-media';

--- a/js/app/modules/readerWindow.js
+++ b/js/app/modules/readerWindow.js
@@ -154,6 +154,15 @@ const ReaderWindow = new Lang.Class({
                 case Actions.HISTORY_FORWARD_ENABLED_CHANGED:
                     this._history_buttons.forward_button.sensitive = payload.enabled;
                     break;
+                case Actions.SEARCH_STARTED:
+                case Actions.SHOW_SET:
+                    this.set_busy(true);
+                    break;
+                case Actions.SEARCH_READY:
+                case Actions.SEARCH_FAILED:
+                case Actions.SET_READY:
+                    this.set_busy(false);
+                    break;
             }
         });
 
@@ -349,17 +358,15 @@ const ReaderWindow = new Lang.Class({
         return this._article_pages.length + 2;
     },
 
-    lock_ui: function () {
+    set_busy: function (busy) {
         let gdk_window = this.page_manager.get_window();
-        if (gdk_window)
-            gdk_window.cursor = Gdk.Cursor.new(Gdk.CursorType.WATCH);
-        this.page_manager.sensitive = false;
-    },
+        if (!gdk_window)
+            return;
 
-    unlock_ui: function () {
-        let gdk_window = this.page_manager.get_window();
-        if (gdk_window)
-            gdk_window.cursor = Gdk.Cursor.new(Gdk.CursorType.ARROW);
-        this.page_manager.sensitive = true;
+        let cursor = null;
+        if (busy)
+            cursor = Gdk.Cursor.new_for_display(Gdk.Display.get_default(),
+                Gdk.CursorType.WATCH);
+        gdk_window.cursor = cursor;
     },
 });

--- a/js/app/modules/window.js
+++ b/js/app/modules/window.js
@@ -182,6 +182,15 @@ const Window = new Lang.Class({
                 case Actions.HISTORY_FORWARD_ENABLED_CHANGED:
                     this._history_buttons.forward_button.sensitive = payload.enabled;
                     break;
+                case Actions.SEARCH_STARTED:
+                case Actions.SHOW_SET:
+                    this.set_busy(true);
+                    break;
+                case Actions.SEARCH_READY:
+                case Actions.SEARCH_FAILED:
+                case Actions.SET_READY:
+                    this.set_busy(false);
+                    break;
             }
         });
 
@@ -331,15 +340,15 @@ const Window = new Lang.Class({
         return this._stack.visible_child;
     },
 
-    lock_ui: function () {
+    set_busy: function (busy) {
         let gdk_window = this.page_manager.get_window();
-        gdk_window.cursor = Gdk.Cursor.new(Gdk.CursorType.WATCH);
-        this.page_manager.sensitive = false;
-    },
+        if (!gdk_window)
+            return;
 
-    unlock_ui: function () {
-        let gdk_window = this.page_manager.get_window();
-        gdk_window.cursor = Gdk.Cursor.new(Gdk.CursorType.ARROW);
-        this.page_manager.sensitive = true;
-    }
+        let cursor = null;
+        if (busy)
+            cursor = Gdk.Cursor.new_for_display(Gdk.Display.get_default(),
+                Gdk.CursorType.WATCH);
+        gdk_window.cursor = cursor;
+    },
 });

--- a/js/app/presenter.js
+++ b/js/app/presenter.js
@@ -350,6 +350,10 @@ const Presenter = new Lang.Class({
                     model: item.model,
                 });
                 this._refresh_article_results(() => {
+                    dispatcher.dispatch({
+                        action_type: Actions.SET_READY,
+                        model: item.model,
+                    });
                     this.view.show_page(this.view.section_page);
                 });
                 break;
@@ -503,9 +507,7 @@ const Presenter = new Lang.Class({
         }
         this._current_article_results_item = item;
 
-        this.view.lock_ui();
         this.engine.get_objects_by_query(query_obj, null, (engine, task) => {
-            this.view.unlock_ui();
             let results, get_more_results_query;
             try {
                 [results, get_more_results_query] = engine.get_objects_by_query_finish(task);

--- a/js/app/reader/presenter.js
+++ b/js/app/reader/presenter.js
@@ -366,10 +366,7 @@ const Presenter = new Lang.Class({
                     limit: RESULTS_SIZE,
                 });
 
-                this.view.lock_ui();
-
                 this.engine.get_objects_by_query(query_obj, null, (engine, task) => {
-                    this.view.unlock_ui();
                     try {
                         [results, get_more_results_query] = engine.get_objects_by_query_finish(task);
                     } catch (error) {

--- a/tests/js/app/modules/testReaderWindow.js
+++ b/tests/js/app/modules/testReaderWindow.js
@@ -131,4 +131,30 @@ describe('Window widget', function () {
         view.show_in_app_standalone_page();
         expect(view.article_pages_visible()).toBe(false);
     });
+
+    // The following two tests are identical to those in testWindow.js.
+    // To be removed when merging ReaderWindow and Window.
+    it('indicates busy during a search', function () {
+        spyOn(view, 'set_busy');
+        dispatcher.dispatch({
+            action_type: Actions.SEARCH_STARTED,
+        });
+        expect(view.set_busy).toHaveBeenCalledWith(true);
+        dispatcher.dispatch({
+            action_type: Actions.SEARCH_READY,
+        });
+        expect(view.set_busy).toHaveBeenCalledWith(false);
+    });
+
+    it('indicates busy during a failed search', function () {
+        spyOn(view, 'set_busy');
+        dispatcher.dispatch({
+            action_type: Actions.SEARCH_STARTED,
+        });
+        expect(view.set_busy).toHaveBeenCalledWith(true);
+        dispatcher.dispatch({
+            action_type: Actions.SEARCH_FAILED,
+        });
+        expect(view.set_busy).toHaveBeenCalledWith(false);
+    });
 });

--- a/tests/js/app/reader/testReaderPresenter.js
+++ b/tests/js/app/reader/testReaderPresenter.js
@@ -135,8 +135,6 @@ const MockView = new Lang.Class({
     remove_all_article_pages: function () {
         this._article_pages = [];
     },
-    lock_ui: function () {},
-    unlock_ui: function () {},
 });
 
 describe('Reader presenter', function () {
@@ -397,7 +395,7 @@ describe('Reader presenter', function () {
             expect(view.show_overview_page).toHaveBeenCalled();
         });
 
-        it('issues a search query after search-entered is dispatched', function (done) {
+        it('dispatches a pair of search-started and search-ready on search', function (done) {
             spyOn(view, 'show_search_results_page');
             dispatcher.dispatch({
                 action_type: Actions.SEARCH_TEXT_ENTERED,
@@ -438,13 +436,17 @@ describe('Reader presenter', function () {
             });
         });
 
-        it('dispatches search-failed if the search fails', function () {
+        it('dispatches a pair of search-started and search-failed if the search fails', function () {
             spyOn(window, 'logError');  // silence console output
             engine.get_objects_by_query_finish.and.throwError(new Error('jet fuel can\'t melt dank memes'));
             dispatcher.dispatch({
                 action_type: Actions.SEARCH_TEXT_ENTERED,
                 text: 'bad query',
             });
+            expect(dispatcher.dispatched_payloads).toContain(jasmine.objectContaining({
+                action_type: Actions.SEARCH_STARTED,
+                query: 'bad query',
+            }));
             expect(dispatcher.dispatched_payloads).toContain(jasmine.objectContaining({
                 action_type: Actions.SEARCH_FAILED,
                 query: 'bad query',

--- a/tests/js/app/testPresenter.js
+++ b/tests/js/app/testPresenter.js
@@ -79,8 +79,6 @@ const MockView = new Lang.Class({
     },
 
     show_page: function (page) {},
-    lock_ui: function () {},
-    unlock_ui: function () {},
     present_with_time: function () {},
 });
 
@@ -186,15 +184,28 @@ describe('Presenter', () => {
             expect(presenter.record_search_metric).toHaveBeenCalled();
         });
 
-        it('dispatches search-failed if the search fails', function () {
+        it('dispatches a pair of search-started and search-failed if the search fails', function () {
             spyOn(window, 'logError');  // silence console output
             engine.get_objects_by_query_finish.and.throwError(new Error('Ugh'));
             dispatcher.dispatch({
                 action_type: Actions.SEARCH_TEXT_ENTERED,
                 text: 'query not found',
             });
-            let payload = dispatcher.last_payload_with_type(Actions.SEARCH_FAILED);
+            let payload = dispatcher.last_payload_with_type(Actions.SEARCH_STARTED);
             expect(payload.query).toBe('query not found');
+            payload = dispatcher.last_payload_with_type(Actions.SEARCH_FAILED);
+            expect(payload.query).toBe('query not found');
+        });
+
+        it('dispatches a pair of search-started and search-ready on search', function () {
+            dispatcher.dispatch({
+                action_type: Actions.SEARCH_TEXT_ENTERED,
+                text: 'query',
+            });
+            let payload = dispatcher.last_payload_with_type(Actions.SEARCH_STARTED);
+            expect(payload.query).toBe('query');
+            payload = dispatcher.last_payload_with_type(Actions.SEARCH_READY);
+            expect(payload.query).toBe('query');
         });
     });
 
@@ -231,6 +242,11 @@ describe('Presenter', () => {
             dispatcher.dispatch({ action_type: Actions.HISTORY_FORWARD_CLICKED });
             Utils.update_gui();
             expect(view.show_page).toHaveBeenCalledWith(view.section_page);
+        });
+
+        it('dispatches a pair of show-set and set-ready when a set is clicked', function () {
+            expect(dispatcher.last_payload_with_type(Actions.SHOW_SET)).toBeDefined();
+            expect(dispatcher.last_payload_with_type(Actions.SET_READY)).toBeDefined();
         });
     });
 });


### PR DESCRIPTION
Now that we update the UI to indicate that a search is in progress, it's
not necessary to render the whole UI insensitive while the search is
going on. And now that we have the dispatcher, it's quite easy to
subscribe the window modules to the correct actions. In order to maintain
all the functionality we already had, we also add a SET_READY action
that's dispatched when a set has filled up with its models.

Instead of lock_ui() and unlock_ui() we now have a private window method
which changes the mouse cursor but doesn't set everything insensitive.

There is a bunch of duplicate code in Window and ReaderWindow now, but
that will be removed soon when we merge them.

[endlessm/eos-sdk#1904]
