### PR TITLE
scss: line-height uses unitless numbers

### DIFF
--- a/data/templates/css/embedly.scss
+++ b/data/templates/css/embedly.scss
@@ -54,10 +54,10 @@ html {
         font-size: 0.9375em; /* 15px / 12px/em * 72/96 */
     }
     p {
-        line-height: 1.56em; /* 25px / 12px/em * 72/96 */
+        line-height: 1.56;
     }
     li {
-        line-height: 1.875em; /* 30px / 12px/em * 72/96 */
+        line-height: 1.875;
     }
     a {
         color: #666666;
@@ -74,7 +74,7 @@ html {
         font-family: Roboto;
         font-style: italic;
         font-size: 1em; /* 16px / 12px/em * 72/96 */
-        line-height: 1.3125em; /* 21px / 12px/em * 72/96 */
+        line-height: 1.3125;
     }
     img {
         clear: right;

--- a/data/templates/css/wikihow.scss
+++ b/data/templates/css/wikihow.scss
@@ -96,7 +96,7 @@ $rhythm: 22px;
     padding: 20px $in-cols * 2;
     color: $gray;
     font: 0.8125em $font1; /* 13px / 12px/em * 72/96 */
-    line-height: $rhythm;
+    line-height: 1.71;
     img {
         height: auto;
         max-width: 100%;
@@ -104,14 +104,14 @@ $rhythm: 22px;
     .eos-article-title {
         color: $gray-dark;
         font: 1.875em $font1; /* 30px / 12px/em * 72/96 */
-        line-height: 1.375em; /* 22px / 12px/em * 72/96 */
+        line-height: 1.375;
         margin-bottom: 36px;
         margin-top: 22px;
     }
     h2, h3, .firstHeading, h4 {
         color: $gray-dark;
         font: 900 0.875em $font2; /* 14px / 12px/em * 72/96 */
-        line-height: $rhythm - 5;
+        line-height: 1.55;
         margin-bottom: $rhythm;
         // text-transform: uppercase
         a {
@@ -208,7 +208,7 @@ h2 + ol, h3 + ol, .steps_list_2 {
 .sd_thumb {
     border: 5px solid #fff;
     background: #fff;
-    line-height: 1.4em;
+    line-height: 1.4;
     margin-bottom: $rhythm;
     @include box-shadow(0 0 6px 0 rgba(#000, 0.3));
     @include box-sizing(border-box);

--- a/data/templates/css/wikimedia.scss
+++ b/data/templates/css/wikimedia.scss
@@ -87,7 +87,7 @@ html {
     $rhythm: 22px;
     color: $gray;
     font: 0.8125em $font1; /* 13px / 12px/em * 72/96 */
-    line-height: $rhythm;
+    line-height: 1.71;
     padding: 20px $cols * 2;
     a {
         color: #277090;
@@ -100,14 +100,14 @@ html {
     .eos-article-title {
         color: $gray-dark;
         font: 1.875em $font1; /* 30px / 12px/em * 72/96 */
-        line-height: 1.375em; /* 22px / 12px/em * 72/96 */
+        line-height: 1.375;
         margin-bottom: 36px;
         margin-top: 22px;
     }
     h2, .firstHeading {
         color: $gray-dark;
         font: 900 1.125em $font2; /* 18px / 12px/em * 72/96 */
-        line-height: $rhythm;
+        line-height: 1.47;
         margin-bottom: $rhythm;
         margin-top: $rhythm;
         // text-transform: uppercase
@@ -281,7 +281,12 @@ html {
         @include box-sizing(border-box);
     }
     .infobox, .infobox_v2 {
-        line-height: 1.4em;
+        th {
+            line-height: 1.6;
+        }
+        td {
+            line-height: 2.0;
+        }
         // &.geography
         *[style*="nowrap"] {
             white-space: normal !important;
@@ -366,7 +371,7 @@ html {
         width: 100%;
     }
     .thumbcaption {
-        line-height: 1.4em;
+        line-height: 1.4;
     }
 }
 


### PR DESCRIPTION
Unitless number avoid a lot of the unexpected inheritance problems
with line heights with units.

https://developer.mozilla.org/en-US/docs/Web/CSS/line-height

With this change our line heights will scale with font size, so as
long as we never choose a line height > 1 there should be no way to
see text overlap like we currently do with a high text scale factor.

One spot where the styling will be slightly different is the
wikimedia infoboxes. We were formally trying to apply line height to
a table, which apparently does nothing, things only work if you apply
the line height to the tr, th and tds in the table.

So the old code was accidentally setting all line heights to 22px
in the infobox. That's bad, as things do appear at different font
sizes in the infobox. But changing things to properly scale with
font size creates some slight visual differences on some infoboxes,
as the font size for headers in the infobox is not actually static
across all wikimedia articles.
[endlessm/eos-sdk#3666]
