### PR TITLE
Grab focus of visible search boxes on app launch

### DIFF
--- a/js/app/actions.js
+++ b/js/app/actions.js
@@ -41,3 +41,4 @@ const SHOW_MEDIA = 'show-media';
 const HIDE_MEDIA = 'hide-media';
 const SHOW_ARTICLE_SEARCH = 'show-article-search';
 const HIDE_ARTICLE_SEARCH = 'hide-article-search';
+const FOCUS_SEARCH = 'focus-search';

--- a/js/app/modules/searchBox.js
+++ b/js/app/modules/searchBox.js
@@ -54,6 +54,11 @@ const SearchBox = new Lang.Class({
                 case Actions.SET_SEARCH_TEXT:
                     this.set_text_programmatically(payload.text);
                     break;
+                case Actions.FOCUS_SEARCH:
+                    if (this.visible) {
+                        this.grab_focus();
+                    }
+                    break;
             }
         });
 

--- a/js/app/presenter.js
+++ b/js/app/presenter.js
@@ -195,6 +195,10 @@ const Presenter = new Lang.Class({
             }
         });
 
+        dispatcher.dispatch({
+            action_type: Actions.FOCUS_SEARCH,
+        });
+
         this._history_presenter.connect('history-item-changed', this._on_history_item_change.bind(this));
 
         this._current_article_results_item = null;

--- a/tests/js/app/modules/testSearchBox.js
+++ b/tests/js/app/modules/testSearchBox.js
@@ -40,6 +40,17 @@ describe('Search box module', function () {
         expect(box.text).toBe('foo');
     });
 
+    it('has focus when focus-search is dispatched', function () {
+        // Search box needs to be mapped and realized before grabbing focus can
+        // take effect, so we stick it in a Gtk.Window first.
+        let win = new Gtk.OffscreenWindow();
+        win.add(box);
+        dispatcher.dispatch({
+            action_type: Actions.FOCUS_SEARCH,
+        });
+        expect(box.is_focus).toBe(true);
+    });
+
     it('dispatches search-text-entered when text is activated', function () {
         box.set_text_programmatically('foo');
         box.emit('activate');


### PR DESCRIPTION
The search box should have focus on app launch so that
the user can immediately start typing a search. We use
the dispatcher to do this.

[endlessm/eos-sdk#3673]
