### PR TITLE
homePageATemplate: give default values for button labels

### DIFF
--- a/js/app/compat/compat.js
+++ b/js/app/compat/compat.js
@@ -1,13 +1,9 @@
-const Gettext = imports.gettext;
 const GLib = imports.gi.GLib;
 const Gtk = imports.gi.Gtk;
 
-const Config = imports.app.config;
 const Engine = imports.search.engine;
 const EosKnowledgePrivate = imports.gi.EosKnowledgePrivate;
 const SetObjectModel = imports.search.setObjectModel;
-
-let _ = Gettext.dgettext.bind(null, Config.GETTEXT_PACKAGE);
 
 function transform_v1_description(json) {
     let modules = {};
@@ -109,10 +105,6 @@ function transform_v1_description(json) {
                 "middle": "home-search",
                 "bottom": "home-page-set-group",
                 "basement": "home-page-basement-set-group",
-            },
-            "properties": {
-                "upper-button-label": _("SEE ALL CATEGORIES"),
-                "basement-button-label": _("HOME"),
             },
         };
         modules["results-card"] = {

--- a/js/app/modules/homePageATemplate.js
+++ b/js/app/modules/homePageATemplate.js
@@ -1,11 +1,15 @@
 // Copyright 2015 Endless Mobile, Inc.
 
+const Gettext = imports.gettext;
 const GObject = imports.gi.GObject;
 const Gtk = imports.gi.Gtk;
 const Lang = imports.lang;
 
+const Config = imports.app.config;
 const Module = imports.app.interfaces.module;
 const TabButton = imports.app.widgets.tabButton;
+
+let _ = Gettext.dgettext.bind(null, Config.GETTEXT_PACKAGE);
 
 /**
  * Class: HomePageATemplate
@@ -30,14 +34,16 @@ const HomePageATemplate = new Lang.Class({
          */
         'upper-button-label': GObject.ParamSpec.string('upper-button-label',
             'Upper tab button label', 'Upper tab button label',
-            GObject.ParamFlags.READWRITE | GObject.ParamFlags.CONSTRUCT_ONLY, ''),
+            GObject.ParamFlags.READWRITE | GObject.ParamFlags.CONSTRUCT_ONLY,
+            _("SEE ALL CATEGORIES")),
         /**
          * Property: basement-button-label
          * Label on the tab button on the basement page
          */
         'basement-button-label': GObject.ParamSpec.string('basement-button-label',
             'Basement tab button label', 'Basement tab button label',
-            GObject.ParamFlags.READWRITE | GObject.ParamFlags.CONSTRUCT_ONLY, ''),
+            GObject.ParamFlags.READWRITE | GObject.ParamFlags.CONSTRUCT_ONLY,
+            _("HOME")),
     },
 
     Template: 'resource:///com/endlessm/knowledge/widgets/homePageATemplate.ui',

--- a/po/POTFILES.in
+++ b/po/POTFILES.in
@@ -6,7 +6,6 @@ data/widgets/searchModule.ui
 data/widgets/suggestedArticlesModule.ui
 data/widgets/suggestedCategoriesModule.ui
 js/app/articleHTMLRenderer.js
-js/app/compat/compat.js
 js/app/modules/aisleInteraction.js
 js/app/modules/encyclopediaWindow.js
 js/app/modules/homePageATemplate.js


### PR DESCRIPTION
We'll have the home page template buttons default to SEE ALL CATEGORIES
and HOME so we don't have to set it in the app.json.

This is a deliberately short sighted fix, as eventually we will want
to just the class as a general purpose template in other use cases.
But for now we don't want to handle localization in app.json files.
[endlessm/eos-sdk#3681]
