### PR TITLE
Added CSS Card sizing classes

### DIFF
--- a/js/app/interfaces/card.js
+++ b/js/app/interfaces/card.js
@@ -161,6 +161,58 @@ const Card = new Lang.Interface({
     },
 
     /**
+     * Method: update_card_sizing_classes
+     * Assigns the appropriate CSS classes based on the height and width
+     *
+     * This method takes the height and width of the card widget and assigns the
+     * appropriate CSS classes, according to our design constraints.
+     */
+    update_card_sizing_classes: function (height, width) {
+        let width_class, height_class;
+
+        if (width < 200) {
+            width_class = StyleClasses.CARD_WIDTH.A;
+        } else if (width < 300) {
+            width_class = StyleClasses.CARD_WIDTH.B;
+        } else if (width < 400) {
+            width_class = StyleClasses.CARD_WIDTH.C;
+        } else if (width < 600) {
+            width_class = StyleClasses.CARD_WIDTH.D;
+        } else if (width < 800) {
+            width_class = StyleClasses.CARD_WIDTH.E;
+        } else if (width < 1000) {
+            width_class = StyleClasses.CARD_WIDTH.F;
+        } else if (width < 1200) {
+            width_class = StyleClasses.CARD_WIDTH.G;
+        } else {
+            width_class = StyleClasses.CARD_WIDTH.H;
+        }
+
+        if (height < 200) {
+            height_class = StyleClasses.CARD_HEIGHT.A;
+        } else if (height < 300) {
+            height_class = StyleClasses.CARD_HEIGHT.B;
+        } else if (height < 400) {
+            height_class = StyleClasses.CARD_HEIGHT.C;
+        } else if (height < 600) {
+            height_class = StyleClasses.CARD_HEIGHT.D;
+        } else {
+            height_class = StyleClasses.CARD_HEIGHT.E;
+        }
+
+        let context = this.get_style_context();
+        if (typeof width_class !== undefined && !context.has_class(width_class)) {
+            Object.keys(StyleClasses.CARD_WIDTH).forEach(name => context.remove_class(StyleClasses.CARD_WIDTH[name]));
+            context.add_class(width_class);
+        }
+
+        if (typeof width_class !== undefined && !context.has_class(height_class)) {
+            Object.keys(StyleClasses.CARD_HEIGHT).forEach(name => context.remove_class(StyleClasses.CARD_HEIGHT[name]));
+            context.add_class(height_class);
+        }
+    },
+
+    /**
      * Method: fade_in
      * Use instead of *Gtk.Widget.show()* or *Gtk.Widget.show_all()*.
      */

--- a/js/app/styleClasses.js
+++ b/js/app/styleClasses.js
@@ -38,6 +38,37 @@ const CARD_B = 'card-b';
 const TEXT_CARD = 'text-card';
 
 /**
+ * Constant: CARD_WIDTH
+ *
+ * This object packs the different CSS classes that describe the width of a card
+ * widget.
+ */
+const CARD_WIDTH = {
+    A: 'width-a',
+    B: 'width-b',
+    C: 'width-c',
+    D: 'width-d',
+    E: 'width-e',
+    F: 'width-f',
+    G: 'width-g',
+    H: 'width-h',
+}
+
+/**
+ * Constant: CARD_HEIGHT
+ *
+ * This object packs the different CSS classes that describe the height of a card
+ * widget.
+ */
+const CARD_HEIGHT = {
+    A: 'height-a',
+    B: 'height-b',
+    C: 'height-c',
+    D: 'height-d',
+    E: 'height-e',
+}
+
+/**
  * Constant: HIGHLIGHTED
  *
  * Matches widgets when they are highlighted.

--- a/tests/js/app/interfaces/testCard.js
+++ b/tests/js/app/interfaces/testCard.js
@@ -106,6 +106,50 @@ describe('Card interface', function () {
         expect(card).toHaveCssClass('variant2');
     });
 
+    describe ('specific sizing classes', function () {
+        // These values fall in the middle of the range of dimensions for such class name
+        let in_between_class_dimensions = {
+            A: 150,
+            B: 250,
+            C: 350,
+            D: 450,
+            E: 650,
+            F: 850,
+            G: 1050,
+            H: 1250,
+        };
+
+        beforeEach(function () {
+            this.win = new Gtk.OffscreenWindow();
+        });
+
+        afterEach(function () {
+            this.win.destroy();
+        });
+
+        Object.keys(StyleClasses.CARD_WIDTH).forEach(width_class => {
+            Object.keys(StyleClasses.CARD_HEIGHT).forEach(height_class => {
+                let width = in_between_class_dimensions[width_class];
+                let height = in_between_class_dimensions[height_class];
+                test_style_classes_for_height_and_width(StyleClasses.CARD_WIDTH[width_class], StyleClasses.CARD_HEIGHT[height_class], height, width);
+            });
+        });
+    });
+
     // FIXME: no way to verify this.
     it('displays the record thumbnail in the thumbnail frame');
 });
+
+function test_style_classes_for_height_and_width(style_class_height, style_class_width, height, width) {
+    it ('assigns correct classes to card of dimensions (' + width + ', ' + height + ')', function () {
+        let card = new Minimal.MinimalCard();
+
+        this.win.add(card);
+        this.win.set_size_request(width, height);
+        this.win.show_all();
+        Utils.update_gui();
+
+        expect(card).toHaveCssClass(style_class_height);
+        expect(card).toHaveCssClass(style_class_width);
+    });
+}

--- a/tests/minimal.js
+++ b/tests/minimal.js
@@ -83,7 +83,12 @@ const MinimalCard = new Lang.Class({
 
     _init: function (props={}) {
         this.parent(props);
-    }
+    },
+
+    vfunc_size_allocate: function (allocation) {
+        this.parent(allocation);
+        this.update_card_sizing_classes(allocation.height, allocation.width);
+    },
 });
 
 const MinimalInteraction = new Lang.Class({


### PR DESCRIPTION
Added the CSS classes that handle the sizing of cards in the new
knowledge/reader apps.

These CSS classes should be added/removed to the card widgets according to the
space constraints, so that we can achieve responsiveness in our user interfaces.

[endlessm/eos-sdk#3720]
