### PR TITLE
compat: don't set template B search page background

### DIFF
--- a/js/app/compat/compat.js
+++ b/js/app/compat/compat.js
@@ -325,9 +325,6 @@ function transform_v1_description(json) {
                 "content": "results-search-banner",
                 "sidebar": "search-results",
             },
-            "properties": {
-                "background-image-uri": json['backgroundSectionURI'],
-            },
         };
         modules["lightbox-card"] = {
             "type": "MediaCard",


### PR DESCRIPTION
We handle our background drawing for template A/B on the window
not the pages themselves
