### PR TITLE
Added SquareGuysArrangement

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -288,6 +288,7 @@ javascript_tests = \
 	tests/js/app/modules/testSetGroupModule.js \
 	tests/js/app/modules/testSidebarTemplate.js \
 	tests/js/app/modules/testSideMenuTemplate.js \
+	tests/js/app/modules/testSquareGuysArrangement.js \
 	tests/js/app/modules/testSuggestedArticlesModule.js \
 	tests/js/app/modules/testSuggestedCategoriesModule.js \
 	tests/js/app/modules/testTextCard.js \

--- a/eos-knowledge.gresource.xml
+++ b/eos-knowledge.gresource.xml
@@ -122,6 +122,7 @@
     <file>js/app/modules/setGroupModule.js</file>
     <file>js/app/modules/sidebarTemplate.js</file>
     <file>js/app/modules/sideMenuTemplate.js</file>
+    <file>js/app/modules/squareGuysArrangement.js</file>
     <file>js/app/modules/standalonePage.js</file>
     <file>js/app/modules/suggestedArticlesModule.js</file>
     <file>js/app/modules/suggestedCategoriesModule.js</file>

--- a/js/app/modules/squareGuysArrangement.js
+++ b/js/app/modules/squareGuysArrangement.js
@@ -1,0 +1,144 @@
+// Copyright 2015 Endless Mobile, Inc.
+
+/* exported SquareGuysArrangement */
+
+const Cairo = imports.gi.cairo;
+const Endless = imports.gi.Endless;
+const GLib = imports.gi.GLib;
+const GObject = imports.gi.GObject;
+const Gtk = imports.gi.Gtk;
+const Lang = imports.lang;
+
+const Arrangement = imports.app.interfaces.arrangement;
+const Module = imports.app.interfaces.module;
+
+const COL_COUNT_MAX = 4;
+const COL_COUNT_MIN = 3;
+const ROW_COUNT = 2;
+const CARD_SIZE_SMALL = 200;
+const CARD_SIZE_BIG = 300;
+const CARD_SIZE_MAX = 400;
+const NUM_SHOWN_MAX = COL_COUNT_MAX * ROW_COUNT;
+const NUM_SHOWN_MIN = COL_COUNT_MIN * ROW_COUNT;
+
+const SquareGuysArrangement = new Lang.Class({
+    Name: 'SquareGuysArrangement',
+    GTypeName: 'EknSquareGuysArrangement',
+    Extends: Endless.CustomContainer,
+    Implements: [ Module.Module, Arrangement.Arrangement ],
+
+    Properties: {
+        'factory': GObject.ParamSpec.override('factory', Module.Module),
+        'factory-name': GObject.ParamSpec.override('factory-name', Module.Module),
+        /**
+         * Property: spacing
+         * The amount of space in pixels between children cards
+         *
+         * Default:
+         *   0
+         */
+        'spacing': GObject.ParamSpec.uint('spacing', 'Spacing',
+            'The amount of space in pixels between children cards',
+            GObject.ParamFlags.READWRITE,
+            0, GLib.MAXUINT16, 0),
+    },
+
+    _init: function (props={}) {
+        this._spacing = 0;
+        this.parent(props);
+
+        this._small_mode = false;
+    },
+
+    add_card: function (widget) {
+        this.add(widget);
+    },
+
+    get_cards: function () {
+        return this.get_children();
+    },
+
+    clear: function () {
+        this.get_children().forEach((child) => this.remove(child));
+    },
+
+    vfunc_get_request_mode: function () {
+        return Gtk.SizeRequestMode.CONSTANT_SIZE;
+    },
+
+    vfunc_get_preferred_width: function () {
+        return [this._get_size_with_spacing(CARD_SIZE_SMALL, COL_COUNT_MIN),
+            this._get_size_with_spacing(CARD_SIZE_MAX, COL_COUNT_MAX)];
+    },
+
+    vfunc_get_preferred_height: function () {
+        let card_size = this._small_mode ? CARD_SIZE_SMALL : CARD_SIZE_BIG;
+        let height = this._get_size_with_spacing(card_size, ROW_COUNT);
+        return [height, height];
+    },
+
+    vfunc_size_allocate: function (alloc) {
+        this.parent(alloc);
+
+        this._small_mode = (alloc.width < this._get_size_with_spacing(CARD_SIZE_BIG, COL_COUNT_MIN));
+        let three_column_mode = (alloc.width < this._get_size_with_spacing(CARD_SIZE_BIG, COL_COUNT_MAX));
+
+        let col_count = three_column_mode ? COL_COUNT_MIN : COL_COUNT_MAX;
+
+        let available_width = alloc.width - (this._spacing * (col_count - 1));
+        let available_height = alloc.height - this._spacing;
+
+        // Cards width and height cannot be larger than the max sizes of the cards
+        let child_width = Math.min(Math.floor(available_width / (col_count)), CARD_SIZE_MAX);
+        let child_height = Math.min(Math.floor(available_height / ROW_COUNT), this._small_mode ? CARD_SIZE_SMALL : CARD_SIZE_BIG);
+        let x = alloc.x;
+        let y = alloc.y;
+        let delta_x = child_width + this._spacing;
+        let delta_y = child_height + this._spacing;
+
+        let extra_arrangement_space = alloc.width - this._get_size_with_spacing(CARD_SIZE_MAX, COL_COUNT_MAX);
+        if (extra_arrangement_space > 0) {
+            // If we get extra card spacing, we pad the cards horizontally, increasing the delta_x
+            let extra_card_spacing = Math.floor(extra_arrangement_space / (col_count - 1));
+            delta_x += extra_card_spacing;
+        }
+        let num_shown_children = three_column_mode ? NUM_SHOWN_MIN : NUM_SHOWN_MAX;
+        this.get_children().forEach((child, ix) => {
+            if (ix >= num_shown_children) {
+                child.set_child_visible(false);
+                return;
+            }
+
+            child.set_child_visible(true);
+            let child_alloc = new Cairo.RectangleInt({
+                x: x,
+                y: y,
+                width: child_width,
+                height: child_height,
+            });
+            child.size_allocate(child_alloc);
+            if (ix % ROW_COUNT == 1) {
+                x += delta_x;
+                y = alloc.y;
+            } else {
+                y += delta_y;
+            }
+        });
+    },
+
+    get spacing() {
+        return this._spacing;
+    },
+
+    set spacing(value) {
+        if (this._spacing === value)
+            return;
+        this._spacing = value;
+        this.notify('spacing');
+        this.queue_resize();
+    },
+
+    _get_size_with_spacing: function (size, count) {
+        return size * count + this._spacing * (count - 1);
+    },
+});

--- a/tests/js/app/modules/testSquareGuysArrangement.js
+++ b/tests/js/app/modules/testSquareGuysArrangement.js
@@ -1,0 +1,104 @@
+// Copyright 2015 Endless Mobile, Inc.
+
+const Gtk = imports.gi.Gtk;
+const Lang = imports.lang;
+
+const SquareGuysArrangement = imports.app.modules.squareGuysArrangement;
+const Minimal = imports.tests.minimal;
+const Utils = imports.tests.utils;
+
+Gtk.init(null);
+
+// Colored box with a natural request of a particular size.
+const ResizeableBox = new Lang.Class({
+    Name: 'ResizeableBox',
+    Extends: Gtk.Frame,
+
+    _init: function (size, props={}) {
+        props['valign'] = Gtk.Align.START;
+        props['halign'] = Gtk.Align.START;
+        props['vexpand'] = false;
+        props['hexpand'] = false;
+        this.parent(props);
+        this.size = size;
+    },
+
+    vfunc_get_preferred_width: function () {
+        return [1, this.size];
+    },
+
+    vfunc_get_preferred_height: function () {
+        return [1, this.size];
+    },
+});
+
+describe('SquareGuys arrangement', function () {
+    beforeEach(function () {
+        this.arrangement = new SquareGuysArrangement.SquareGuysArrangement({
+            hexpand: false,
+            valign: Gtk.Align.START,
+            spacing: 0,
+        });
+    });
+
+    it('constructs', function () {
+        expect(this.arrangement).toBeDefined();
+    });
+
+    Minimal.test_arrangement_compliance();
+
+    describe('sizing allocation', function () {
+        // At 2000x2000, all eight cards should be visible and of size 400x300
+        testSizingArrangementForDimensions(2000, 2000, 8, 400, 300);
+
+        // At 1200x1200, all eight cards should be visible and of size 300x300
+        testSizingArrangementForDimensions(1200, 1200, 8, 300, 300);
+
+        // At 1000x1000, only first six cards should be visible; all cards of size 333x300
+        testSizingArrangementForDimensions(1000, 1000, 6, 333, 300);
+
+        // At 900x900, only first six cards should be visible; all cards of size 300x300
+        testSizingArrangementForDimensions(900, 900, 6, 300, 300);
+
+        // At 800x600, only first six cards should be visible; all cards of size 266x200
+        testSizingArrangementForDimensions(800, 600, 6, 266, 200);
+
+        // At 600x400, only first six cards should be visible; all cards of size 200x200
+        testSizingArrangementForDimensions(600, 400, 6, 200, 200);
+    });
+});
+
+function testSizingArrangementForDimensions(arr_width, arr_height, visible_children, child_width, child_height) {
+    it ('handles arrangement with dimensions ' + arr_width + 'x' + arr_height, function () {
+        let add_card = (card) => {
+            card.show_all();
+            this.arrangement.add(card);
+            return card;
+        };
+        let cards = [];
+
+        this.win = new Gtk.OffscreenWindow();
+        this.win.add(this.arrangement);
+        this.win.set_size_request(arr_width, arr_height);
+        this.win.show_all();
+
+        for (let i=0; i<8; i++) {
+            cards.push(add_card(new ResizeableBox(400)));
+        }
+
+        this.win.queue_resize();
+        Utils.update_gui();
+
+        this.arrangement.get_children().forEach((card, i) => {
+            if (i < visible_children) {
+                expect(card.get_allocation().width).toBe(child_width);
+                expect(card.get_allocation().height).toBe(child_height);
+                expect(card.get_child_visible()).toBe(true);
+            } else {
+                expect(card.get_child_visible()).toBe(false);
+            }
+        });
+
+        this.win.destroy();
+    });
+}

--- a/tests/smoke-tests/squareGuysArrangementSmokeTest.js
+++ b/tests/smoke-tests/squareGuysArrangementSmokeTest.js
@@ -1,0 +1,50 @@
+const GLib = imports.gi.GLib;
+const Gtk = imports.gi.Gtk;
+const Lang = imports.lang;
+
+const SquareGuysArrangement = imports.app.modules.squareGuysArrangement;
+
+Gtk.init(null);
+
+const Box = new Lang.Class({
+    Name: 'Box',
+    Extends: Gtk.Frame,
+
+    _init: function (props={}) {
+        this.parent(props);
+
+        this._label = new Gtk.Label();
+        this.add(this._label);
+
+        let context = this.get_style_context();
+        let colors = ['fce94f', 'fcaf3e', 'e9b96e', '8ae234', '729fcf',
+            'ad7fa8', 'ef2929', '888a85'];
+        let color = colors[GLib.random_int_range(0, colors.length)];
+        let provider = new Gtk.CssProvider();
+        provider.load_from_data('*{background-color:#' + color + ';}');
+        context.add_provider(provider, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION);
+    },
+
+    vfunc_size_allocate: function (alloc) {
+        this.parent(alloc);
+        this._label.label = alloc.width + 'x' + alloc.height;
+    },
+});
+
+let win = new Gtk.Window();
+let arrangement = new SquareGuysArrangement.SquareGuysArrangement({
+    hexpand: false,
+    valign: Gtk.Align.START,
+    spacing: 8,
+});
+
+for (let i = 0; i < 10; i++) {
+    let card = new Box({
+        expand: true,
+    });
+    arrangement.add(card);
+}
+
+win.add(arrangement);
+win.show_all();
+Gtk.main();


### PR DESCRIPTION
An arrangement implementation that keeps the square proportions of its cards.

Two rows of cards are displayed, even if more models are added. Eight cards are
displayed (4x2) when the arrangement width is greater than 1200px. Six cards are
displayed (3x2) when the width is between [600px, 1200px). The minimum width for
the arrangement is 600px.

[endlessm/eos-sdk#3696]
