### PR TITLE
Fix coverage

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -386,9 +386,9 @@ EXTRA_DIST += jasmine.json
 
 # # # COVERAGE # # #
 
-EOS_JS_COVERAGE_FILES = \
-	$(js_files) \
-	$(NULL)
+# Don't specify the resource:/// URIs here, because the tests load modules from
+# the local directory, not from the GResource
+EOS_JS_COVERAGE_FILES := $(shell find $(top_srcdir)/js -name '*.js' | $(SED) s,^$(top_srcdir)/,,)
 
 @EOS_COVERAGE_RULES@
 

--- a/configure.ac
+++ b/configure.ac
@@ -82,6 +82,7 @@ GTK_DOC_CHECK([1.18], [--flavour no-tmpl])
 GOBJECT_INTROSPECTION_REQUIRE([1.30])
 # Various tools
 AC_PROG_AWK  # needed for TAP driver
+AC_PROG_SED  # needed for finding files for coverage
 AC_REQUIRE_AUX_FILE([tap-driver.sh])
 AC_PATH_PROG([GIRDOCTOOL], [g-ir-doc-tool], [notfound])
 AC_ARG_VAR([GIRDOCTOOL], [Path to g-ir-doc-tool])


### PR DESCRIPTION
$(js_files) is gone, so add all the Javascript files under js/ to
EOS_JS_COVERAGE_FILES by using find and sed.

Note, if you're ever debugging this: you can add "| tee debug.txt" to the
command inside the parentheses.

[endlessm/eos-sdk#3747]
