### PR TITLE
testCard: temporarily disable timing specific tests

### DIFF
--- a/tests/js/app/interfaces/testCard.js
+++ b/tests/js/app/interfaces/testCard.js
@@ -33,7 +33,10 @@ describe('Card interface', function () {
         });
     });
 
-    it('adds the "invisible" and "fade-in" style classes while fading', function (done) {
+    // FIXME: the following two tests relied to much on exact timings and were
+    // fragile on machines under high load or with slower processors. We should
+    // rewrite in a way that does not rely on callback timings.
+    xit('adds the "invisible" and "fade-in" style classes while fading', function (done) {
         card.FADE_IN_TIME_MS = 20;
         Mainloop.timeout_add(10, () => {
             expect(card).toHaveCssClass(StyleClasses.INVISIBLE);
@@ -50,7 +53,7 @@ describe('Card interface', function () {
         Utils.update_gui();
     });
 
-    it('is insensitive while fading', function (done) {
+    xit('is insensitive while fading', function (done) {
         card.FADE_IN_TIME_MS = 20;
         Mainloop.timeout_add(10, () => {
             expect(card.sensitive).toBeFalsy();


### PR DESCRIPTION
We still want to test the fade in functionality, but need to find
a way to do it that is less fragile.
[endlessm/eos-sdk#3622]
