### PR TITLE
Added HalfArrangement

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -275,6 +275,7 @@ javascript_tests = \
 	tests/js/app/modules/testCarouselArrangement.js \
 	tests/js/app/modules/testContextBanner.js \
 	tests/js/app/modules/testDividedBannerTemplate.js \
+	tests/js/app/modules/testHalfArrangement.js \
 	tests/js/app/modules/testHighlightsModule.js \
 	tests/js/app/modules/testHamburgerBasementTemplate.js \
 	tests/js/app/modules/testItemGroupModule.js \

--- a/eos-knowledge.gresource.xml
+++ b/eos-knowledge.gresource.xml
@@ -102,6 +102,7 @@
     <file>js/app/modules/encyclopediaCoverTemplate.js</file>
     <file>js/app/modules/encyclopediaWindow.js</file>
     <file>js/app/modules/gridArrangement.js</file>
+    <file>js/app/modules/halfArrangement.js</file>
     <file>js/app/modules/hamburgerBasementTemplate.js</file>
     <file>js/app/modules/highlightsModule.js</file>
     <file>js/app/modules/itemGroupModule.js</file>

--- a/js/app/modules/halfArrangement.js
+++ b/js/app/modules/halfArrangement.js
@@ -1,0 +1,191 @@
+// Copyright 2015 Endless Mobile, Inc.
+
+/* exported HalfArrangement */
+
+const Cairo = imports.gi.cairo;
+const Endless = imports.gi.Endless;
+const GLib = imports.gi.GLib;
+const GObject = imports.gi.GObject;
+const Lang = imports.lang;
+
+const Arrangement = imports.app.interfaces.arrangement;
+const Card = imports.app.interfaces.card;
+const Module = imports.app.interfaces.module;
+
+const HIGHLIGHTED_CARDS_COUNT = 2;
+const MAX_CARDS_PER_ROW = 4;
+const MIN_CARDS_PER_ROW = 3;
+const FOUR_CARDS_THRESHOLD = 4 * Card.MinSize.C;
+const SMALL_CARDS_THRESHOLD = 3 * Card.MinSize.C;
+const FEATURED_CARD_HEIGHT = Card.MinSize.C;
+const CARD_HEIGHT_MIN = Card.MinSize.C;
+const CARD_HEIGHT_MAX = Card.MaxSize.C;
+const MINIMUM_ARRANGEMENT_WIDTH = 2 * Card.MinSize.C;
+
+/**
+ * Class: HalfArrangement
+ * Arrangement with two featured cards and as many supporting cards as desired
+ *
+ * This arrangement shows two featured cards in the first row, followed by as
+ * many supporting cards as needed in subsequent rows.
+ *
+ * Each row of supporting cards packs either three or four, depending on the
+ * total width of the arrangement.
+ */
+const HalfArrangement = new Lang.Class({
+    Name: 'HalfArrangement',
+    Extends: Endless.CustomContainer,
+    Implements: [ Module.Module, Arrangement.Arrangement ],
+
+    Properties: {
+        'factory': GObject.ParamSpec.override('factory', Module.Module),
+        'factory-name': GObject.ParamSpec.override('factory-name', Module.Module),
+
+        /**
+         * Property: spacing
+         * The amount of space in pixels between children cards
+         *
+         * Default:
+         *   0
+         */
+        'spacing': GObject.ParamSpec.uint('spacing', 'Spacing',
+            'The amount of space in pixels between children cards',
+            GObject.ParamFlags.READWRITE,
+            0, GLib.MAXUINT16, 0),
+    },
+
+    _init: function (props={}) {
+        this._spacing = 0;
+        this._small_card_mode = false;
+        this._cards_per_row = MAX_CARDS_PER_ROW;
+
+        this.parent(props);
+    },
+
+    add_card: function (widget) {
+        this.add(widget);
+    },
+
+    get_cards: function () {
+        return this.get_children();
+    },
+
+    clear: function () {
+        this.get_children().forEach((child) => this.remove(child));
+    },
+
+    vfunc_get_preferred_width: function () {
+        return [MINIMUM_ARRANGEMENT_WIDTH + this._spacing, FOUR_CARDS_THRESHOLD * 2];
+    },
+
+    vfunc_get_preferred_height: function () {
+        // Calculate space for featured card
+        let req_height = FEATURED_CARD_HEIGHT + this._spacing;
+
+        // Calculate space for support cards
+        let children_count = this.get_children().length - HIGHLIGHTED_CARDS_COUNT;
+        let children_rows = Math.ceil(children_count / this._cards_per_row);
+        let card_height = this._small_card_mode ? CARD_HEIGHT_MIN : CARD_HEIGHT_MAX;
+        req_height += card_height * children_rows + this._spacing * (children_rows - 1);
+
+        return [req_height, req_height];
+    },
+
+    vfunc_size_allocate: function (alloc) {
+        this.parent(alloc);
+
+        let three_column_mode = alloc.width + (MIN_CARDS_PER_ROW * this._spacing) < FOUR_CARDS_THRESHOLD;
+        this._small_card_mode = alloc.width < SMALL_CARDS_THRESHOLD;
+        this._cards_per_row = (three_column_mode ? MIN_CARDS_PER_ROW : MAX_CARDS_PER_ROW);
+
+        let highlighted_width = Math.floor((alloc.width - this._spacing) / HIGHLIGHTED_CARDS_COUNT);
+        let spare_pixels = alloc.width - (highlighted_width * HIGHLIGHTED_CARDS_COUNT + this._spacing);
+
+        let x = alloc.x;
+        let y = alloc.y;
+        let all_children = this.get_children();
+
+        // Featured cards:
+        // Place two featured cards at top of arrangement
+        all_children.slice(0, HIGHLIGHTED_CARDS_COUNT).forEach((card) => {
+            let card_alloc = new Cairo.RectangleInt({
+                x: x,
+                y: y,
+                width: highlighted_width,
+                height: FEATURED_CARD_HEIGHT,
+            });
+
+            x += (highlighted_width + this._spacing + spare_pixels);
+            card.size_allocate(card_alloc);
+            card.set_child_visible(true);
+        });
+
+        x = alloc.x;
+        y += FEATURED_CARD_HEIGHT + this._spacing;
+        let gutters_per_row = this._cards_per_row - 1;
+        let card_width = Math.floor((alloc.width - gutters_per_row * this._spacing) / this._cards_per_row);
+        let card_height = this._small_card_mode ? FEATURED_CARD_HEIGHT : CARD_HEIGHT_MAX;
+        let delta_x = card_width + this._spacing;
+
+        // Calculate spare pixels
+        // The floor operation we do above may lead us to have 1..3 spare pixels
+        spare_pixels = alloc.width - (card_width * this._cards_per_row + this._spacing * gutters_per_row);
+
+        // Child cards
+        // Place rest of cards below the featured cards, in as many rows as needed
+        all_children.slice(HIGHLIGHTED_CARDS_COUNT).forEach((card, ix) => {
+            let card_alloc = new Cairo.RectangleInt({
+                x: x,
+                y: y,
+                width: card_width,
+                height: card_height,
+            });
+            card.size_allocate(card_alloc);
+            card.set_child_visible(true);
+
+            if ((ix + 1) % this._cards_per_row === 0) {
+                x = alloc.x;
+                y += card_height + this._spacing;
+            } else {
+                x += delta_x + this._get_spare_pixels_for_card_index(spare_pixels, ix);
+            }
+        });
+    },
+
+    get spacing() {
+        return this._spacing;
+    },
+
+    set spacing(value) {
+        if (this._spacing === value)
+            return;
+        this._spacing = value;
+        this.notify('spacing');
+        this.queue_resize();
+    },
+
+    _get_spare_pixels_for_card_index: function (spare_pixels, ix) {
+        if (spare_pixels === 0)
+            return 0;
+
+        // All gutters need an extra pixel
+        if (spare_pixels === this._cards_per_row - 1)
+            return 1;
+
+        let column = ix % this._cards_per_row;
+        let num_gutters = this._cards_per_row - 1;
+
+        // Assign a spare pixel to the center gutter if that helps keep things symmetric
+        if (num_gutters % 2 === 1 && spare_pixels % 2 === 1) {
+            if (column === (num_gutters - 1) / 2)
+                return 1;
+            spare_pixels--;
+        }
+        // Assign remaining spare pixels to alternating columns on either side
+        if (column < Math.ceil(spare_pixels / 2))
+            return 1;
+        if (column >= num_gutters - Math.floor(spare_pixels / 2))
+            return 1;
+        return 0;
+    },
+});

--- a/tests/js/app/modules/testHalfArrangement.js
+++ b/tests/js/app/modules/testHalfArrangement.js
@@ -1,0 +1,92 @@
+// Copyright 2015 Endless Mobile, Inc.
+
+const Gtk = imports.gi.Gtk;
+
+const Card = imports.app.interfaces.card;
+const HalfArrangement = imports.app.modules.halfArrangement;
+const Minimal = imports.tests.minimal;
+const MockWidgets = imports.tests.mockWidgets;
+const Utils = imports.tests.utils;
+
+Gtk.init(null);
+
+describe('Half Arrangement', function () {
+    beforeEach(function () {
+        this.arrangement = new HalfArrangement.HalfArrangement();
+    });
+
+    it('constructs', function () {
+        expect(this.arrangement).toBeDefined();
+    });
+
+    Minimal.test_arrangement_compliance();
+
+    describe('sizing allocation', function () {
+        beforeEach(function () {
+            let add_card = (card) => {
+                card.show_all();
+                this.arrangement.add_card(card);
+                return card;
+            };
+
+            for (let i = 0; i < 5; i++)
+                add_card(new MockWidgets.TestBox(2000));
+
+            this.win = new Gtk.OffscreenWindow();
+            this.win.add(this.arrangement);
+        });
+
+        afterEach(function () {
+            this.win.destroy();
+        });
+
+        // At width=2000, featured cards should be 1000x300,
+        // and the children cards should be 500x399.
+        testSizingArrangementForDimensions(2000, 500, Card.MaxSize.C);
+
+        // At width=1200, featured cards should be 600x300,
+        // and the children cards should be 300x399.
+        testSizingArrangementForDimensions(1200, 300, Card.MaxSize.C);
+
+        // At width=1000, featured cards should be 500x300,
+        // and the children cards should be 333x399.
+        testSizingArrangementForDimensions(1000, 333, Card.MaxSize.C);
+
+        // At width=900, featured cards should be 450x300,
+        // and the children cards should be 300x399.
+        testSizingArrangementForDimensions(900, 300, Card.MaxSize.C);
+
+        // At width=800, featured cards should be 400x300,
+        // and the children cards should be 266x300.
+        testSizingArrangementForDimensions(800, 266, Card.MinSize.C);
+
+        // At width=600, featured cards should be 300x300,
+        // and the children cards should be 200x300.
+        testSizingArrangementForDimensions(600, 200, Card.MinSize.C);
+    });
+});
+
+function testSizingArrangementForDimensions(arrangement_size, card_width, card_height) {
+    it('handles arrangement with width=' + arrangement_size, function () {
+        this.win.set_size_request(arrangement_size, arrangement_size);
+        this.win.show_all();
+
+        this.win.queue_resize();
+        Utils.update_gui();
+
+        let all_cards = this.arrangement.get_cards();
+        // Test featured cards
+        all_cards.slice(0, 2).forEach((card) => {
+            expect(card.get_child_visible()).toBe(true);
+            expect(card.get_allocation().width).toBe(arrangement_size / 2);
+            expect(card.get_allocation().height).toBe(Card.MinSize.C);
+        });
+
+        // Test support cards
+        all_cards.slice(2, all_cards.length).forEach((card) => {
+            expect(card.get_child_visible()).toBe(true);
+            expect(card.get_allocation().width).toBe(card_width);
+            expect(card.get_allocation().height).toBe(card_height);
+        });
+    });
+}

--- a/tests/smoke-tests/halfArrangementSmokeTest.js
+++ b/tests/smoke-tests/halfArrangementSmokeTest.js
@@ -1,0 +1,30 @@
+const Gtk = imports.gi.Gtk;
+
+const ColoredBox = imports.tests.coloredBox;
+const HalfArrangement = imports.app.modules.halfArrangement;
+
+Gtk.init(null);
+
+let win = new Gtk.Window();
+let scrolled_win = new Gtk.ScrolledWindow({
+    min_content_width: 600,
+    min_content_height: 600,
+});
+let arrangement = new HalfArrangement.HalfArrangement({
+    hexpand: true,
+    valign: Gtk.Align.START,
+    spacing: 0,
+});
+
+for (let i = 0; i < 10; i++) {
+    let card = new ColoredBox.ColoredBox({
+        expand: true,
+    });
+    arrangement.add_card(card);
+}
+
+scrolled_win.add(arrangement);
+win.add(scrolled_win);
+win.connect('destroy', Gtk.main_quit);
+win.show_all();
+Gtk.main();


### PR DESCRIPTION
Added the HalfArrangement, an arrangement that displays two featured cards in
the first row, and then as many rows as needed to display all additional,
supporting cards.

[endlessm/eos-sdk#3697]
