### PR TITLE
SquareGuysArrangement shows any number of rows

### DIFF
--- a/tests/js/app/modules/testSquareGuysArrangement.js
+++ b/tests/js/app/modules/testSquareGuysArrangement.js
@@ -12,11 +12,7 @@ Gtk.init(null);
 
 describe('SquareGuys arrangement', function () {
     beforeEach(function () {
-        this.arrangement = new SquareGuysArrangement.SquareGuysArrangement({
-            hexpand: false,
-            valign: Gtk.Align.START,
-            spacing: 0,
-        });
+        this.arrangement = new SquareGuysArrangement.SquareGuysArrangement();
     });
 
     it('constructs', function () {
@@ -25,49 +21,76 @@ describe('SquareGuys arrangement', function () {
 
     Minimal.test_arrangement_compliance();
 
+    describe('maximum rows', function () {
+        let msg = 'shows correct number of cards for max_rows = '
+        // At 2000x2000, and unlimited max_rows, all 20 cards should be visible
+        testSizingArrangementForDimensions(msg + 0, 2000, 2000, 0, 20, 399, 300);
+
+        // At 2000x2000, and 1 max_row, only four cards should be visible and of size 399x300
+        testSizingArrangementForDimensions(msg + 1, 2000, 2000, 1, 4, 399, 300);
+
+        // At 2000x2000, and 2 max_rows, only eight cards should be visible and of size 399x300
+        testSizingArrangementForDimensions(msg + 2, 2000, 2000, 2, 8, 399, 300);
+    });
+
     describe('sizing allocation', function () {
-        // At 2000x2000, all eight cards should be visible and of size 399x300
-        testSizingArrangementForDimensions(2000, 2000, 8, 399, 300);
+        let msg = 'handles arrangement for specified dimensions';
+        // At 2000x2000, and 2 max_rows, all eight cards should be visible and of size 399x300
+        testSizingArrangementForDimensions(msg, 2000, 2000, 2, 8, 399, 300);
 
-        // At 1200x1200, all eight cards should be visible and of size 300x300
-        testSizingArrangementForDimensions(1200, 1200, 8, 300, 300);
+        // At 1200x1200, and 2 max_rows, all eight cards should be visible and of size 300x300
+        testSizingArrangementForDimensions(msg, 1200, 1200, 2, 8, 300, 300);
 
-        // At 1000x1000, only first six cards should be visible; all cards of size 333x300
-        testSizingArrangementForDimensions(1000, 1000, 6, 333, 300);
+        // At 1000x1000, and 2 max_rows, only first six cards should be visible; all cards of size 333x300
+        testSizingArrangementForDimensions(msg, 1000, 1000, 2, 6, 333, 300);
 
-        // At 900x900, only first six cards should be visible; all cards of size 300x300
-        testSizingArrangementForDimensions(900, 900, 6, 300, 300);
+        // At 900x900, and 2 max_rows, only first six cards should be visible; all cards of size 300x300
+        testSizingArrangementForDimensions(msg, 900, 900, 2, 6, 300, 300);
 
-        // At 800x600, only first six cards should be visible; all cards of size 266x200
-        testSizingArrangementForDimensions(800, 600, 6, 266, 200);
+        // At 800x600, and 2 max_rows, only first six cards should be visible; all cards of size 266x200
+        testSizingArrangementForDimensions(msg, 800, 600, 2, 6, 266, 200);
 
-        // At 600x400, only first six cards should be visible; all cards of size 200x200
-        testSizingArrangementForDimensions(600, 400, 6, 200, 200);
+        // At 600x400, and 2 max_rows, only first six cards should be visible; all cards of size 200x200
+        testSizingArrangementForDimensions(msg, 600, 400, 2, 6, 200, 200);
     });
 });
 
-function testSizingArrangementForDimensions(arr_width, arr_height, visible_children, child_width, child_height) {
-    it ('handles arrangement with dimensions ' + arr_width + 'x' + arr_height, function () {
-        let add_card = (card) => {
+function testSizingArrangementForDimensions(message, arr_width, arr_height, max_rows, visible_children, child_width, child_height) {
+    let arrangement, cards, add_card, win;
+
+    beforeEach(function () {
+        arrangement = new SquareGuysArrangement.SquareGuysArrangement({
+            hexpand: false,
+            valign: Gtk.Align.START,
+            spacing: 0,
+            max_rows: max_rows,
+        });
+        add_card = (card) => {
             card.show_all();
-            this.arrangement.add(card);
+            arrangement.add(card);
             return card;
         };
-        let cards = [];
+        cards = [];
+        win = new Gtk.OffscreenWindow();
+    });
 
-        this.win = new Gtk.OffscreenWindow();
-        this.win.add(this.arrangement);
-        this.win.set_size_request(arr_width, arr_height);
-        this.win.show_all();
+    afterEach(function () {
+        win.destroy();
+    });
+
+    it (message + ' (' + arr_width + 'x' + arr_height + ')', function () {
+        win.add(arrangement);
+        win.set_size_request(arr_width, arr_height);
+        win.show_all();
 
         for (let i=0; i<8; i++) {
             cards.push(add_card(new MockWidgets.TestBox(400)));
         }
 
-        this.win.queue_resize();
+        win.queue_resize();
         Utils.update_gui();
 
-        this.arrangement.get_children().forEach((card, i) => {
+        arrangement.get_children().forEach((card, i) => {
             if (i < visible_children) {
                 expect(card.get_allocation().width).toBe(child_width);
                 expect(card.get_allocation().height).toBe(child_height);
@@ -76,7 +99,5 @@ function testSizingArrangementForDimensions(arr_width, arr_height, visible_child
                 expect(card.get_child_visible()).toBe(false);
             }
         });
-
-        this.win.destroy();
     });
 }

--- a/tests/smoke-tests/squareGuysArrangementSmokeTest.js
+++ b/tests/smoke-tests/squareGuysArrangementSmokeTest.js
@@ -6,10 +6,15 @@ const SquareGuysArrangement = imports.app.modules.squareGuysArrangement;
 Gtk.init(null);
 
 let win = new Gtk.Window();
+let scrolled_win = new Gtk.ScrolledWindow({
+    min_content_width: 600,
+    min_content_height: 600,
+});
 let arrangement = new SquareGuysArrangement.SquareGuysArrangement({
     hexpand: false,
     valign: Gtk.Align.START,
     spacing: 8,
+    max_rows: 0,
 });
 
 for (let i = 0; i < 10; i++) {
@@ -19,7 +24,8 @@ for (let i = 0; i < 10; i++) {
     arrangement.add(card);
 }
 
+scrolled_win.add(arrangement);
+win.add(scrolled_win);
 win.connect('destroy', Gtk.main_quit);
-win.add(arrangement);
 win.show_all();
 Gtk.main();


### PR DESCRIPTION
Originally, SquareGuysArrangement was meant to always show two rows of square
cards. But in some other situations, we may want to show only one show, or even
unlimited rows.

We now have a max_rows property to handle this.

[endlessm/eos-sdk#3775]
