### PR TITLE
Only issue search ready signal when search is complete

### DIFF
--- a/js/app/modules/buffetInteraction.js
+++ b/js/app/modules/buffetInteraction.js
@@ -187,11 +187,11 @@ const BuffetInteraction = new Lang.Class({
                 action_type: Actions.APPEND_SEARCH,
                 models: results,
             });
-        });
 
-        dispatcher.dispatch({
-            action_type: Actions.SEARCH_READY,
-            query: history_item.query,
+            dispatcher.dispatch({
+                action_type: Actions.SEARCH_READY,
+                query: history_item.query,
+            });
         });
     },
 


### PR DESCRIPTION
We had a bug where we were issuing a search ready signal
before the async callback from engine had been called.
This meant that the search page thought it had no results
and so showed the no results page.

[endlessm/eos-sdk#3780]
