### PR TITLE
Interaction does not expose view property

### DIFF
--- a/js/app/application.js
+++ b/js/app/application.js
@@ -90,7 +90,7 @@ const Application = new Lang.Class({
     },
 
     vfunc_window_removed: function (win) {
-        if (this._interaction && this._interaction.view === win) {
+        if (this._interaction) {
             Dispatcher.get_default().reset();
             this._interaction = null;
         }


### PR DESCRIPTION
Previously in our EosApplication instance, when a window was removed we
checked whether it was the main window of our interaction. We can't do
that anymore because we removed the Interaction.view property. However, I
believe the check is unnecessary because all of our apps only have one
window; so just remove it.

This was preventing a window from opening when the app was activated a
second time after closing a window the first time.

[endlessm/eos-sdk#3691]
