### PR TITLE
sideMenuTemplate: only trigger side menu when mouse on left

### DIFF
--- a/js/app/modules/sideMenuTemplate.js
+++ b/js/app/modules/sideMenuTemplate.js
@@ -115,7 +115,7 @@ const SideMenuTemplate = new Lang.Class({
     },
 
     _on_motion: function (widget, event) {
-        let [got_coords, x] = event.get_coords();
+        let [got_coords, x] = event.get_root_coords();
         if (!got_coords)
             return Gdk.EVENT_PROPAGATE;
 


### PR DESCRIPTION
gdk event coordinates are relative to their gdk windows. Triggering
the side menu when the x value of the coordinates is <3 will trigger
the side menu on mouseover of the left side of any gdk window in
the sideMenuTemplate.

This was biting us with scrolled windows somewhere. We can just
use absolute coordinates. This won't work if the entire template
is not on the left of the window, but the entire feature would
not make sense in that case.
[endlessm/eos-sdk#3801]
