### PR TITLE
Add hover color to side menu

### DIFF
--- a/data/css/endless_buffet.css
+++ b/data/css/endless_buffet.css
@@ -182,7 +182,8 @@ EknSideMenuTemplate .menu .card .title {
     font-weight: bold;
 }
 
-EknSideMenuTemplate .menu .home-button:hover {
+EknSideMenuTemplate .menu .home-button:hover,
+EknSideMenuTemplate .menu .card:hover .title {
     color: #5bc2e5;
 }
 


### PR DESCRIPTION
The category titles in the side menu are now light blue on mouseover,
just like how the HOME label already behaved.

[endlessm/eos-sdk#3805]
