### PR TITLE
sideMenuTemplate: only trigger menu when mouse on left

### DIFF
--- a/js/app/modules/sideMenuTemplate.js
+++ b/js/app/modules/sideMenuTemplate.js
@@ -115,10 +115,12 @@ const SideMenuTemplate = new Lang.Class({
     },
 
     _on_motion: function (widget, event) {
-        let [got_coords, x] = event.get_coords();
+        let [got_coords, event_x] = event.get_root_coords();
         if (!got_coords)
             return Gdk.EVENT_PROPAGATE;
 
+        let [ret, win_x, win_y] = this.get_window().get_origin();
+        let x = event_x - win_x;
         if (!this.menu_open && x <= _MENU_HOT_ZONE_WIDTH_PX)
             this._open_menu();
         else if (this.menu_open && x > this._menu_grid.get_allocation().width)


### PR DESCRIPTION
Take two. Trigger the menu when event.get_coords().x < 3 will trigger
improperly when mousing over gdk windows that aren't on the left of
the template.

By using absolute coordinates everywhere in our calculations we should
not only trigger for mouse motion that really on the left three pixels
of the template
[endlessm/eos-sdk#3801]
