### PR TITLE
Dispatch first launch when sets are loaded

### DIFF
--- a/tests/js/app/modules/testMeshInteraction.js
+++ b/tests/js/app/modules/testMeshInteraction.js
@@ -141,6 +141,8 @@ describe('Mesh interaction', function () {
     it('can be constructed', function () {});
 
     it('dispatches category models for home page', () => {
+        mesh.desktop_launch(0);
+        Utils.update_gui();
         let payloads = dispatcher.dispatched_payloads.filter((payload) => {
             return payload.action_type === Actions.APPEND_SETS;
         });
@@ -164,6 +166,7 @@ describe('Mesh interaction', function () {
 
     it('dispatches app-launched on launch from desktop', function () {
         mesh.desktop_launch(0);
+        Utils.update_gui();
         expect(dispatcher.last_payload_with_type(Actions.FIRST_LAUNCH).launch_type)
             .toBe(Launcher.LaunchType.DESKTOP);
     });
@@ -185,6 +188,7 @@ describe('Mesh interaction', function () {
         engine.get_object_by_id_finish.and.returnValue(new ContentObjectModel.ContentObjectModel());
 
         mesh.desktop_launch(0);
+        Utils.update_gui();
         let payloads = dispatcher.payloads_with_type(Actions.FIRST_LAUNCH);
         expect(payloads.length).toBe(1);
 


### PR DESCRIPTION
Previously we would dispatch the "first launch" action when the app was
launched for the first time, as its name suggests. This is still what we
do for launches from search and from search results. For desktop launch,
however, we need to dispatch first launch only after the sets have
finished loading, so that we never show an unpopulated home page.

This involves splitting the initial sets query out into its own async
method, and calling that method in the launcher methods instead of in the
constructor. For desktop launch, we then dispatch the appropriate actions
in the callback. For the other two launch types, the callback is just a
dummy callback, because we don't start out showing the home page, so the
sets can just load in the background.

[endlessm/eos-sdk#3795]
