### PR TITLE
Wait to hide brand screen until all content has loaded

### DIFF
--- a/js/app/actions.js
+++ b/js/app/actions.js
@@ -33,6 +33,7 @@ const CLEAR_HIGHLIGHTED_ITEM = 'clear-highlighted-item';
 const APPEND_SETS = 'append-sets';
 const APPEND_ITEMS = 'append-items';
 const APPEND_SEARCH = 'append-search';
+const MODULE_READY = 'module-ready';
 const NEED_MORE_SUGGESTED_ARTICLES = 'need-more-suggested-articles';
 const APPEND_SUGGESTED_ARTICLES = 'append-suggested-articles';
 const CLEAR_SUGGESTED_ARTICLES = 'clear-suggested-articles';

--- a/js/app/modules/highlightsModule.js
+++ b/js/app/modules/highlightsModule.js
@@ -144,6 +144,10 @@ const HighlightsModule = new Lang.Class({
             all_models = all_models.concat(models);
             if (get_more === null) {
                 all_models.forEach(this._add_item, this);
+                Dispatcher.get_default().dispatch({
+                    action_type: Actions.MODULE_READY,
+                    module: this,
+                });
                 return;
             }
             engine.get_objects_by_query(get_more, null, process_results);

--- a/tests/js/app/modules/testBuffetInteraction.js
+++ b/tests/js/app/modules/testBuffetInteraction.js
@@ -101,6 +101,9 @@ describe('Buffet interaction', function () {
         buffet.BRAND_SCREEN_TIME_MS = 0;
         buffet.desktop_launch(0);
         expect(dispatcher.last_payload_with_type(Actions.BRAND_SCREEN_DONE)).not.toBeDefined();
+        dispatcher.dispatch({
+            action_type: Actions.MODULE_READY,
+        });
         Utils.update_gui();
         expect(dispatcher.last_payload_with_type(Actions.BRAND_SCREEN_DONE)).toBeDefined();
     });
@@ -108,6 +111,9 @@ describe('Buffet interaction', function () {
     it('shows the brand screen only once', function () {
         buffet.BRAND_SCREEN_TIME_MS = 0;
         buffet.desktop_launch(0);
+        dispatcher.dispatch({
+            action_type: Actions.MODULE_READY,
+        });
         buffet.desktop_launch(0);
         Utils.update_gui();
         let payloads = dispatcher.payloads_with_type(Actions.BRAND_SCREEN_DONE);


### PR DESCRIPTION
Previously we would transition away from the brand loading
page after a fixed period of time. Sometimes, not enough
time had elapsed for the content to load so the user
would see a blank page for a second or two. Now we
wait until the content has entirely loaded.

[endlessm/eos-sdk#3798]
