### PR TITLE
v1-preset-json: fix reader sidebar

### DIFF
--- a/data/compat/v1-preset-json/reader.json
+++ b/data/compat/v1-preset-json/reader.json
@@ -37,9 +37,6 @@
         },
         "front-page": {
             "type": "SidebarTemplate",
-            "properties": {
-                "on-left": false
-            },
             "slots": {
                 "content": {
                     "type": "AppBanner",
@@ -73,6 +70,7 @@
                 }
             },
             "properties": {
+                "on-left": false,
                 "sidebar-width": 576,
                 "fixed": false,
                 "column-homogeneous": true,


### PR DESCRIPTION
Accidentally added a double properties object, so the property
putting the sidebar on the right hand side of the home page was
not kicking in.
[endlessm/eos-sdk#3561]
