### PR TITLE
arrangements: properly set clip

### DIFF
--- a/js/app/modules/halfArrangement.js
+++ b/js/app/modules/halfArrangement.js
@@ -11,6 +11,7 @@ const Lang = imports.lang;
 const Arrangement = imports.app.interfaces.arrangement;
 const Card = imports.app.interfaces.card;
 const Module = imports.app.interfaces.module;
+const Utils = imports.app.utils;
 
 const FEATURED_CARDS_PER_ROW = 2;
 const MAX_CARDS_PER_ROW = 4;
@@ -160,6 +161,7 @@ const HalfArrangement = new Lang.Class({
                 x += delta_x + this._get_spare_pixels_for_card_index(spare_pixels, ix);
             }
         });
+        Utils.set_container_clip(this);
     },
 
     get spacing() {

--- a/js/app/modules/squareGuysArrangement.js
+++ b/js/app/modules/squareGuysArrangement.js
@@ -12,6 +12,7 @@ const Lang = imports.lang;
 const Arrangement = imports.app.interfaces.arrangement;
 const Card = imports.app.interfaces.card;
 const Module = imports.app.interfaces.module;
+const Utils = imports.app.utils;
 
 const COL_COUNT_MAX = 4;
 const COL_COUNT_MIN = 3;
@@ -138,6 +139,7 @@ const SquareGuysArrangement = new Lang.Class({
         all_children.slice(visible_children_count, all_children.length).forEach((card) => {
             card.set_child_visible(false);
         });
+        Utils.set_container_clip(this);
     },
 
     get spacing() {

--- a/js/app/modules/windshieldArrangement.js
+++ b/js/app/modules/windshieldArrangement.js
@@ -11,6 +11,7 @@ const Lang = imports.lang;
 const Arrangement = imports.app.interfaces.arrangement;
 const Card = imports.app.interfaces.card;
 const Module = imports.app.interfaces.module;
+const Utils = imports.app.utils;
 
 const SECOND_ROW_CARD_COUNT = 3;
 const CARD_SIZE_SMALL = Card.MinSize.B;
@@ -137,6 +138,7 @@ const WindshieldArrangement = new Lang.Class({
         all_children.slice(SECOND_ROW_CARD_COUNT + 1, all_children.length).forEach((card) => {
             card.set_child_visible(false);
         });
+        Utils.set_container_clip(this);
     },
 
     get spacing() {

--- a/js/app/utils.js
+++ b/js/app/utils.js
@@ -223,3 +223,16 @@ function has_descendant_with_type (widget, klass) {
     }
     return false;
 }
+
+// Kinda annoying quirk of gtk--any container doing a custom allocate needs to
+// set its clip properly to accommodate widgets that draw outside of their
+// allocation (such as widgets with box shadow). Call this function to do so.
+function set_container_clip (container) {
+    let clip = container.get_allocation();
+    container.forall((child) => {
+        if (child.get_child_visible() && child.get_visible()) {
+            clip = Gdk.rectangle_union(child.get_clip(), clip);
+        }
+    });
+    container.set_clip(clip);
+}


### PR DESCRIPTION
Any container with a custom size allocate needs to set its clip
properly to be the union of its visible children's clips. In tree
gtk widgets have much better tools to tackle this, but added a
simple util function that should accommodate our needs for now.
[endlessm/eos-sdk#3784]
