### PR TITLE
Render borders, triangles, and arrows on cards

### DIFF
--- a/data/css/endless_buffet.css
+++ b/data/css/endless_buffet.css
@@ -140,6 +140,49 @@ EknScrollingTemplate .no-results {
 .search-result-card {
     background-color: white;
     box-shadow: 0 0 5px alpha(black, 0.25);
+    border-color: transparent;  /* used for the triangle in the corner */
+}
+
+.post-card.set .thumbnail {
+    border: 0px solid transparent;  /* used for the triangle in the corner */
+}
+
+.thumb-card.arrow,
+.post-card.article.arrow,
+.search-result-card.arrow {
+    -gtk-icon-source: url('resource:///com/endlessm/knowledge/data/images/arrow-gray.svg');
+    -gtk-icon-transform: rotate(45deg);
+}
+
+.thumb-card:hover,
+.thumb-card:active,
+.post-card.article:hover,
+.post-card.article:active,
+.post-card.set:hover .thumbnail,
+.post-card.set:active .thumbnail,
+.search-result-card:hover,
+.search-result-card:active {
+    outline: 1px solid #49bde3;
+    border-color: #49bde3;  /* used for the triangle in the corner */
+    outline-offset: -1px;
+    outline-radius: 0;
+}
+
+.thumb-card:active,
+.post-card.article:active,
+.search-result-card:active {
+    box-shadow: none;
+}
+
+.thumb-card.arrow:hover,
+.thumb-card.arrow:active,
+.post-card.article.arrow:hover,
+.post-card.article.arrow:active,
+.post-card.set .thumbnail.arrow, /* both hover and non-hover */
+.search-result-card.arrow:hover,
+.search-result-card.arrow:active {
+    -gtk-icon-source: url('resource:///com/endlessm/knowledge/data/images/arrow-white.svg');
+    -gtk-icon-transform: rotate(45deg);
 }
 
 .post-card.article .content-frame {
@@ -156,6 +199,10 @@ EknScrollingTemplate .no-results {
     background-repeat: no-repeat;
     background-size: 100% 100%;
     background-position: center;
+}
+
+.post-card.set:active {
+    background-size: 98% 98%;
 }
 
 .post-card.set .content-frame {

--- a/data/images/arrow-gray.svg
+++ b/data/images/arrow-gray.svg
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" width="16" height="16"
+  viewBox="0 0 16 16">
+  <path style="fill:#bebebe;stroke:none"
+    d="m 7.5,13.5 c 0,0 2.89469,-2.897166 4.5,-4.5 L 0,9 0,7 12,7 C 10.39469,5.3946891 7.5,2.5 7.5,2.5 L 9,1 16,8 9,15 z"/>
+</svg>

--- a/data/images/arrow-white.svg
+++ b/data/images/arrow-white.svg
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" width="16" height="16"
+  viewBox="0 0 16 16">
+  <path style="fill:white;stroke:none"
+    d="m 7.5,13.5 c 0,0 2.89469,-2.897166 4.5,-4.5 L 0,9 0,7 12,7 C 10.39469,5.3946891 7.5,2.5 7.5,2.5 L 9,1 16,8 9,15 z"/>
+</svg>

--- a/eos-knowledge.gresource.xml
+++ b/eos-knowledge.gresource.xml
@@ -22,6 +22,8 @@
     <file preprocess="xml-stripblanks">data/images/reader/left-arrow.svg</file>
     <file preprocess="xml-stripblanks">data/images/reader/right-arrow.svg</file>
     <file preprocess="xml-stripblanks">data/images/reader/standalone_arrow.svg</file>
+    <file preprocess="xml-stripblanks" compressed="true">data/images/arrow-gray.svg</file>
+    <file preprocess="xml-stripblanks" compressed="true">data/images/arrow-white.svg</file>
     <file preprocess="xml-stripblanks">data/images/deckbg.svg</file>
     <file preprocess="xml-stripblanks">data/images/sleeveshadow_left.svg</file>
     <file preprocess="xml-stripblanks">data/images/sleeveshadow_right.svg</file>

--- a/js/app/modules/searchResultCard.js
+++ b/js/app/modules/searchResultCard.js
@@ -1,6 +1,7 @@
 // Copyright 2015 Endless Mobile, Inc.
 
 const Cairo = imports.gi.cairo;
+const Gdk = imports.gi.Gdk;
 const GObject = imports.gi.GObject;
 const Lang = imports.lang;
 
@@ -76,5 +77,12 @@ const SearchResultCard = new Lang.Class({
         this._content_frame.size_allocate(text_alloc);
 
         this.update_card_sizing_classes(total_width, alloc.width);
+    },
+
+    vfunc_draw: function (cr) {
+        this.parent(cr);
+        Utils.render_border_with_arrow(this, cr);
+        cr.$dispose();  // workaround bug for not freeing cairo context
+        return Gdk.EVENT_PROPAGATE;
     },
 });

--- a/js/app/modules/thumbCard.js
+++ b/js/app/modules/thumbCard.js
@@ -1,6 +1,7 @@
 // Copyright 2015 Endless Mobile, Inc.
 
 const Cairo = imports.gi.cairo;
+const Gdk = imports.gi.Gdk;
 const GObject = imports.gi.GObject;
 const Gtk = imports.gi.Gtk;
 const Lang = imports.lang;
@@ -101,6 +102,13 @@ const ThumbCard = new Lang.Class({
         this._thumbnail_frame.size_allocate(thumb_alloc);
         this._content_frame.size_allocate(text_alloc);
         this.update_card_sizing_classes(alloc.height, alloc.width);
+    },
+
+    vfunc_draw: function (cr) {
+        this.parent(cr);
+        Utils.render_border_with_arrow(this, cr);
+        cr.$dispose();  // workaround bug for not freeing cairo context
+        return Gdk.EVENT_PROPAGATE;
     },
 
     _should_go_horizontal: function (width, height) {

--- a/js/app/utils.js
+++ b/js/app/utils.js
@@ -1,5 +1,6 @@
 /* exported dbus_object_path_for_webview, get_web_plugin_dbus_name,
-get_web_plugin_dbus_name_for_webview, has_descendant_with_type */
+get_web_plugin_dbus_name_for_webview, has_descendant_with_type,
+render_border_with_arrow */
 
 const EosKnowledgePrivate = imports.gi.EosKnowledgePrivate;
 const Format = imports.format;
@@ -235,4 +236,30 @@ function set_container_clip (container) {
         }
     });
     container.set_clip(clip);
+}
+
+function render_border_with_arrow (widget, cr) {
+    let context = widget.get_style_context();
+    let width = widget.get_allocated_width();
+    let height = widget.get_allocated_height();
+
+    // Draw focus rectangle even when the widget is not focused, so we can
+    // style it with outline
+    Gtk.render_focus(context, cr, 0, 0, width, height);
+
+    // Render the triangle in the corner
+    // FIXME: gtk_style_context_get_border_color is deprecated; ideally we
+    // want to get the "outline" style rather than the "border" style, but
+    // that is private to GTK and can only be accessed with render_focus().
+    let color = context.get_border_color(context.get_state());
+    cr.save();
+    Gdk.cairo_set_source_rgba(cr, color);
+    cr.moveTo(width, height);
+    cr.lineTo(width - 36, height);
+    cr.lineTo(width, height - 36);
+    cr.fill();
+    cr.restore();
+
+    // Render the arrow on top of the triangle
+    Gtk.render_arrow(context, cr, 0, width - 15, height - 15, 12);
 }


### PR DESCRIPTION
This (ab)uses the "outline" CSS property and gtk_render_focus() to render
a blue border on top of the cards on hover, hopefully without causing a
reallocation, which the "border" property would do.

It also renders triangles with arrows inside them in the lower right
corners. I created the arrow SVGs myself since the one from design was
actually a PNG.

InVision specs:
https://endlessm.invisionapp.com/d/main#/console/4678196/107218154/preview

[endlessm/eos-sdk#3797]
