### PR TITLE
Put no search results page inside scrolled window.

### DIFF
--- a/data/css/endless_buffet.css
+++ b/data/css/endless_buffet.css
@@ -51,16 +51,17 @@ EknThematicModule .text-card .title.label,
     padding: 20px 50px;
 }
 
-EknScrollingTemplate .suggested-categories,
-EknScrollingTemplate .suggested-articles {
+EknSearchModule .suggested-categories,
+EknSearchModule .suggested-articles {
     background-color: #f6f6f6;
 }
 
-EknScrollingTemplate:not(.overshoot):not(.undershoot) {
+EknScrollingTemplate:not(.overshoot):not(.undershoot),
+EknSearchModule {
     background-color: #e7ecee;
 }
 
-EknScrollingTemplate .no-results {
+EknSearchModule .no-results {
     background-color: white;
 }
 

--- a/data/widgets/searchModule.ui
+++ b/data/widgets/searchModule.ui
@@ -24,61 +24,67 @@
       </packing>
     </child>
     <child>
-      <object class="GtkGrid" id="no-results-grid">
+      <object class="GtkScrolledWindow" id="scrolled-window">
         <property name="visible">True</property>
         <property name="can_focus">False</property>
-        <property name="orientation">vertical</property>
-        <property name="halign">fill</property>
-        <property name="hexpand">True</property>
         <child>
-          <object class="GtkGrid" id="message-grid">
-            <property name="orientation">vertical</property>
+          <object class="GtkGrid" id="no-results-grid">
             <property name="visible">True</property>
             <property name="can_focus">False</property>
-            <property name="halign">center</property>
-            <property name="valign">start</property>
+            <property name="orientation">vertical</property>
+            <property name="halign">fill</property>
             <property name="hexpand">True</property>
             <child>
-              <object class="GtkLabel" id="message-title">
-                <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="halign">start</property>
-                <property name="valign">fill</property>
-                <property name="vexpand">True</property>
-                <property name="label">Placeholder</property>
-                <property name="wrap">True</property>
-                <property name="wrap_mode">word-char</property>
-                <property name="ellipsize">end</property>
-                <property name="lines">5</property>
-                <property name="use_markup">True</property>
-                <style>
-                  <class name="results-message-title"/>
-                </style>
-              </object>
-            </child>
-            <child>
-              <object class="GtkSeparator" id="separator">
-                <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="hexpand">True</property>
-                <property name="halign">fill</property>
-              </object>
-            </child>
-            <child>
-              <object class="GtkLabel" id="message-subtitle">
+              <object class="GtkGrid" id="message-grid">
+                <property name="orientation">vertical</property>
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
                 <property name="halign">center</property>
+                <property name="valign">start</property>
                 <property name="hexpand">True</property>
-                <property name="label">Placeholder</property>
-                <property name="wrap">True</property>
-                <property name="wrap_mode">word-char</property>
-                <property name="ellipsize">end</property>
-                <property name="lines">5</property>
-                <property name="use_markup">True</property>
-                <style>
-                  <class name="results-message-subtitle"/>
-                </style>
+                <child>
+                  <object class="GtkLabel" id="message-title">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="halign">start</property>
+                    <property name="valign">fill</property>
+                    <property name="vexpand">True</property>
+                    <property name="label">Placeholder</property>
+                    <property name="wrap">True</property>
+                    <property name="wrap_mode">word-char</property>
+                    <property name="ellipsize">end</property>
+                    <property name="lines">5</property>
+                    <property name="use_markup">True</property>
+                    <style>
+                      <class name="results-message-title"/>
+                    </style>
+                  </object>
+                </child>
+                <child>
+                  <object class="GtkSeparator" id="separator">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="hexpand">True</property>
+                    <property name="halign">fill</property>
+                  </object>
+                </child>
+                <child>
+                  <object class="GtkLabel" id="message-subtitle">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="halign">center</property>
+                    <property name="hexpand">True</property>
+                    <property name="label">Placeholder</property>
+                    <property name="wrap">True</property>
+                    <property name="wrap_mode">word-char</property>
+                    <property name="ellipsize">end</property>
+                    <property name="lines">5</property>
+                    <property name="use_markup">True</property>
+                    <style>
+                      <class name="results-message-subtitle"/>
+                    </style>
+                  </object>
+                </child>
               </object>
             </child>
           </object>


### PR DESCRIPTION
Previously we were putting the entire search module
inside a scrolled window. This doesn't work though,
because the ListArrangement is in its own scrolled
window so you end up with two scrollbars.

Instead we put just the no results page in a scrolled
window, and the ListArrangement can continue using
its own proprietary scroll.

[endlessm/eos-sdk#3822]
