### PR TITLE
Fixes to Template B apps on composite mode

### DIFF
--- a/data/compat/v1-preset-json/B.json
+++ b/data/compat/v1-preset-json/B.json
@@ -41,7 +41,7 @@
                 "top-left": {
                     "type": "AppBanner",
                     "properties": {
-                        "min-fraction": 0.4,
+                        "min-fraction": 0.3,
                         "max-fraction": 0.7,
                         "valign": "center",
                         "halign": "center",

--- a/data/css/endless_knowledge.css
+++ b/data/css/endless_knowledge.css
@@ -418,8 +418,8 @@ EknWindow.background-right {
 .search-page-b .search-results .results-message-title,
 .search-page-b .search-results .results-message-subtitle,
 .search-page-b .search-results .error-message {
-    font-size: 1.2em;
-    padding: 10px 25px;
+    font-size: 0.8em;
+    padding: 8px 15px;
 }
 
 .section-page-a GtkSeparator,

--- a/data/widgets/searchBannerModule.ui
+++ b/data/widgets/searchBannerModule.ui
@@ -9,7 +9,7 @@
     <property name="halign">fill</property>
     <property name="label">Search results for ...</property>
     <property name="ellipsize">end</property>
-    <property name="lines">5</property>
+    <property name="lines">3</property>
     <property name="wrap">True</property>
     <property name="wrap_mode">word-char</property>
     <property name="xalign">0</property>

--- a/js/app/modules/dividedBannerTemplate.js
+++ b/js/app/modules/dividedBannerTemplate.js
@@ -1,3 +1,4 @@
+const Cairo = imports.gi.cairo;
 const GObject = imports.gi.GObject;
 const Gtk = imports.gi.Gtk;
 const Lang = imports.lang;
@@ -26,6 +27,9 @@ const DividedBannerTemplate = new Lang.Class({
 
     Template: 'resource:///com/endlessm/knowledge/data/widgets/dividedBannerTemplate.ui',
 
+    WIDTH_THRESHOLD: 800,
+    SMALL_TOP_RIGHT_SLOT: 200,
+
     _init: function (props={}) {
         this._cards = null;
         this.parent(props);
@@ -40,9 +44,25 @@ const DividedBannerTemplate = new Lang.Class({
             this.attach.bind(this, submodule).apply(this, PACKING_ARGS[slot]);
             this['_' + slot] = submodule;
         });
+
+        this._orig_row_spacing = this.row_spacing;
     },
 
     get_slot_names: function () {
         return [ 'top-left', 'top-right', 'bottom' ];
+    },
+
+    vfunc_size_allocate: function (alloc) {
+        this.parent(alloc);
+
+        if (alloc.width < this.WIDTH_THRESHOLD) {
+            this._orig_row_spacing = this.row_spacing;
+            this.row_spacing = this._orig_row_spacing / 2;
+            let top_right_alloc = this['_top-right'].get_allocation();
+            top_right_alloc.width = this.SMALL_TOP_RIGHT_SLOT;
+            this['_top-right'].size_allocate(top_right_alloc);
+        } else {
+            this.row_spacing = this._orig_row_spacing;
+        }
     },
 });


### PR DESCRIPTION
We add some visual fixes to Template B apps so that they are displayed nicely
on composite mode, which calls for a 720x480 resolution.

The biggest change is the adjustments required by the sidebar template to reduce
the width of the sidebar when the app window is reduced below a certain
threshold.

[endlessm/eos-sdk#3752]
