### PR TITLE
Process dispatcher actions only when needed

### DIFF
--- a/js/app/application.js
+++ b/js/app/application.js
@@ -105,7 +105,6 @@ const Application = new Lang.Class({
     // To be overridden in subclass
     ensure_interaction: function () {
         if (this._interaction === null) {
-            Dispatcher.get_default().start();
             this._interaction = InteractionLoader.create_interaction(this, this.resource_path);
         }
     },

--- a/tests/js/app/testDispatcher.js
+++ b/tests/js/app/testDispatcher.js
@@ -11,7 +11,6 @@ describe('Dispatcher', function () {
         jasmine.addMatchers(InstanceOfMatcher.customMatchers);
 
         dispatcher = new Dispatcher.Dispatcher();
-        dispatcher.start();
     });
 
     afterEach(function () {
@@ -84,7 +83,6 @@ describe('Dispatcher', function () {
             dispatcher.register(spy1);
             dispatcher.register(spy2);
             dispatcher.reset();
-            dispatcher.start();
             dispatcher.dispatch({
                 action_type: 'foo',
             });
@@ -100,7 +98,6 @@ describe('Dispatcher', function () {
                 action_type: 'foo',
             });
             dispatcher.reset();
-            dispatcher.start();
             let spy = jasmine.createSpy();
             dispatcher.register(spy);
             GLib.idle_add(GLib.PRIORITY_LOW, () => {
@@ -109,36 +106,15 @@ describe('Dispatcher', function () {
             });
         });
     });
-});
 
-// Spying on GLib.source_remove is unfortunately an implementation detail.
-describe('Dispatcher start and stop', function () {
-    let dispatcher;
-
-    beforeEach(function () {
+    // Spying on GLib.source_remove and expecting the idle source to be added
+    // as a consequence of dispatch() is unfortunately an implementation detail.
+    it('does not stop twice if calling stop() twice', function () {
         spyOn(GLib, 'source_remove').and.callThrough();
-        dispatcher = new Dispatcher.Dispatcher();
-    });
-
-    it('does not start twice if calling start() twice', function (done) {
-        dispatcher.start();
-        let spy = jasmine.createSpy();
-        dispatcher.register(spy);
-        dispatcher.start();
-        dispatcher.stop();
+        let dispatcher = new Dispatcher.Dispatcher();
         dispatcher.dispatch({
             action_type: 'foo',
         });
-        GLib.idle_add(GLib.PRIORITY_LOW, () => {
-            expect(spy).not.toHaveBeenCalled();
-            expect(GLib.source_remove.calls.count()).toEqual(1);
-            done();
-            return GLib.SOURCE_REMOVE;
-        });
-    });
-
-    it('does not stop twice if calling stop() twice', function () {
-        dispatcher.start();
         dispatcher.stop();
         dispatcher.stop();
         expect(GLib.source_remove.calls.count()).toEqual(1);


### PR DESCRIPTION
Instead of checking the dispatcher queue in an idle function that runs
over and over again, only start processing the queue when an action is
dispatched. Also stop the idle function when the queue becomes empty.

This prevents CPU load from going to 100% while the app is not doing
anything.

This makes the dispatcher's start() method obsolete, so remove it.

[endlessm/eos-sdk#3833]
