### PR TITLE
Don't align the search module to the center

### DIFF
--- a/data/compat/v1-preset-json/A.json
+++ b/data/compat/v1-preset-json/A.json
@@ -150,7 +150,6 @@
                         "category-suggestions": null
                     },
                     "properties": {
-                        "halign": "center",
                         "message-justify": "left",
                         "message-halign": "center"
                     }


### PR DESCRIPTION
We don't want it centered. We want it to naturally
fill its available space.

[endlessm/eos-sdk#3822]
