### PR TITLE
Adjust margins to fit in composite mode

### DIFF
--- a/data/compat/v1-preset-json/buffet.json
+++ b/data/compat/v1-preset-json/buffet.json
@@ -77,8 +77,8 @@
                                         "halign": "center",
                                         "margin-top": 20,
                                         "margin-bottom": 20,
-                                        "margin-start": 50,
-                                        "margin-end": 50
+                                        "margin-start": 20,
+                                        "margin-end": 20
                                     },
                                     "slots": {
                                         "arrangement": {
@@ -115,8 +115,8 @@
                                         "halign": "center",
                                         "margin-top": 20,
                                         "margin-bottom": 20,
-                                        "margin-start": 50,
-                                        "margin-end": 50
+                                        "margin-start": 20,
+                                        "margin-end": 20
                                     },
                                     "slots": {
                                         "large-arrangement": {
@@ -207,8 +207,8 @@
                     "properties" : {
                         "max-rows": 1,
                         "spacing": 10,
-                        "margin-start": 50,
-                        "margin-end": 50,
+                        "margin-start": 20,
+                        "margin-end": 20,
                         "margin-bottom": 20
                     }
                 },
@@ -224,8 +224,8 @@
                         "max-rows": 1,
                         "valign": "end",
                         "spacing": 20,
-                        "margin-start": 50,
-                        "margin-end": 50,
+                        "margin-start": 20,
+                        "margin-end": 20,
                         "margin-bottom": 20
                     }
                 },


### PR DESCRIPTION
An easy way to make the new travel app fit nicely on composite monitors (with
720x480 resolution) is to reduce the side margins for the vertical templates.

Notice that it would have been enough to reduce down to 30px, but I'd rather
make it a 20px margin all around.

[endlessm/eos-sdk#3857]
