### PR TITLE
searchBannerModule: don't assert results were found

### DIFF
--- a/js/app/modules/searchBannerModule.js
+++ b/js/app/modules/searchBannerModule.js
@@ -65,7 +65,7 @@ const SearchBannerModule = new Lang.Class({
                     surrounded by Unicode left and right double quotes (U+201C
                     and U+201D). Make sure to include %s in your translation and
                     use whatever quote marks are appropriate for your language. */
-                    this.label = Utils.format_ui_string(this.get_style_context(), _("Results were found for “%s”"),
+                    this.label = Utils.format_ui_string(this.get_style_context(), _("Results for “%s”"),
                         payload.query, StyleClasses.QUERY);
                     break;
                 case Actions.SEARCH_FAILED:


### PR DESCRIPTION
The search banner will just inform you the search query you are looking
at results for, but will not assume results have or have not been found.
[endlessm/eos-sdk#3881]
