### PR TITLE
Center context banner properly

### DIFF
--- a/data/widgets/sideMenuTemplate.ui
+++ b/data/widgets/sideMenuTemplate.ui
@@ -41,9 +41,10 @@
         <property name="label_xalign">0</property>
         <property name="shadow_type">none</property>
         <child>
-          <object class="GtkGrid" id="context-bar-grid">
+          <object class="GtkBox" id="context-bar">
             <property name="visible">True</property>
             <property name="can_focus">False</property>
+            <property name="orientation">horizontal</property>
             <child>
               <object class="GtkButton" id="menu-button">
                 <property name="visible">True</property>
@@ -62,8 +63,7 @@
                 </style>
               </object>
               <packing>
-                <property name="left_attach">0</property>
-                <property name="top_attach">0</property>
+                <property name="pack_type">start</property>
               </packing>
             </child>
             <style>
@@ -83,7 +83,7 @@
   <object class="GtkSizeGroup" id="context-bar-overlay-size-group">
     <property name="mode">vertical</property>
     <widgets>
-      <widget name="context-bar-grid"/>
+      <widget name="context-bar"/>
       <widget name="spacer"/>
     </widgets>
   </object>

--- a/js/app/modules/sideMenuTemplate.js
+++ b/js/app/modules/sideMenuTemplate.js
@@ -60,7 +60,7 @@ const SideMenuTemplate = new Lang.Class({
 
     Template: 'resource:///com/endlessm/knowledge/data/widgets/sideMenuTemplate.ui',
     Children: [ 'home-button', 'menu-button', 'menu-close-button' ],
-    InternalChildren: [ 'context-bar-grid', 'grid', 'menu-grid', 'separator' ],
+    InternalChildren: [ 'context-bar', 'grid', 'menu-grid', 'separator' ],
 
     _init: function (props={}) {
         this._menu_open = false;
@@ -71,7 +71,7 @@ const SideMenuTemplate = new Lang.Class({
             halign: Gtk.Align.CENTER,
         });
         if (context)
-            this._context_bar_grid.add(context);
+            this._context_bar.set_center_widget(context);
 
         this._menu_panel = this.add_panel_widget(this._menu_grid, Gtk.PositionType.LEFT);
 


### PR DESCRIPTION
Make sure the context banner is not unbalanced by the presence of the
hamburger menu widget to its left.

[endlessm/eos-sdk#3782]
