### PR TITLE
Standardize names of payload properties

### DIFF
--- a/js/app/modules/aisleInteraction.js
+++ b/js/app/modules/aisleInteraction.js
@@ -173,7 +173,7 @@ const AisleInteraction = new Lang.Class({
                     this._load_more_suggestions(payload.query);
                     break;
                 case Actions.SEARCH_TEXT_ENTERED:
-                    this._on_search(payload.text);
+                    this._on_search(payload.query);
                     break;
                 case Actions.AUTOCOMPLETE_CLICKED:
                 case Actions.ITEM_CLICKED:

--- a/js/app/modules/buffetInteraction.js
+++ b/js/app/modules/buffetInteraction.js
@@ -121,7 +121,7 @@ const BuffetInteraction = new Lang.Class({
                     });
                     break;
                 case Actions.SEARCH_TEXT_ENTERED:
-                    this._start_search_via_history(payload.text);
+                    this._start_search_via_history(payload.query);
                     break;
                 case Actions.NEED_MORE_SEARCH:
                     this._load_more_results();

--- a/js/app/modules/meshInteraction.js
+++ b/js/app/modules/meshInteraction.js
@@ -87,7 +87,7 @@ const MeshInteraction = new Lang.Class({
         dispatcher.register((payload) => {
             switch(payload.action_type) {
                 case Actions.SEARCH_TEXT_ENTERED:
-                    this._do_search(payload.text);
+                    this._do_search(payload.query);
                     break;
                 case Actions.ARTICLE_LINK_CLICKED:
                     this._load_uri(payload.ekn_id);
@@ -118,7 +118,7 @@ const MeshInteraction = new Lang.Class({
                     this._history_presenter.set_current_item_from_props({
                         page_type: this.ARTICLE_PAGE,
                         model: payload.model,
-                        query: payload.text,
+                        query: payload.query,
                     });
                     break;
             }

--- a/js/app/modules/searchBox.js
+++ b/js/app/modules/searchBox.js
@@ -59,7 +59,7 @@ const SearchBox = new Lang.Class({
         this.connect('activate', () => {
             dispatcher.dispatch({
                 action_type: Actions.SEARCH_TEXT_ENTERED,
-                text: this.text,
+                query: this.text,
             });
         });
         this.connect('menu-item-selected', (entry, ekn_id) => {

--- a/tests/js/app/modules/testAisleInteraction.js
+++ b/tests/js/app/modules/testAisleInteraction.js
@@ -446,7 +446,7 @@ describe('Aisle interaction', function () {
             spyOn(view, 'show_search_page');
             dispatcher.dispatch({
                 action_type: Actions.SEARCH_TEXT_ENTERED,
-                text: 'Azucar',
+                query: 'Azucar',
             });
             Mainloop.idle_add(function () {
                 expect(engine.get_objects_by_query)
@@ -513,7 +513,7 @@ describe('Aisle interaction', function () {
             engine.get_objects_by_query_finish.and.throwError(new Error('jet fuel can\'t melt dank memes'));
             dispatcher.dispatch({
                 action_type: Actions.SEARCH_TEXT_ENTERED,
-                text: 'bad query',
+                query: 'bad query',
             });
             expect(dispatcher.dispatched_payloads).toContain(jasmine.objectContaining({
                 action_type: Actions.SEARCH_STARTED,
@@ -528,7 +528,7 @@ describe('Aisle interaction', function () {
         it('records a metric when search-entered is dispatched', function (done) {
             dispatcher.dispatch({
                 action_type: Actions.SEARCH_TEXT_ENTERED,
-                text: 'Azucar',
+                query: 'Azucar',
             });
             Mainloop.idle_add(function () {
                 expect(interaction.record_search_metric).toHaveBeenCalled();

--- a/tests/js/app/modules/testBuffetInteraction.js
+++ b/tests/js/app/modules/testBuffetInteraction.js
@@ -313,7 +313,7 @@ describe('Buffet interaction', function () {
             });
             dispatcher.dispatch({
                 action_type: Actions.SEARCH_TEXT_ENTERED,
-                text: 'user query',
+                query: 'user query',
             });
         });
 

--- a/tests/js/app/modules/testMeshInteraction.js
+++ b/tests/js/app/modules/testMeshInteraction.js
@@ -291,7 +291,7 @@ describe('Mesh interaction', function () {
         it('queries the engine', function () {
             dispatcher.dispatch({
                 action_type: Actions.SEARCH_TEXT_ENTERED,
-                text: query,
+                query: query,
             });
             expect(engine.get_objects_by_query)
                 .toHaveBeenCalledWith(jasmine.objectContaining({
@@ -304,7 +304,7 @@ describe('Mesh interaction', function () {
         it('show the search page', function () {
             dispatcher.dispatch({
                 action_type: Actions.SEARCH_TEXT_ENTERED,
-                text: query,
+                query: query,
             });
             expect(dispatcher.last_payload_with_type(Actions.SHOW_SEARCH_PAGE)).toBeDefined();
         });
@@ -312,7 +312,7 @@ describe('Mesh interaction', function () {
         it('records a metric', function () {
             dispatcher.dispatch({
                 action_type: Actions.SEARCH_TEXT_ENTERED,
-                text: query,
+                query: query,
             });
             expect(mesh._record_search_metric).toHaveBeenCalled();
         });
@@ -320,7 +320,7 @@ describe('Mesh interaction', function () {
         it('loads the results from engine', function () {
             dispatcher.dispatch({
                 action_type: Actions.SEARCH_TEXT_ENTERED,
-                text: query,
+                query: query,
             });
             expect(dispatcher.has_payload_sequence([
                 Actions.SEARCH_STARTED,
@@ -337,7 +337,7 @@ describe('Mesh interaction', function () {
             engine.get_objects_by_query_finish.and.throwError(new Error('Ugh'));
             dispatcher.dispatch({
                 action_type: Actions.SEARCH_TEXT_ENTERED,
-                text: query,
+                query: query,
             });
             expect(dispatcher.dispatched_payloads).toContain(jasmine.objectContaining({
                 action_type: Actions.SEARCH_FAILED,
@@ -349,14 +349,14 @@ describe('Mesh interaction', function () {
             engine.get_objects_by_query.and.stub();
             dispatcher.dispatch({
                 action_type: Actions.SEARCH_TEXT_ENTERED,
-                text: query,
+                query: query,
             });
             let cancellable = engine.get_objects_by_query.calls.mostRecent().args[1];
             let cancel_spy = jasmine.createSpy();
             cancellable.connect(cancel_spy);
             dispatcher.dispatch({
                 action_type: Actions.SEARCH_TEXT_ENTERED,
-                text: 'bar',
+                query: 'bar',
             });
             expect(cancel_spy).toHaveBeenCalled();
         });
@@ -393,7 +393,7 @@ describe('Mesh interaction', function () {
             dispatcher.dispatch({
                 action_type: Actions.AUTOCOMPLETE_CLICKED,
                 model: article_model,
-                text: 'foo',
+                query: 'foo',
             });
             let payload = dispatcher.last_payload_with_type(Actions.APPEND_SEARCH);
             expect(payload.models).toEqual([ article_model ]);

--- a/tests/js/app/modules/testSearchBox.js
+++ b/tests/js/app/modules/testSearchBox.js
@@ -54,7 +54,7 @@ describe('Search box module', function () {
         box.set_text_programmatically('foo');
         box.emit('activate');
         let payload = dispatcher.last_payload_with_type(Actions.SEARCH_TEXT_ENTERED);
-        expect(payload.text).toBe('foo');
+        expect(payload.query).toBe('foo');
     });
 
     it('calls into engine for auto complete results', function () {
@@ -74,5 +74,6 @@ describe('Search box module', function () {
         let payload = dispatcher.last_payload_with_type(Actions.AUTOCOMPLETE_CLICKED);
         expect(payload.model).toBe(model);
         expect(payload.context).toEqual([ model ]);
+        expect(payload.query).toEqual('foo');
     });
 });


### PR DESCRIPTION
We were inconsistent about using 'text' or
'query' as the name of the string passed from
the search box to the interaction module.
This standardizes it to always be 'query'.

Note that we keep the name 'text' to refer
to when the interaction module sets the string
on the search box.

[endlessm/eos-sdk#3931]
