### PR TITLE
navButtonOverlay: animate buttons without resize

### DIFF
--- a/data/css/endless_knowledge.css
+++ b/data/css/endless_knowledge.css
@@ -523,7 +523,7 @@ EosWindow .scrollbar.slider {
     border: 1px solid alpha(white, 0.4);
     box-shadow: inset 0px 1px 1px 0px alpha(black, 0.5),
         inset 0px 1px 4px 0px alpha(black, 0.4);
-    transition: padding 500ms ease-in-out;
+    -EknGrowButton-grow-pixels: 15;
 }
 
 .nav-back-button GtkImage, .nav-forward-button GtkImage {
@@ -534,21 +534,13 @@ EosWindow .scrollbar.slider {
 .nav-back-button, .nav-forward-button.rtl {
     border-left: 0px;
     border-radius: 0px 27px 27px 0px;
-    padding: 15px 15px 15px 0px;
+    padding: 15px;
 }
 
 .nav-forward-button, .nav-back-button.rtl {
     border-radius: 27px 0px 0px 27px;
     border-right: 0px;
-    padding: 15px 0px 15px 15px;
-}
-
-.nav-back-button:hover, .nav-forward-button.rtl:hover {
-    padding-left: 15px;
-}
-
-.nav-forward-button:hover, .nav-back-button.rtl:hover {
-    padding-right: 15px;
+    padding: 15px;
 }
 
 .nav-back-button .image {

--- a/data/css/endless_reader.css
+++ b/data/css/endless_reader.css
@@ -148,9 +148,9 @@ overridden by app specific CSS */
     color: white;
     background-color: alpha(black, 0.3);
     padding: 16px; /* (55px (button width) - 23px (icon width)) / 2 */
-    transition: padding 500ms ease-in-out;
     opacity: 1.0;
     transition: opacity 400ms;
+    -EknGrowButton-grow-pixels: 8;
 }
 
 .nav-back-button GtkImage, .nav-forward-button GtkImage {
@@ -160,18 +160,12 @@ overridden by app specific CSS */
 .nav-back-button {
     border-left: 0px;
     border-radius: 0px 6px 6px 0px;
+    padding-left: 24px;
 }
 
 .nav-forward-button {
     border-radius: 6px 0px 0px 6px;
     border-right: 0px;
-}
-
-.nav-back-button:hover {
-    padding-left: 24px;
-}
-
-.nav-forward-button:hover {
     padding-right: 24px;
 }
 


### PR DESCRIPTION
We were transitioning the padding of our navigation buttons to
achieve a grow effect, which triggered a resize every frame and
was far too slow.

Instead we will manage our grow effect with a cairo translation
so we can avoid resizing the widget.
[endlessm/eos-sdk#3924]
