### PR TITLE
Remove the text card from size group, not list box

### DIFF
--- a/js/app/modules/listArrangement.js
+++ b/js/app/modules/listArrangement.js
@@ -38,11 +38,11 @@ const ListArrangement = new Lang.Class({
     },
 
     clear: function () {
-        let children = this._list_box.get_children();
-        children.forEach((child) => {
+        this._list_box.get_children().forEach((child) => {
             this._list_box.remove(child);
-            this._size_group.remove_widget(child);
         });
-
+        this._size_group.get_widgets().forEach((widget) => {
+            this._size_group.remove_widget(widget);
+        });
     },
 });


### PR DESCRIPTION
Previously we were trying to add a text card to the
size group, but then rather than remove the text card
later, we would try and remove its parent, the list
box item.

[endlessm/eos-sdk#3863]
