### PR TITLE
Responsive margins module should be optional

### DIFF
--- a/data/compat/v1-preset-json/A.json
+++ b/data/compat/v1-preset-json/A.json
@@ -147,7 +147,8 @@
                             "type": "CardA"
                         },
                         "article-suggestions": null,
-                        "category-suggestions": null
+                        "category-suggestions": null,
+                        "responsive-margins": null
                     },
                     "properties": {
                         "message-justify": "left",

--- a/data/compat/v1-preset-json/B.json
+++ b/data/compat/v1-preset-json/B.json
@@ -128,7 +128,8 @@
                             "type": "TextCard"
                         },
                         "article-suggestions": null,
-                        "category-suggestions": null
+                        "category-suggestions": null,
+                        "responsive-margins": null
                     },
                     "properties": {
                         "message-valign": "center"
@@ -160,7 +161,8 @@
                                     "type": "TextCard"
                                 },
                                 "article-suggestions": null,
-                                "category-suggestions": null
+                                "category-suggestions": null,
+                                "responsive-margins": null
                             },
                             "properties": {
                                 "message-valign": "center"

--- a/data/compat/v1-preset-json/encyclopedia.json
+++ b/data/compat/v1-preset-json/encyclopedia.json
@@ -103,7 +103,8 @@
                                             }
                                         },
                                         "article-suggestions": null,
-                                        "category-suggestions": null
+                                        "category-suggestions": null,
+                                        "responsive-margins": null
                                     }
                                 }
                             }

--- a/data/compat/v1-preset-json/reader.json
+++ b/data/compat/v1-preset-json/reader.json
@@ -110,7 +110,8 @@
                             }
                         },
                         "article-suggestions": null,
-                        "category-suggestions": null
+                        "category-suggestions": null,
+                        "responsive-margins": null
                     }
                 }
             }

--- a/js/app/modules/scrollingTemplate.js
+++ b/js/app/modules/scrollingTemplate.js
@@ -35,8 +35,12 @@ const ScrollingTemplate = new Lang.Class({
         let content = this.create_submodule('content');
         let responsive_margins = this.create_submodule('responsive-margins');
 
-        responsive_margins.add(content);
-        this._viewport.add(responsive_margins);
+        if (responsive_margins) {
+            responsive_margins.add(content);
+            this._viewport.add(responsive_margins);
+        } else {
+            this._viewport.add(content);
+        }
     },
 
     // Module override

--- a/js/app/modules/searchModule.js
+++ b/js/app/modules/searchModule.js
@@ -98,8 +98,12 @@ const SearchModule = new Lang.Class({
         this.parent(props);
         this._arrangement = this.create_submodule('arrangement');
         let responsive_margins = this.create_submodule('responsive-margins');
-        responsive_margins.add(this._arrangement);
-        this.add_named(responsive_margins, RESULTS_PAGE_NAME);
+        if (responsive_margins) {
+            responsive_margins.add(this._arrangement);
+            this.add_named(responsive_margins, RESULTS_PAGE_NAME);
+        } else {
+            this.add_named(this._arrangement, RESULTS_PAGE_NAME);
+        }
 
         this._suggested_articles_module = this.create_submodule('article-suggestions');
         if (this._suggested_articles_module)


### PR DESCRIPTION
The ResponsiveMarginsModule added for the new travel app should be an optional
module! All other apps should still be able to open if this module is not
present in their definition.

[endlessm/eos-sdk#3789]
