### PR TITLE
Allow the app banner on template A apps to be smaller

### DIFF
--- a/data/compat/v1-preset-json/A.json
+++ b/data/compat/v1-preset-json/A.json
@@ -71,7 +71,7 @@
                 "top": {
                     "type": "AppBanner",
                     "properties": {
-                        "min-fraction": 0.2,
+                        "min-fraction": 0.1,
                         "max-fraction": 0.7
                     }
                 },


### PR DESCRIPTION
Currently, the app banner can only scale down to
a minimum of 20% of its original size. This
is not small enough to account for composite
mode (assuming we want to keep card A sizes fixed).

So this commit allows it to reduce to 10%.

[endlessm/eos-sdk#3911]
