### PR TITLE
window: update top bar search visibility on first page

### DIFF
--- a/js/app/modules/window.js
+++ b/js/app/modules/window.js
@@ -298,7 +298,7 @@ const Window = new Lang.Class({
         }.bind(this));
 
         this._stack.connect_after('notify::visible-child',
-            this._after_stack_visible_child_changed.bind(this));
+            this._update_top_bar_visibility.bind(this));
 
         this.show_all();
         this._set_background_position_style(StyleClasses.BACKGROUND_LEFT);
@@ -312,7 +312,7 @@ const Window = new Lang.Class({
         context.add_class(klass);
     },
 
-    _after_stack_visible_child_changed: function () {
+    _update_top_bar_visibility: function () {
         let new_page = this._stack.visible_child;
         this._search_box.visible =
             !Utils.has_descendant_with_type(new_page, SearchBox.SearchBox);
@@ -324,6 +324,7 @@ const Window = new Lang.Class({
             // Even though we didn't change, this should still count as the
             // first transition.
             this._stack.transition_duration = this.TRANSITION_DURATION;
+            this._update_top_bar_visibility();
             return;
         }
 


### PR DESCRIPTION
If this first page we ask the window to show is the page that is
already visible in the stack, we were not updating the search
box visibility properly.

This makes sure we always update the top bar search visibility, and
fixes a double search bar regression on templates A and B.
[endlessm/eos-sdk#3947]
