### PR TITLE
Limit title label to 3 lines

### DIFF
--- a/data/widgets/readerDocumentCard.ui
+++ b/data/widgets/readerDocumentCard.ui
@@ -20,7 +20,7 @@
                 <property name="wrap">True</property>
                 <property name="wrap_mode">word-char</property>
                 <property name="ellipsize">end</property>
-                <property name="lines">4</property>
+                <property name="lines">3</property>
                 <property name="xalign">0</property>
                 <property name="visible">True</property>
                 <property name="halign">start</property>


### PR DESCRIPTION
To ensure that the article page fits on composite
monitor screens.

[endlessm/eos-sdk#3911]
