### PR TITLE
Tooltips should be hidden first, then destroyed

### DIFF
--- a/js/app/webviewTooltipPresenter.js
+++ b/js/app/webviewTooltipPresenter.js
@@ -154,6 +154,7 @@ const WebviewTooltipPresenter = new GObject.Class({
 
     _remove_link_tooltip: function () {
         if (this._link_tooltip) {
+            this._link_tooltip.hide();
             this._link_tooltip.destroy();
             this._link_tooltip = null;
         }
@@ -173,9 +174,6 @@ const WebviewTooltipPresenter = new GObject.Class({
             modal: false,
         });
         this._link_tooltip.get_style_context().add_class(StyleClasses.READER_WEBVIEW_TOOLTIP);
-        this._link_tooltip.connect('leave-notify-event', () => {
-            this._remove_link_tooltip();
-        });
         if (!this.emit('show-tooltip', this._link_tooltip, uri))
             this._remove_link_tooltip();
     },


### PR DESCRIPTION
We were simply destroying the tooltips instead of hiding them first, and that
was causing a flicker instead of the fadeout animation.

Also, we were needlessly connecting to the "leave-notify-event" signal.

[endlessm/eos-sdk#3946]
