### PR TITLE
Consolidate three mock widget types into one.

### DIFF
--- a/tests/js/app/modules/testReaderWindow.js
+++ b/tests/js/app/modules/testReaderWindow.js
@@ -50,10 +50,10 @@ describe('Window widget', function () {
         factory.add_named_mock('front-page', MockWidgets.MockSidebarTemplate);
         factory.add_named_mock('back-page', Minimal.MinimalBackCover);
         factory.add_named_mock('search-page', Minimal.MinimalPage);
-        factory.add_named_mock('standalone-page', Minimal.MinimalStandalonePage);
+        factory.add_named_mock('standalone-page', Minimal.MinimalBinModule);
         factory.add_named_mock('document-arrangement', Minimal.MinimalArrangement);
-        factory.add_named_mock('lightbox', Minimal.MinimalLightbox);
-        factory.add_named_mock('navigation', Minimal.MinimalNavigation);
+        factory.add_named_mock('lightbox', Minimal.MinimalBinModule);
+        factory.add_named_mock('navigation', Minimal.MinimalBinModule);
         factory.add_named_mock('window', ReaderWindow.ReaderWindow, {
             'front-page': 'front-page',
             'back-page': 'back-page',

--- a/tests/js/app/modules/testWindow.js
+++ b/tests/js/app/modules/testWindow.js
@@ -58,8 +58,8 @@ describe('Window', function () {
         factory.add_named_mock('search-page', Minimal.MinimalPage);
         factory.add_named_mock('article-page', Minimal.MinimalPage);
         factory.add_named_mock('all-sets-page', Minimal.MinimalPage);
-        factory.add_named_mock('lightbox', Minimal.MinimalLightbox);
-        factory.add_named_mock('navigation', Minimal.MinimalNavigation);
+        factory.add_named_mock('lightbox', Minimal.MinimalBinModule);
+        factory.add_named_mock('navigation', Minimal.MinimalBinModule);
         factory.add_named_mock('brand-screen', Minimal.MinimalPage);
         factory.add_named_mock('real-search-box', SearchBox.SearchBox);
         factory.add_named_mock('window', Window.Window, {

--- a/tests/minimal.js
+++ b/tests/minimal.js
@@ -1,8 +1,8 @@
 // Copyright 2015 Endless Mobile, Inc.
 
 /* exported MinimalArrangement, MinimalBackCover, MinimalCard, MinimalDocumentCard,
-MinimalPage, MinimalHomePage, MinimalInteraction, MinimalLightbox, MinimalModule,
-MinimalNavigation, MinimalStandalonePage, test_arrangement_compliance */
+MinimalPage, MinimalHomePage, MinimalInteraction, MinimalBinModule, MinimalModule,
+test_arrangement_compliance */
 
 const GLib = imports.gi.GLib;
 const GObject = imports.gi.GObject;
@@ -231,8 +231,8 @@ const MinimalDocumentCard = new Lang.Class({
     clear_content: function () {},
 });
 
-const MinimalLightbox = new Lang.Class({
-    Name: 'MinimalLightbox',
+const MinimalBinModule = new Lang.Class({
+    Name: 'MinimalBinModule',
     Extends: Gtk.Frame,
     Implements: [ Module.Module ],
 
@@ -243,37 +243,7 @@ const MinimalLightbox = new Lang.Class({
 
     _init: function (props={}) {
         this.parent(props);
-    },
-});
-
-const MinimalNavigation = new Lang.Class({
-    Name: 'MinimalNavigation',
-    Extends: Gtk.Frame,
-    Implements: [ Module.Module ],
-
-    Properties: {
-        'factory': GObject.ParamSpec.override('factory', Module.Module),
-        'factory-name': GObject.ParamSpec.override('factory-name', Module.Module),
-    },
-
-    _init: function (props={}) {
-        this.parent(props);
-    },
-});
-
-const MinimalStandalonePage = new Lang.Class({
-    Name: 'MinimalStandalonePage',
-    Extends: Gtk.Frame,
-    Implements: [ Module.Module ],
-
-    Properties: {
-        'factory': GObject.ParamSpec.override('factory', Module.Module),
-        'factory-name': GObject.ParamSpec.override('factory-name', Module.Module),
-    },
-
-    _init: function (props={}) {
-        this.parent(props);
-        this.infobar = new Gtk.Label();
+        this.infobar = new Gtk.Label(); // StandalonePage requires this
     },
 });
 


### PR DESCRIPTION
Consolidate the MinimalLightbox, MinimalNavigation,
and MinimalStandalonePage widget types into one,
MinimalWidget class. Note that we cannot go further
and consolidate MinimalWidget with MinimalModule,
since the widget needs to subclass a real GtkWidget,
e.g. GtkFrame, for the tests to work.

[endlessm/eos-sdk#3824]
