### PR TITLE
Allow the Copy Image menu item to be included in Webkit Context Menu

### DIFF
--- a/js/app/widgets/eknWebview.js
+++ b/js/app/widgets/eknWebview.js
@@ -88,9 +88,10 @@ const EknWebview = new Lang.Class({
 
     _load_context_menu: function (webview, context_menu, event) {
         context_menu.get_items().forEach(function (item) {
-            // Remove all menu items except 'Copy'
+            // Remove unwanted menu items
             let action = item.get_stock_action();
             if (action !== WebKit2.ContextMenuAction.COPY &&
+                action !== WebKit2.ContextMenuAction.COPY_IMAGE_TO_CLIPBOARD &&
                 action !== WebKit2.ContextMenuAction.INSPECT_ELEMENT) {
                 context_menu.remove(item);
             }


### PR DESCRIPTION
We want to allow users to copy images from
webkit to other applications. So we should not
exclude the Copy Image menu item from Webkit's
context menu.

[endlessm/eos-sdk#3814]
