### PR TITLE
Override Searchbar font size in composite

### DIFF
--- a/data/css/endless_knowledge.css
+++ b/data/css/endless_knowledge.css
@@ -546,7 +546,7 @@ EosWindow .scrollbar.slider {
     font-family: Roboto;
 }
 
-.composite .headerbar .entry {
+.composite .entry {
     font-size: 18px;
 }
 


### PR DESCRIPTION
We want the font size of the SearchBar to be larger in composite, but previously
assigned the wrong class name. To be more consistent, we leave the topbar class
out of the selector.

[endlessm/eos-sdk#3975]
