### PR TITLE
Use default font size for Search bar in composite

### DIFF
--- a/data/css/endless_buffet.css
+++ b/data/css/endless_buffet.css
@@ -391,10 +391,6 @@ EknAppBanner {
 
 /* Changes for composite TVs */
 
-.composite .entry {
-    font-size: 18px;
-}
-
 .composite .search-results GtkListBoxRow {
     padding: 0 40px;
 }

--- a/data/css/endless_reader.css
+++ b/data/css/endless_reader.css
@@ -306,10 +306,6 @@ scrollbars, style the GTK scrollbars to look slightly more like them */
     font-family: Roboto;
 }
 
-.composite .entry {
-    font-size: 18px;
-}
-
 .composite .progress-label,
 .composite .article-snippet .synopsis {
     font-size: 14px;


### PR DESCRIPTION
We now override the font size for the search bar widget when in composite mode
directly in the SDK, since the same specification is used for all apps.

[endlessm/eos-sdk#3975]
