### PR TITLE
Increase font size on image captions and infoboxes

### DIFF
--- a/data/templates/css/reader2.scss
+++ b/data/templates/css/reader2.scss
@@ -294,26 +294,26 @@ $max-d: 599px;
     #inside-content {
         font-size: 22px;
         color: black;
-    }
 
-    .infobox {
-        th:only-child,
-        caption {
-            line-height: 20px;
-            font-size: 20px !important;
+        .infobox {
+            th:only-child,
+            caption {
+                line-height: 20px;
+                font-size: 20px !important;
+            }
+
+            tr > th:first-child:not(:only-child),
+            tr > td:first-child:not(:only-child),
+            th ~ td,
+            td:first-child ~ td {
+                line-height: 20px;
+                font-size: 20px;
+            }
         }
 
-        tr > th:first-child:not(:only-child),
-        tr > td:first-child:not(:only-child),
-        th ~ td,
-        td:first-child ~ td {
-            line-height: 20px;
+        .thumbcaption,
+        td .eos-image-link + * {
             font-size: 20px;
         }
-    }
-
-    .thumbcaption,
-    td .eos-image-link + * {
-        font-size: 20px;
     }
 }


### PR DESCRIPTION
Our CSS pre-processor specification was not correctly assigning the desired
overrides for composite mode, due to not having the appropriate selectors.
This was easy to fix with a proper nesting of selectors.

(Martin & Fernando)

[endlessm/eos-sdk#4018]
