### PR TITLE
Fix images arrangement on small window

### DIFF
--- a/data/templates/css/embedly.scss
+++ b/data/templates/css/embedly.scss
@@ -89,6 +89,16 @@ html {
     }
 }
 
+/* Lower resolutions */
+@media (max-width: 450px) {
+    #inside-content {
+        img {
+            float: center;
+            display: block;
+        }
+    }
+}
+
 /* Composite resolutions */
 @media (device-width: 720px) and (device-height: 480px),
        (device-width: 720px) and (device-height: 576px) {


### PR DESCRIPTION
Floating images were placed strangely between paragraphs. Instead
modify the corresponding css to make sure floating images are placed
centered between paragraphs.

[endlessm/eos-sdk#4015]
