### PR TITLE
Scroll to the top when returning to pages

### DIFF
--- a/js/app/modules/scrollingTemplate.js
+++ b/js/app/modules/scrollingTemplate.js
@@ -51,10 +51,30 @@ const ScrollingTemplate = new Lang.Class({
                 scroll_server: this.name,
             });
         });
+
+        Dispatcher.get_default().register((payload) => {
+            switch (payload.action_type) {
+                case Actions.SHOW_HOME_PAGE:
+                case Actions.SHOW_ALL_SETS_PAGE:
+                case Actions.SHOW_SECTION_PAGE:
+                case Actions.SHOW_SEARCH_PAGE:
+                case Actions.SHOW_ARTICLE_PAGE:
+                    this._return_to_top();
+                    break;
+            }
+        });
     },
 
     // Module override
     get_slot_names: function () {
         return ['content', 'responsive-margins'];
+    },
+
+    // return scroll position to the top of the window
+    _return_to_top: function () {
+        let lower = this.vadjustment.get_lower();
+        if (this.vadjustment.get_value() !== lower) {
+            this.vadjustment.set_value(lower);
+        }
     },
 });

--- a/tests/js/app/modules/testScrollingTemplate.js
+++ b/tests/js/app/modules/testScrollingTemplate.js
@@ -5,6 +5,8 @@ const Gtk = imports.gi.Gtk;
 const Utils = imports.tests.utils;
 Utils.register_gresource();
 
+const Actions = imports.app.actions;
+const MockDispatcher = imports.tests.mockDispatcher;
 const MockFactory = imports.tests.mockFactory;
 const MockPlaceholder = imports.tests.mockPlaceholder;
 const ScrollingTemplate = imports.app.modules.scrollingTemplate;
@@ -37,5 +39,25 @@ describe('Scrolling template', function () {
     it('packs all its children', function () {
         let content = factory.get_created_named_mocks('placeholder')[0];
         expect(template).toHaveDescendant(content);
+    });
+
+    describe('when showing pages', function () {
+        beforeEach(function () {
+            template.vadjustment.set_value(template.vadjustment.get_upper());
+        });
+
+        function test_show_page (action, descriptor) {
+            it('scrolls back to the top of the ' + descriptor + ' page', function () {
+                MockDispatcher.mock_default().dispatch({
+                    action_type: action,
+                });
+                expect(template.vadjustment.get_value()).toBe(template.vadjustment.get_lower());
+            });
+        }
+        test_show_page(Actions.SHOW_HOME_PAGE, 'home');
+        test_show_page(Actions.SHOW_ALL_SETS_PAGE, 'sets');
+        test_show_page(Actions.SHOW_SECTION_PAGE, 'section');
+        test_show_page(Actions.SHOW_SEARCH_PAGE, 'search');
+        test_show_page(Actions.SHOW_ARTICLE_PAGE, 'article');
     });
 });


### PR DESCRIPTION
Returning to pages should always scroll to the top of the page in
order to preserve consistency.

[endlessm/eos-sdk#3792]
