### PR TITLE
Put context label inside space container

### DIFF
--- a/data/widgets/postCard.ui
+++ b/data/widgets/postCard.ui
@@ -49,22 +49,6 @@
                     </style>
                   </object>
                 </child>
-                <child>
-                  <object class="GtkLabel" id="context-label">
-                    <property name="can_focus">False</property>
-                    <property name="expand">True</property>
-                    <property name="halign">center</property>
-                    <property name="valign">end</property>
-                    <property name="use_markup">True</property>
-                    <property name="wrap">True</property>
-                    <property name="wrap_mode">word-char</property>
-                    <property name="ellipsize">end</property>
-                    <property name="lines">2</property>
-                    <style>
-                      <class name="card-context"/>
-                    </style>
-                  </object>
-                </child>
               </object>
             </child>
             <style>

--- a/data/widgets/thumbCard.ui
+++ b/data/widgets/thumbCard.ui
@@ -33,7 +33,7 @@
                     <property name="can_focus">False</property>
                     <property name="expand">True</property>
                     <property name="halign">center</property>
-                    <property name="valign">end</property>
+                    <property name="valign">center</property>
                     <property name="xalign">0</property>
                     <property name="use_markup">True</property>
                     <property name="wrap">True</property>
@@ -48,7 +48,7 @@
                 <child>
                   <object class="GtkLabel" id="synopsis-label">
                     <property name="can_focus">False</property>
-                    <property name="hexpand">True</property>
+                    <property name="expand">True</property>
                     <property name="halign">center</property>
                     <property name="use_markup">True</property>
                     <property name="wrap">True</property>
@@ -57,22 +57,6 @@
                     <property name="lines">5</property>
                     <style>
                       <class name="card-synopsis"/>
-                    </style>
-                  </object>
-                </child>
-                <child>
-                  <object class="GtkLabel" id="context-label">
-                    <property name="can_focus">False</property>
-                    <property name="expand">True</property>
-                    <property name="halign">center</property>
-                    <property name="valign">end</property>
-                    <property name="use_markup">True</property>
-                    <property name="wrap">True</property>
-                    <property name="wrap_mode">word-char</property>
-                    <property name="ellipsize">end</property>
-                    <property name="lines">2</property>
-                    <style>
-                      <class name="card-context"/>
                     </style>
                   </object>
                 </child>

--- a/js/app/interfaces/card.js
+++ b/js/app/interfaces/card.js
@@ -16,6 +16,7 @@ const Engine = imports.search.engine;
 const ImageCoverFrame = imports.app.widgets.imageCoverFrame;
 const Module = imports.app.interfaces.module;
 const SetObjectModel = imports.search.setObjectModel;
+const SpaceContainer = imports.app.widgets.spaceContainer;
 const StyleClasses = imports.app.styleClasses;
 const Utils = imports.app.utils;
 
@@ -169,12 +170,34 @@ const Card = new Lang.Interface({
      * Moreover, we want to exclude the 'Ekn'-prefixed tags which won't mean
      * anything to the user.
      */
-    set_context_label_from_model: function (label) {
-        this.set_label_or_hide(label,
-                               this.model.tags.filter((tag) => !tag.startsWith('Ekn'))
-                               .slice(0, 2)
-                               .join(' | ')
-                               .toLocaleUpperCase());
+    set_context_label_from_model: function (container) {
+        this._space_container = new SpaceContainer.SpaceContainer({
+            orientation: Gtk.Orientation.HORIZONTAL,
+        });
+
+        // Sort the context tags from shortest to longest in order to
+        // maximise chances that we can fit two of them on the card.
+        let tags = this.model.tags.filter((tag) => !tag.startsWith('Ekn'))
+                              .sort((a, b) => a.length - b.length);
+        if (tags.length > 0) {
+            let first_tag = new Gtk.Label({
+                lines: 1,
+                label: tags[0].toLocaleUpperCase(),
+            });
+            this._space_container.add(first_tag);
+
+            if (tags.length > 1) {
+                let second_tag = new Gtk.Label({
+                    lines: 1,
+                    label: ' | ' + tags[1].toLocaleUpperCase(),
+                });
+                this._space_container.add(second_tag);
+            }
+        }
+
+        this._space_container.get_style_context().add_class('card-context');
+        this._space_container.show_all();
+        container.add(this._space_container);
     },
 
     /**

--- a/js/app/modules/postCard.js
+++ b/js/app/modules/postCard.js
@@ -31,8 +31,7 @@ const PostCard = new Lang.Class({
     },
 
     Template: 'resource:///com/endlessm/knowledge/data/widgets/postCard.ui',
-    InternalChildren: [ 'thumbnail-frame', 'title-label', 'context-label',
-        'inner-content-grid', 'shadow-frame' ],
+    InternalChildren: [ 'thumbnail-frame', 'title-label', 'inner-content-grid', 'shadow-frame' ],
 
     _init: function (props={}) {
         this.parent(props);
@@ -55,7 +54,7 @@ const PostCard = new Lang.Class({
                 return Gdk.EVENT_PROPAGATE;
             });
         } else {
-            this.set_context_label_from_model(this._context_label);
+            this.set_context_label_from_model(this._inner_content_grid);
         }
     },
 

--- a/js/app/modules/thumbCard.js
+++ b/js/app/modules/thumbCard.js
@@ -31,7 +31,7 @@ const ThumbCard = new Lang.Class({
     },
 
     Template: 'resource:///com/endlessm/knowledge/data/widgets/thumbCard.ui',
-    InternalChildren: [ 'thumbnail-frame', 'grid', 'inner-grid', 'content-frame', 'title-label', 'synopsis-label', 'context-label'],
+    InternalChildren: [ 'thumbnail-frame', 'grid', 'inner-grid', 'content-frame', 'title-label', 'synopsis-label' ],
 
     _init: function (props={}) {
         this.parent(props);
@@ -39,7 +39,8 @@ const ThumbCard = new Lang.Class({
         this.set_title_label_from_model(this._title_label);
         this.set_thumbnail_frame_from_model(this._thumbnail_frame);
         this.set_label_or_hide(this._synopsis_label, this.model.synopsis);
-        this.set_context_label_from_model(this._context_label);
+        this.set_context_label_from_model(this._inner_grid);
+
         this.set_size_request(Card.MinSize.A, Card.MinSize.A);
 
         Utils.set_hand_cursor_on_widget(this);
@@ -70,15 +71,15 @@ const ThumbCard = new Lang.Class({
         // thumbnail image
         if (this._should_go_horizontal(alloc.width, alloc.height)) {
             this._title_label.justify = Gtk.Justification.LEFT;
-            this._title_label.halign = this._synopsis_label.halign = this._context_label.halign = Gtk.Align.START;
+            this._title_label.halign = this._synopsis_label.halign = this._space_container.halign = Gtk.Align.START;
             orientation = Gtk.Orientation.HORIZONTAL;
-            this._title_label.xalign = this._context_label.xalign = 0;
+            this._title_label.xalign = 0;
             proportion = 1/2;
         } else {
             this._title_label.justify = Gtk.Justification.CENTER;
-            this._title_label.halign = this._synopsis_label.halign = this._context_label.halign = Gtk.Align.CENTER;
+            this._title_label.halign = this._synopsis_label.halign = this._space_container.halign = Gtk.Align.CENTER;
             orientation = Gtk.Orientation.VERTICAL;
-            this._title_label.xalign = this._context_label.xalign = 0.5;
+            this._title_label.xalign = 0.5;
             proportion = 2/3;
         }
 
@@ -98,10 +99,13 @@ const ThumbCard = new Lang.Class({
             height: text_h,
         });
 
-        if (this._should_show_synopsis(alloc.width, alloc.height))
+        if (this._should_show_synopsis(alloc.width, alloc.height)) {
             this.set_label_or_hide(this._synopsis_label, this.model.synopsis);
-        else
+            this._title_label.valign = Gtk.Align.END;
+        } else {
+            this._title_label.valign = Gtk.Align.CENTER;
             this._synopsis_label.hide();
+        }
 
         this._thumbnail_frame.size_allocate(thumb_alloc);
         this._content_frame.size_allocate(text_alloc);

--- a/tests/js/app/interfaces/testCard.js
+++ b/tests/js/app/interfaces/testCard.js
@@ -79,10 +79,12 @@ describe('Card interface', function () {
     });
 
     it('sets a context label visible if model has tags', function () {
-        let label = new Gtk.Label();
-        card.set_context_label_from_model(label);
-        expect(label.visible).toBeTruthy();
-        expect(label.label).toBe('FOO | BAR');
+        let grid = new Gtk.Grid();
+        card.set_context_label_from_model(grid);
+        let first_tag = Gtk.test_find_label(grid, 'FOO');
+        expect(first_tag).not.toBeNull();
+        let second_tag = Gtk.test_find_label(grid, ' | BAR');
+        expect(second_tag).not.toBeNull();
     });
 
     it('markup-escapes the title', function () {


### PR DESCRIPTION
Previously, the context label was awkwardly
spilling over onto two lines in composite
mode. This fixes that by splitting them into
two labels, and putting both in a space
container, thus ensuring that if there is
not enough room to show both labels,
only one will get shown.

We also sort context labels from shortest
to longest in length to maximise the chances
we get to show two of them.

[endlessm/eos-sdk#4017]
