### PR TITLE
readerDocumentCard: don't grab focus on creation

### DIFF
--- a/js/app/modules/readerDocumentCard.js
+++ b/js/app/modules/readerDocumentCard.js
@@ -135,7 +135,6 @@ const ReaderDocumentCard = new Lang.Class({
 
             this._size_group.add_widget(this.content_view);
             this._content_grid.attach(this.content_view, 2, 0, 1, 2);
-            this.content_view.grab_focus();
             this.content_view.show_all();
         });
     },


### PR DESCRIPTION
The reader card will not even be the current page in the page
manager when we try to do this, the line makes no sense.

Focus seems to work fine without it.
[endlessm/eos-sdk#4043]
