### PR TITLE
Use Gdk.Rectangle instead of Cairo.RectangleInt, again

### DIFF
--- a/js/app/modules/sidebarTemplate.js
+++ b/js/app/modules/sidebarTemplate.js
@@ -2,9 +2,9 @@
 
 /* exported SidebarTemplate, get_css_for_module */
 
-const Cairo = imports.gi.cairo;
 const Endless = imports.gi.Endless;
 const EosKnowledgePrivate = imports.gi.EosKnowledgePrivate;
+const Gdk = imports.gi.Gdk;
 const GLib = imports.gi.GLib;
 const GObject = imports.gi.GObject;
 const Gtk = imports.gi.Gtk;
@@ -124,13 +124,13 @@ const SidebarTemplate = new Lang.Class({
         let sidebar_left = this.sidebar_first;
         if (this.get_direction() === Gtk.TextDirection.RTL)
             sidebar_left = !sidebar_left;
-        this.sidebar_frame.size_allocate(new Cairo.RectangleInt({
+        this.sidebar_frame.size_allocate(new Gdk.Rectangle({
             x: alloc.x + (sidebar_left ? 0 : content_width),
             y: alloc.y,
             width: sidebar_width,
             height: alloc.height,
         }));
-        this.content_frame.size_allocate(new Cairo.RectangleInt({
+        this.content_frame.size_allocate(new Gdk.Rectangle({
             x: alloc.x + (sidebar_left ? sidebar_width : 0),
             y: alloc.y,
             width: content_width,

--- a/js/app/modules/splitPercentageTemplate.js
+++ b/js/app/modules/splitPercentageTemplate.js
@@ -1,8 +1,8 @@
 // Copyright 2016 Endless Mobile, Inc.
 
-const Cairo = imports.gi.cairo;
 const Endless = imports.gi.Endless;
 const EosKnowledgePrivate = imports.gi.EosKnowledgePrivate;
+const Gdk = imports.gi.Gdk;
 const GObject = imports.gi.GObject;
 const Gtk = imports.gi.Gtk;
 const Lang = imports.lang;
@@ -126,13 +126,13 @@ const SplitPercentageTemplate = new Lang.Class({
         }
 
         let start_on_left = this.get_direction() === Gtk.TextDirection.LTR;
-        this._start_frame.size_allocate(new Cairo.RectangleInt({
+        this._start_frame.size_allocate(new Gdk.Rectangle({
             x: alloc.x + (start_on_left ? 0 : end_width),
             y: alloc.y,
             width: start_width,
             height: alloc.height,
         }));
-        this._end_frame.size_allocate(new Cairo.RectangleInt({
+        this._end_frame.size_allocate(new Gdk.Rectangle({
             x: alloc.x + (start_on_left ? start_width : 0),
             y: alloc.y,
             width: end_width,


### PR DESCRIPTION
A few stragglers, courtesy of yours truly. Forgot to rebase the
commit moving to the new rectangle on the recent changes to the
SidebarTemplate
[endlessm/eos-sdk#3590]
