### PR TITLE
Preserve original spacing in DividedBannerTemplate

### DIFF
--- a/js/app/modules/dividedBannerTemplate.js
+++ b/js/app/modules/dividedBannerTemplate.js
@@ -44,7 +44,7 @@ const DividedBannerTemplate = new Lang.Class({
             this['_' + slot] = submodule;
         });
 
-        this._orig_row_spacing = this.row_spacing;
+        this._orig_row_spacing = null;
     },
 
     get_slot_names: function () {
@@ -54,8 +54,11 @@ const DividedBannerTemplate = new Lang.Class({
     vfunc_size_allocate: function (alloc) {
         this.parent(alloc);
 
-        if (alloc.width < this.WIDTH_THRESHOLD) {
+        if (this._orig_row_spacing === null) {
             this._orig_row_spacing = this.row_spacing;
+        }
+
+        if (alloc.width < this.WIDTH_THRESHOLD) {
             this.row_spacing = this._orig_row_spacing / 2;
         } else {
             this.row_spacing = this._orig_row_spacing;

--- a/tests/js/app/modules/testDividedBannerTemplate.js
+++ b/tests/js/app/modules/testDividedBannerTemplate.js
@@ -12,6 +12,8 @@ const MockPlaceholder = imports.tests.mockPlaceholder;
 const StyleClasses = imports.app.styleClasses;
 const WidgetDescendantMatcher = imports.tests.WidgetDescendantMatcher;
 
+const ORIG_ROW_SPACING = 30;
+
 Gtk.init(null);
 
 describe('DividedBannerTemplate module', function () {
@@ -53,6 +55,43 @@ describe('DividedBannerTemplate module', function () {
     describe('CSS style context', function () {
         it('has divided banner template class', function () {
             expect(home_page).toHaveCssClass('divided-banner-template');
+        });
+    });
+
+    describe("when allocates size", function () {
+        let win;
+
+        beforeEach(function () {
+            win = new Gtk.OffscreenWindow();
+            home_page.row_spacing = ORIG_ROW_SPACING;
+            win.add(home_page);
+            win.show_all();
+        });
+
+        afterEach(function () {
+            win.destroy();
+        });
+
+        it('sets the original row spacing', function () {
+            win.set_size_request(640, 480);
+            Utils.update_gui();
+            expect(home_page._orig_row_spacing).toBe(ORIG_ROW_SPACING);
+        });
+
+        it('reduces spacing to half when the width available < 800px', function () {
+            win.set_size_request(720, 480);
+            Utils.update_gui();
+            win.set_size_request(640, 480);
+            Utils.update_gui();
+            expect(home_page.row_spacing).toBe(home_page._orig_row_spacing / 2);
+        });
+
+        it('restores original spacing when width the available >= 800px', function () {
+            win.set_size_request(800, 600);
+            Utils.update_gui();
+            win.set_size_request(1024, 768);
+            Utils.update_gui();
+            expect(home_page.row_spacing).toBe(home_page._orig_row_spacing);
         });
     });
 });


### PR DESCRIPTION
The original row spacing was being overridden with smaller and
smaller values each time it allocated its size, when the width
available was less than 800px.

Store the original row spacing value only once, the first time
size_allocate is called.

Add tests for preserving this behavior and to guarantee that this
function is idempotent.

[endlessm/eos-sdk#4056]
