### PR TITLE
Picard knows nothing about compact modes

### DIFF
--- a/js/tools/picard.js
+++ b/js/tools/picard.js
@@ -59,9 +59,7 @@ function main() {
     let module_name = ARGV.shift() + 'Arrangement';
     let warehouse = new Warehouse.Warehouse();
     let ArrangementClass = warehouse.type_to_class(module_name);
-    widgets.arrangement = new ArrangementClass({
-        compact_mode: true,
-    });
+    widgets.arrangement = new ArrangementClass();
 
     build_ui();
     connect_signals();


### PR DESCRIPTION
I inadvertently left a change on picard.js that should not be there.
Reverting it.

[endlessm/eos-sdk#3982]
