### PR TITLE
searchModule: only set spinner active when visible

### DIFF
--- a/data/widgets/searchModule.ui
+++ b/data/widgets/searchModule.ui
@@ -16,7 +16,6 @@
         <property name="margin_end">20</property>
         <property name="margin_top">20</property>
         <property name="vexpand">True</property>
-        <property name="active">True</property>
       </object>
       <packing>
         <property name="position">1</property>

--- a/js/app/modules/searchModule.js
+++ b/js/app/modules/searchModule.js
@@ -95,7 +95,7 @@ const SearchModule = new Lang.Class({
     },
 
     Template: 'resource:///com/endlessm/knowledge/data/widgets/searchModule.ui',
-    InternalChildren: [ 'message-title', 'message-subtitle', 'no-results-grid' ],
+    InternalChildren: [ 'message-title', 'message-subtitle', 'no-results-grid', 'spinner' ],
 
     _init: function (props={}) {
         this.parent(props);
@@ -123,6 +123,9 @@ const SearchModule = new Lang.Class({
                 });
             });
         }
+        this.connect('notify::visible-child', () => {
+            this._spinner.active = this.visible_child_name === SPINNER_PAGE_NAME;
+        });
 
         dispatcher.register((payload) => {
             switch (payload.action_type) {

--- a/tests/js/app/modules/testSearchModule.js
+++ b/tests/js/app/modules/testSearchModule.js
@@ -70,6 +70,18 @@ describe('Search module', function () {
         expect(search_module.visible_child_name).toBe('spinner');
     });
 
+    it('only activates the spinner when it is shown', function () {
+        search_module.visible_child_name = 'message';
+        Utils.update_gui();
+        expect(search_module.get_child_by_name('spinner').active).toBe(false);
+        dispatcher.dispatch({
+            action_type: Actions.SEARCH_STARTED,
+            query: 'myfoobar',
+        });
+        Utils.update_gui();
+        expect(search_module.get_child_by_name('spinner').active).toBe(true);
+    });
+
     it('displays the search page when there are search results', function () {
         search_module.visible_child_name = 'message';
         dispatcher.dispatch({


### PR DESCRIPTION
Otherwise our app will consistently eat 2% cpu usage even when
nothing is happening (or the app isn't even on screen).

Performance wise shouldn't have a huge affect, but will save us
a little time recomputing style properties every frame.
[endlessm/eos-sdk#3590]
