### PR TITLE
SideBySideArrangement

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -309,6 +309,7 @@ javascript_tests = \
 	tests/js/app/modules/testSetBannerModule.js \
 	tests/js/app/modules/testSetGroupModule.js \
 	tests/js/app/modules/testSidebarTemplate.js \
+	tests/js/app/modules/testSideBySideArrangement.js \
 	tests/js/app/modules/testSideMenuTemplate.js \
 	tests/js/app/modules/testSplitPercentageTemplate.js \
 	tests/js/app/modules/testSquareGuysArrangement.js \

--- a/eos-knowledge.gresource.xml
+++ b/eos-knowledge.gresource.xml
@@ -142,6 +142,7 @@
     <file>js/app/modules/setBannerModule.js</file>
     <file>js/app/modules/setGroupModule.js</file>
     <file>js/app/modules/sidebarTemplate.js</file>
+    <file>js/app/modules/sideBySideArrangement.js</file>
     <file>js/app/modules/sideMenuTemplate.js</file>
     <file>js/app/modules/splitPercentageTemplate.js</file>
     <file>js/app/modules/squareGuysArrangement.js</file>

--- a/js/app/modules/sideBySideArrangement.js
+++ b/js/app/modules/sideBySideArrangement.js
@@ -1,0 +1,131 @@
+// Copyright 2016 Endless Mobile, Inc.
+
+/* exported SideBySideArrangement */
+
+const Endless = imports.gi.Endless;
+const GObject = imports.gi.GObject;
+const Gtk = imports.gi.Gtk;
+const Lang = imports.lang;
+
+const Arrangement = imports.app.interfaces.arrangement;
+const Card = imports.app.interfaces.card;
+const Module = imports.app.interfaces.module;
+
+const MENU_HEIGHT = 50;
+const MAX_CARDS = 8;
+const _HorizontalThreshold = {
+    TINY: 720,
+    SMALL: 900,
+    LARGE: 1200,
+};
+const _HorizontalSpacing = {
+    TINY: 15,
+    SMALL: 20,
+    LARGE: 40,
+    XLARGE: 50,
+};
+/**
+ * Class: SideBySideArrangement
+ * Arrangement to be used in horizontal menus
+ *
+ * This arrangement presents cards in a horizontal layout, and is intended to
+ * display menu items.
+ */
+const SideBySideArrangement = new Lang.Class({
+    Name: 'SideBySideArrangement',
+    GTypeName: 'EknSideBySideArrangement',
+    Extends: Endless.CustomContainer,
+    Implements: [ Module.Module, Arrangement.Arrangement ],
+
+    Properties: {
+        'factory': GObject.ParamSpec.override('factory', Module.Module),
+        'factory-name': GObject.ParamSpec.override('factory-name', Module.Module),
+        'all-visible': GObject.ParamSpec.override('all-visible', Arrangement.Arrangement),
+        'spacing': GObject.ParamSpec.override('spacing', Arrangement.Arrangement),
+    },
+
+    _init: function (props={}) {
+        this._horizontal_threshold = _HorizontalThreshold.LARGE;
+        this._all_visible = true;
+
+        this.parent(props);
+    },
+
+    add_card: function (widget) {
+        this.add(widget);
+    },
+
+    get_cards: function () {
+        return this.get_children();
+    },
+
+    clear: function () {
+        this.get_children().forEach((child) => this.remove(child));
+    },
+
+    get all_visible() {
+        return this._all_visible;
+    },
+
+    // Removing a visible widget should recalculate the positions of all widgets
+    vfunc_remove: function (widget) {
+        let needs_resize = widget.get_child_visible();
+        this.parent(widget);
+        if (needs_resize)
+            this.queue_resize();
+    },
+
+    vfunc_get_request_mode: function () {
+        return Gtk.SizeRequestMode.CONSTANT_SIZE;
+    },
+
+    vfunc_get_preferred_height: function () {
+        return [MENU_HEIGHT, MENU_HEIGHT];
+    },
+
+    vfunc_get_preferred_width: function () {
+        return [0, MAX_CARDS * Card.MinSize.H];
+    },
+
+    vfunc_size_allocate: function (alloc) {
+        this.parent(alloc);
+
+        this._all_visible = true;
+        let all_cards = this.get_children();
+
+        if (all_cards.length === 0)
+            return;
+
+        let spacing = this._get_horizontal_spacing(alloc.width);
+        let available_width = alloc.width;
+        let x = alloc.x;
+        let y = alloc.y;
+
+        all_cards.forEach((card) => {
+            let [card_min, card_nat] = card.get_preferred_width();
+            if (card_nat < available_width) {
+                let offset = card_nat + spacing;
+                this.place_card(card, x, y, card_nat, MENU_HEIGHT);
+                available_width -= offset;
+                x += offset;
+            } else {
+                this._all_visible = false;
+                card.set_child_visible(false);
+            }
+        });
+    },
+
+    _get_horizontal_spacing: function (width) {
+        let spacing;
+        if (width <= _HorizontalThreshold.TINY) {
+            spacing = _HorizontalSpacing.TINY;
+        } else if (width <= _HorizontalThreshold.SMALL) {
+            spacing = _HorizontalSpacing.SMALL;
+        } else if (width <= _HorizontalThreshold.LARGE) {
+            spacing = _HorizontalSpacing.LARGE;
+        } else {
+            spacing = _HorizontalSpacing.XLARGE;
+        }
+        return spacing;
+    },
+});

--- a/tests/js/app/modules/testSideBySideArrangement.js
+++ b/tests/js/app/modules/testSideBySideArrangement.js
@@ -1,0 +1,78 @@
+// Copyright 2016 Endless Mobile, Inc.
+
+const Gtk = imports.gi.Gtk;
+
+const Minimal = imports.tests.minimal;
+const SideBySideArrangement = imports.app.modules.sideBySideArrangement;
+const Utils = imports.tests.utils;
+
+Gtk.init(null);
+
+Minimal.test_arrangement_compliance(SideBySideArrangement.SideBySideArrangement);
+
+describe('SideBySide Arrangement', function () {
+    let arrangement;
+
+    beforeEach(function () {
+        arrangement = new SideBySideArrangement.SideBySideArrangement();
+    });
+
+    describe('sizing allocation', function () {
+        let win, arrangement_height, child_width;
+
+        beforeEach(function () {
+            // Constant sizes on the widgets
+            arrangement_height = 100;
+            child_width = 100;
+
+            for (let i = 0; i < 10; i++) {
+                let card = new Minimal.MinimalCard({
+                    width_request: child_width,
+                });
+                arrangement.add_card(card);
+            }
+            win = new Gtk.OffscreenWindow();
+            win.add(arrangement);
+            win.show_all();
+        });
+
+        afterEach(function () {
+            win.destroy();
+        });
+
+        function testSizingArrangementForDimensions(arr_width, visible_children, spacing) {
+            let message = 'handles arrangement for width=' + arr_width;
+            let x = 0;
+
+            it (message, function () {
+                win.set_size_request(arr_width, 100);
+                Utils.update_gui();
+
+                arrangement.get_children().forEach((card, i) => {
+                    if (i < visible_children) {
+                        expect(card.get_child_visible()).toBe(true);
+                        expect(card.get_allocation().x).toBe(x);
+                        x += (child_width + spacing);
+                    } else {
+                        expect(card.get_child_visible()).toBe(false);
+                    }
+                });
+            });
+        }
+
+        // At width=2000px, all ten cards should be visible with 50px spacing
+        testSizingArrangementForDimensions(2000, 10, 50);
+        // At width=1200px, eight cards should be visible, with 40px spacing
+        testSizingArrangementForDimensions(1200, 8, 40);
+        // At width=1000px, seven cards should be visible, with 40px spacing
+        testSizingArrangementForDimensions(1000, 7, 40);
+        // At width=800px, seven cards should be visible, with 20px spacing
+        testSizingArrangementForDimensions(900, 7, 20);
+        // At width=800px, six cards should be visible, with 20px spacing
+        testSizingArrangementForDimensions(800, 6, 20);
+        // At width=720px, six cards should be visible, with 15px spacing
+        testSizingArrangementForDimensions(720, 6, 15);
+        // At width=600px, five cards should be visible, with 15x spacing
+        testSizingArrangementForDimensions(600, 5, 15);
+    });
+});


### PR DESCRIPTION
The SideBySideArrangement organizes cards as they would appear in a menu bar.
Each card appears next to each other, and the arrangement only shows as many
cards as it has available width.

[endlessm/eos-sdk#3994]
