### PR TITLE
Backport MockFactory.get_last_created_named_mock()

### DIFF
--- a/tests/mockFactory.js
+++ b/tests/mockFactory.js
@@ -37,6 +37,11 @@ const MockFactory = new Lang.Class({
         return this._created_mocks[name] || [];
     },
 
+    get_last_created_named_mock: function (name) {
+        let mocks = this.get_created_named_mocks(name);
+        return mocks[mocks.length - 1];
+    },
+
     create_module_for_slot: function (parent, slot, props={}) {
         if (parent.get_slot_names().indexOf(slot) === -1)
             throw new Error('No slot named ' + slot + ' according to module.get_slot_names.');


### PR DESCRIPTION
This needs to be available on eos2.5 for a cherry-pick.

[endlessm/eos-sdk#4037]
