### PR TITLE
Add text-halign property to card interface.

### DIFF
--- a/js/app/interfaces/card.js
+++ b/js/app/interfaces/card.js
@@ -126,6 +126,18 @@ const Card = new Lang.Interface({
             'Highlight string', 'Substring to be highlighted on card',
             GObject.ParamFlags.READWRITE,
             ''),
+        /**
+         * Property: text-halign
+         * Horizontal alignment of text when card is in _not_ in horizontal mode.
+         *
+         * Default value:
+         *   **Gtk.Align.CENTER**
+         */
+        'text-halign': GObject.ParamSpec.enum('text-halign',
+            'Title halign', 'Horizontal alignment of title text',
+            GObject.ParamFlags.READWRITE | GObject.ParamFlags.CONSTRUCT_ONLY,
+            Gtk.Align.$gtype, Gtk.Align.CENTER),
+
     },
 
     set css (v) {

--- a/js/app/modules/articleSnippetCard.js
+++ b/js/app/modules/articleSnippetCard.js
@@ -35,6 +35,7 @@ const ArticleSnippetCard = new Lang.Class({
         'title-capitalization': GObject.ParamSpec.override('title-capitalization',
             Card.Card),
         'highlight-string': GObject.ParamSpec.override('highlight-string', Card.Card),
+        'text-halign': GObject.ParamSpec.override('text-halign', Card.Card),
     },
 
     Template: 'resource:///com/endlessm/knowledge/data/widgets/articleSnippetCard.ui',

--- a/js/app/modules/cardA.js
+++ b/js/app/modules/cardA.js
@@ -38,6 +38,7 @@ const CardA = new Lang.Class({
         'title-capitalization': GObject.ParamSpec.override('title-capitalization',
             Card.Card),
         'highlight-string': GObject.ParamSpec.override('highlight-string', Card.Card),
+        'text-halign': GObject.ParamSpec.override('text-halign', Card.Card),
     },
 
     Template: 'resource:///com/endlessm/knowledge/data/widgets/cardA.ui',

--- a/js/app/modules/cardB.js
+++ b/js/app/modules/cardB.js
@@ -27,6 +27,7 @@ const CardB = new Lang.Class({
         'title-capitalization': GObject.ParamSpec.override('title-capitalization',
             Card.Card),
         'highlight-string': GObject.ParamSpec.override('highlight-string', Card.Card),
+        'text-halign': GObject.ParamSpec.override('text-halign', Card.Card),
     },
 
     Template: 'resource:///com/endlessm/knowledge/data/widgets/cardB.ui',

--- a/js/app/modules/knowledgeDocumentCard.js
+++ b/js/app/modules/knowledgeDocumentCard.js
@@ -50,6 +50,7 @@ const KnowledgeDocumentCard = new Lang.Class({
         'custom-css': GObject.ParamSpec.override('custom-css',
             DocumentCard.DocumentCard),
         'highlight-string': GObject.ParamSpec.override('highlight-string', Card.Card),
+        'text-halign': GObject.ParamSpec.override('text-halign', Card.Card),
 
         /**
          * Property: show-top-title

--- a/js/app/modules/mediaCard.js
+++ b/js/app/modules/mediaCard.js
@@ -29,6 +29,7 @@ const MediaCard = new Lang.Class({
         'title-capitalization': GObject.ParamSpec.override('title-capitalization',
             Card.Card),
         'highlight-string': GObject.ParamSpec.override('highlight-string', Card.Card),
+        'text-halign': GObject.ParamSpec.override('text-halign', Card.Card),
     },
 
     Template: 'resource:///com/endlessm/knowledge/data/widgets/mediaCard.ui',

--- a/js/app/modules/postCard.js
+++ b/js/app/modules/postCard.js
@@ -28,6 +28,7 @@ const PostCard = new Lang.Class({
         'title-capitalization': GObject.ParamSpec.override('title-capitalization',
             Card.Card),
         'highlight-string': GObject.ParamSpec.override('highlight-string', Card.Card),
+        'text-halign': GObject.ParamSpec.override('text-halign', Card.Card),
     },
 
     Template: 'resource:///com/endlessm/knowledge/data/widgets/postCard.ui',
@@ -72,6 +73,7 @@ const PostCard = new Lang.Class({
             let content_height = this._get_content_height(alloc.height);
             child_alloc.y = alloc.height - content_height;
             child_alloc.height = content_height;
+            this._title_label.halign = this._space_container.halign = this.text_halign;
         }
         this._shadow_frame.size_allocate(child_alloc);
         this.update_card_sizing_classes(alloc.height, alloc.width);

--- a/js/app/modules/readerCard.js
+++ b/js/app/modules/readerCard.js
@@ -39,6 +39,7 @@ const ReaderCard = new Lang.Class({
         'title-capitalization': GObject.ParamSpec.override('title-capitalization',
             Card.Card),
         'highlight-string': GObject.ParamSpec.override('highlight-string', Card.Card),
+        'text-halign': GObject.ParamSpec.override('text-halign', Card.Card),
     },
 
     Template: 'resource:///com/endlessm/knowledge/data/widgets/readerCard.ui',

--- a/js/app/modules/readerDocumentCard.js
+++ b/js/app/modules/readerDocumentCard.js
@@ -46,6 +46,7 @@ const ReaderDocumentCard = new Lang.Class({
         'title-capitalization': GObject.ParamSpec.override('title-capitalization',
             Card.Card),
         'highlight-string': GObject.ParamSpec.override('highlight-string', Card.Card),
+        'text-halign': GObject.ParamSpec.override('text-halign', Card.Card),
         'content-view': GObject.ParamSpec.override('content-view', DocumentCard.DocumentCard),
         'custom-css': GObject.ParamSpec.override('custom-css',
             DocumentCard.DocumentCard),

--- a/js/app/modules/searchResultCard.js
+++ b/js/app/modules/searchResultCard.js
@@ -27,6 +27,7 @@ const SearchResultCard = new Lang.Class({
         'title-capitalization': GObject.ParamSpec.override('title-capitalization',
             Card.Card),
         'highlight-string': GObject.ParamSpec.override('highlight-string', Card.Card),
+        'text-halign': GObject.ParamSpec.override('text-halign', Card.Card),
     },
 
     Template: 'resource:///com/endlessm/knowledge/data/widgets/searchResultCard.ui',

--- a/js/app/modules/sequenceCard.js
+++ b/js/app/modules/sequenceCard.js
@@ -42,6 +42,7 @@ const SequenceCard = new Lang.Class({
         'model': GObject.ParamSpec.override('model', Card.Card),
         'title-capitalization': GObject.ParamSpec.override('title-capitalization', Card.Card),
         'highlight-string': GObject.ParamSpec.override('highlight-string', Card.Card),
+        'text-halign': GObject.ParamSpec.override('text-halign', Card.Card),
         /**
          * Property: sequence
          * A <Sequence> value for the card. Previous or next.

--- a/js/app/modules/setPreviewCard.js
+++ b/js/app/modules/setPreviewCard.js
@@ -45,6 +45,7 @@ const SetPreviewCard = new Lang.Class({
         'title-capitalization': GObject.ParamSpec.override('title-capitalization',
             Card.Card),
         'highlight-string': GObject.ParamSpec.override('highlight-string', Card.Card),
+        'text-halign': GObject.ParamSpec.override('text-halign', Card.Card),
     },
 
     Template: 'resource:///com/endlessm/knowledge/data/widgets/setPreviewCard.ui',

--- a/js/app/modules/textCard.js
+++ b/js/app/modules/textCard.js
@@ -37,6 +37,7 @@ const TextCard = new Lang.Class({
         'title-capitalization': GObject.ParamSpec.override('title-capitalization',
             Card.Card),
         'highlight-string': GObject.ParamSpec.override('highlight-string', Card.Card),
+        'text-halign': GObject.ParamSpec.override('text-halign', Card.Card),
 
         /**
          * Property: underline-on-hover

--- a/js/app/modules/thumbCard.js
+++ b/js/app/modules/thumbCard.js
@@ -37,6 +37,7 @@ const ThumbCard = new Lang.Class({
         'title-capitalization': GObject.ParamSpec.override('title-capitalization',
             Card.Card),
         'highlight-string': GObject.ParamSpec.override('highlight-string', Card.Card),
+        'text-halign': GObject.ParamSpec.override('text-halign', Card.Card),
     },
 
     Template: 'resource:///com/endlessm/knowledge/data/widgets/thumbCard.ui',
@@ -86,7 +87,7 @@ const ThumbCard = new Lang.Class({
             proportion = 1/2;
         } else {
             this._title_label.justify = Gtk.Justification.CENTER;
-            this._title_label.halign = this._synopsis_label.halign = this._space_container.halign = Gtk.Align.CENTER;
+            this._title_label.halign = this._synopsis_label.halign = this._space_container.halign = this.text_halign;
             orientation = Gtk.Orientation.VERTICAL;
             this._title_label.xalign = 0.5;
             proportion = 2/3;


### PR DESCRIPTION
Allows us to customize the alignment of text
when a card is not in horizontal mode. This allows
us to reuse the cards from the reader app in the news
app.

[endlessm/eos-sdk#4099]
