### PR TITLE
Sdk/3993

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -296,6 +296,7 @@ javascript_tests = \
 	tests/js/app/modules/testPaperTemplate.js \
 	tests/js/app/modules/testPianoArrangement.js \
 	tests/js/app/modules/testPostCard.js \
+	tests/js/app/modules/testPublishedDateOrder.js \
 	tests/js/app/modules/testQuarterArrangement.js \
 	tests/js/app/modules/testQuiltArrangement.js \
 	tests/js/app/modules/testReaderCard.js \

--- a/eos-knowledge.gresource.xml
+++ b/eos-knowledge.gresource.xml
@@ -131,6 +131,7 @@
     <file>js/app/modules/pianoArrangement.js</file>
     <file>js/app/modules/pianolaArrangement.js</file>
     <file>js/app/modules/postCard.js</file>
+    <file>js/app/modules/publishedDateOrder.js</file>
     <file>js/app/modules/quarterArrangement.js</file>
     <file>js/app/modules/quiltArrangement.js</file>
     <file>js/app/modules/readerCard.js</file>

--- a/js/app/modules/publishedDateOrder.js
+++ b/js/app/modules/publishedDateOrder.js
@@ -1,0 +1,35 @@
+// Copyright 2016 Endless Mobile, Inc.
+
+/* exported PublishedDateOrder */
+
+const GObject = imports.gi.GObject;
+const Lang = imports.lang;
+
+const Module = imports.app.interfaces.module;
+const Order = imports.app.interfaces.order;
+
+/**
+ * Class: PublishedDateOrder
+ * Order that sorts object models by publication date
+ */
+const PublishedDateOrder = new Lang.Class({
+    Name: 'PublishedDateOrder',
+    Extends: GObject.Object,
+    Implements: [Module.Module, Order.Order],
+
+    Properties: {
+        'factory': GObject.ParamSpec.override('factory', Module.Module),
+        'factory-name': GObject.ParamSpec.override('factory-name', Module.Module),
+        'ascending': GObject.ParamSpec.override('ascending', Order.Order),
+    },
+
+    compare_impl: function (left, right) {
+        if (!left.published && !right.published)
+            return 0;
+        if (!left.published)
+            return -1;
+        if (!right.published)
+            return 1;
+        return left.published.localeCompare(right.published);
+    },
+});

--- a/tests/js/app/modules/testPublishedDateOrder.js
+++ b/tests/js/app/modules/testPublishedDateOrder.js
@@ -1,0 +1,54 @@
+// Copyright 2016 Endless Mobile, Inc.
+
+const PublishedDateOrder = imports.app.modules.publishedDateOrder;
+const ArticleObjectModel = imports.search.articleObjectModel;
+
+describe('Published date order', function () {
+    let order, models;
+
+    const UNSORTED_DATES = [
+        '2013-07-03T00:00:00',
+        '2014-07-03T00:00:00',
+        '',
+        '2012-07-03T00:00:00',
+    ];
+    const SORTED_DATES = [
+        '',
+        '2012-07-03T00:00:00',
+        '2013-07-03T00:00:00',
+        '2014-07-03T00:00:00',
+    ];
+
+    beforeEach(function () {
+        models = UNSORTED_DATES.map(date =>
+            new ArticleObjectModel.ArticleObjectModel({ published: date }));
+    });
+
+    describe('ascending', function () {
+        beforeEach(function () {
+            order = new PublishedDateOrder.PublishedDateOrder();
+        });
+
+        it('is the default', function () {
+            expect(order.ascending).toBeTruthy();
+        });
+
+        it('sorts models by published date', function () {
+            expect(models.sort(order.compare.bind(order))
+                .map(model => model.published)).toEqual(SORTED_DATES);
+        });
+    });
+
+    describe('descending', function () {
+        beforeEach(function () {
+            order = new PublishedDateOrder.PublishedDateOrder({
+                ascending: false,
+            });
+        });
+
+        it('sorts models by published date', function () {
+            expect(models.sort(order.compare.bind(order))
+                .map(model => model.published)).toEqual(SORTED_DATES.reverse());
+        });
+    });
+});


### PR DESCRIPTION
Be able to sort cards by the date in which ObjectModels have been published. Also, handle objects without the published property gracefully.

[endlessm/eos-sdk#3993]

This can be merged after [endlessm/eos-sdk#3990] is merged.
