### PR TITLE
Remove leftover prop from SuggestedCategoriesModule

### DIFF
--- a/data/compat/v1-preset-json/news.json
+++ b/data/compat/v1-preset-json/news.json
@@ -296,8 +296,7 @@
                         "second": {
                             "type": "SuggestedCategoriesModule",
                             "properties": {
-                                    "featured-only": true,
-                                    "show-title": false
+                                "show-title": false
                             },
                             "slots": {
                                 "arrangement": {


### PR DESCRIPTION
We no longer require the "featured-only" property on SuggestedCategoriesModule,
hence we need to remove it from the json specification for the news app to
work properly.

[endlessm/eos-sdk#4120]
