### PR TITLE
Put the downloader.ini in /usr/share rather than /etc

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -226,7 +226,6 @@ subst = $(SED) \
 	-e 's,%pkglibdir%,$(pkglibdir),g' \
 	-e 's,%typelibdir%,$(typelibdir),g' \
 	-e 's,%webextensiondir%,$(webextensiondir),g' \
-	-e 's,%sysconfdir%,$(sysconfdir),g' \
 	$(NULL)
 
 subst_files = \
@@ -264,8 +263,7 @@ bin_SCRIPTS += \
 	picard \
 	$(NULL)
 
-confdir = $(sysconfdir)/eos-knowledge-lib
-dist_conf_DATA = data/downloader.ini
+dist_pkgdata_DATA = data/downloader.ini
 
 # # # TESTS # # #
 

--- a/js/search/config.js.in
+++ b/js/search/config.js.in
@@ -1,1 +1,1 @@
-const SYSCONFDIR = '%sysconfdir%';
+const PKGDATADIR = '%pkgdatadir%';

--- a/js/search/downloader.js
+++ b/js/search/downloader.js
@@ -198,7 +198,7 @@ const SubscriptionDownloader = new Lang.Class({
     _load_from_config: function () {
         let config_env = GLib.getenv('EKN_UPDATER_CONFIG');
         if (config_env === null)
-            config_env = Config.SYSCONFDIR + '/eos-knowledge-lib/downloader.ini';
+            config_env = Config.PKGDATADIR + '/downloader.ini';
 
         let kf = GLib.KeyFile.new();
         kf.load_from_file(config_env, GLib.KeyFileFlags.NONE);


### PR DESCRIPTION
We weren't even shipping the files in /etc to begin with due to Debian
packaging, and this also helps prevent OSTree conflicts.

https://phabricator.endlessm.com/T10604
