### PR TITLE
Correct documentation headers for all files

### DIFF
--- a/js/app/application.js
+++ b/js/app/application.js
@@ -28,6 +28,9 @@ const KnowledgeSearchIface = '\
   </interface> \
 </node>';
 
+/**
+ * Class: Application
+ */
 const Application = new Lang.Class({
     Name: 'Application',
     GTypeName: 'EknApplication',

--- a/js/app/articleHTMLRenderer.js
+++ b/js/app/articleHTMLRenderer.js
@@ -24,6 +24,9 @@ function load_article_template () {
     return _template_contents;
 }
 
+/**
+ * Class: ArticleHTMLRenderer
+ */
 const ArticleHTMLRenderer = new Lang.Class({
     Name: "ArticleHTMLRenderer",
     GTypeName: 'EknArticleHTMLRenderer',

--- a/js/app/interfaces/module.js
+++ b/js/app/interfaces/module.js
@@ -2,6 +2,9 @@ const GLib = imports.gi.GLib;
 const GObject = imports.gi.GObject;
 const Lang = imports.lang;
 
+/**
+ * Interface: Module
+ */
 const Module = new Lang.Interface({
     Name: 'Module',
     Requires: [ GObject.Object ],

--- a/js/app/moduleFactory.js
+++ b/js/app/moduleFactory.js
@@ -6,6 +6,9 @@ const Engine = imports.search.engine;
 const EosKnowledgePrivate = imports.gi.EosKnowledgePrivate;
 const Warehouse = imports.app.warehouse;
 
+/**
+ * Class: ModuleFactory
+ */
 const ModuleFactory = new Lang.Class({
     Name: 'ModuleFactory',
     Extends: GObject.Object,

--- a/js/app/modules/articleSnippetCard.js
+++ b/js/app/modules/articleSnippetCard.js
@@ -12,7 +12,7 @@ const StyleClasses = imports.app.styleClasses;
 const Utils = imports.app.utils;
 
 /**
- * Class: Reader.ArticleSnippetCard
+ * Class: ArticleSnippetCard
  * Widget to display an article snippet
  *
  * Displays a snippet with a title and a couple of lines of synopsis.

--- a/js/app/modules/encyclopediaWindow.js
+++ b/js/app/modules/encyclopediaWindow.js
@@ -9,6 +9,9 @@ const Module = imports.app.interfaces.module;
 const StyleClasses = imports.app.styleClasses;
 const Utils = imports.app.utils;
 
+/**
+ * Class: EncyclopediaWindow
+ */
 const EncyclopediaWindow = new Lang.Class({
     Name: 'EncyclopediaWindow',
     Extends: Endless.Window,

--- a/js/app/modules/gridArrangement.js
+++ b/js/app/modules/gridArrangement.js
@@ -10,6 +10,9 @@ const Arrangement = imports.app.interfaces.arrangement;
 const InfiniteScrolledWindow = imports.app.widgets.infiniteScrolledWindow;
 const Module = imports.app.interfaces.module;
 
+/**
+ * Class: GridArrangement
+ */
 const GridArrangement = new Lang.Class({
     Name: 'GridArrangement',
     GTypeName: 'EknGridArrangement',

--- a/js/app/modules/readerCard.js
+++ b/js/app/modules/readerCard.js
@@ -14,7 +14,7 @@ const Utils = imports.app.utils;
 let _ = Gettext.dgettext.bind(null, Config.GETTEXT_PACKAGE);
 
 /**
- * Class: Reader.Card
+ * Class: ReaderCard
  *
  * A card implementation with sizing and styling specific to Reader apps.
  *

--- a/js/app/modules/readerWindow.js
+++ b/js/app/modules/readerWindow.js
@@ -18,7 +18,7 @@ const StyleClasses = imports.app.styleClasses;
 const Utils = imports.app.utils;
 
 /**
- * Class: Reader.Window
+ * Class: ReaderWindow
  * The window of the reader app.
  *
  * This class has the API to add, modify, and display article and done pages.

--- a/js/app/modules/squareGuysArrangement.js
+++ b/js/app/modules/squareGuysArrangement.js
@@ -18,6 +18,9 @@ const CARD_SIZE_SMALL = Card.MinSize.B;
 const CARD_SIZE_BIG = Card.MinSize.C;
 const CARD_SIZE_MAX = Card.MaxSize.C;
 
+/**
+ * Class: SquareGuysArrangement
+ */
 const SquareGuysArrangement = new Lang.Class({
     Name: 'SquareGuysArrangement',
     GTypeName: 'EknSquareGuysArrangement',

--- a/js/app/modules/thirtiesArrangement.js
+++ b/js/app/modules/thirtiesArrangement.js
@@ -20,6 +20,9 @@ const CARD_WIDTH_SMALL = Card.MinSize.B;
 const CARD_WIDTH_BIG = Card.MinSize.H;
 const COL_COUNT = 3;
 
+/**
+ * Class: ThirtiesArrangement
+ */
 const ThirtiesArrangement = new Lang.Class({
     Name: 'ThirtiesArrangement',
     GTypeName: 'EknThirtiesArrangement',

--- a/js/app/styleClasses.js
+++ b/js/app/styleClasses.js
@@ -1,5 +1,5 @@
 /**
- * File: styleClasses
+ * File: StyleClasses
  *
  * This file enumerates all of our knowledge widget css style classes in a bunch
  * of constants.

--- a/js/app/widgets/infiniteScrolledWindow.js
+++ b/js/app/widgets/infiniteScrolledWindow.js
@@ -5,6 +5,9 @@ const Lang = imports.lang;
 
 GObject.ParamFlags.READWRITE = GObject.ParamFlags.READABLE | GObject.ParamFlags.WRITABLE;
 
+/**
+ * Class: InfiniteScrolledWindow
+ */
 const InfiniteScrolledWindow = new Lang.Class({
     Name: 'InfiniteScrolledWindow',
     GTypeName: 'EknInfiniteScrolledWindow',

--- a/js/app/widgets/progressLabel.js
+++ b/js/app/widgets/progressLabel.js
@@ -12,7 +12,7 @@ String.prototype.format = Format.format;
 GObject.ParamFlags.READWRITE = GObject.ParamFlags.READABLE | GObject.ParamFlags.WRITABLE;
 
 /**
- * Class: Reader.ProgressLabel
+ * Class: ProgressLabel
  * Widget indicating how much of the magazine issue has been read
  *
  * Extends:

--- a/js/app/widgets/tabButton.js
+++ b/js/app/widgets/tabButton.js
@@ -7,6 +7,9 @@ const Utils = imports.app.utils;
 
 GObject.ParamFlags.READWRITE = GObject.ParamFlags.READABLE | GObject.ParamFlags.WRITABLE;
 
+/**
+ * Class: TabButton
+ */
 const TabButton = new Lang.Class({
     Name: 'TabButton',
     GTypeName: 'EknTabButton',

--- a/js/search/domain.js
+++ b/js/search/domain.js
@@ -15,6 +15,9 @@ const QueryObject = imports.search.queryObject;
 const SetObjectModel = imports.search.setObjectModel;
 const Utils = imports.search.utils;
 
+/**
+ * Class: Domain
+ */
 const Domain = new Lang.Class({
     Name: 'Domain',
     Abstract: true,

--- a/js/search/xapianBridge.js
+++ b/js/search/xapianBridge.js
@@ -8,6 +8,9 @@ const Soup = imports.gi.Soup;
 const AsyncTask = imports.search.asyncTask;
 const QueryObject = imports.search.queryObject;
 
+/**
+ * Class: XapianBridge
+ */
 const XapianBridge = new Lang.Class({
     Name: 'XapianBridge',
     GTypeName: 'EknXapianBridge',


### PR DESCRIPTION
Some classes and interfaces didn't have headers, so their members were
"orphaned" in the side menu of the generated docs.

Other headers had titles that didn't correspond with the current name of
the class.

https://phabricator.endlessm.com/T10607
