### PR TITLE
T10714

### DIFF
--- a/js/app/modules/backgroundModule.js
+++ b/js/app/modules/backgroundModule.js
@@ -14,6 +14,8 @@ const DominantColor = imports.app.dominantColor;
 const Module = imports.app.interfaces.module;
 const Utils = imports.app.utils;
 
+const DEFAULT_COLOR = '#BBBCB6';
+
 // FIXME: Replace for real blurred images
 const _topImage = 'resource:///com/endlessm/knowledge/data/images/background.png';
 
@@ -142,7 +144,12 @@ const BackgroundModule = new Lang.Class({
         this._model = model;
 
         DominantColor.get_dominant_color(model, null, (helper, task) => {
-            let color = helper.get_dominant_color_finish(task);
+            let color;
+            try {
+                color = helper.get_dominant_color_finish(task);
+            } catch (error) {
+                color = DEFAULT_COLOR;
+            }
             this._set_background(color);
         });
     },

--- a/tests/js/app/modules/testBackgroundModule.js
+++ b/tests/js/app/modules/testBackgroundModule.js
@@ -51,4 +51,16 @@ describe('Background Module', function () {
 
         expect(Gtk.CssProvider.prototype.load_from_data.calls.mostRecent().args[0]).toMatch(color);
     });
+
+    it('handles models without thumbnail', function () {
+        let model = new ContentObjectModel.ContentObjectModel();
+
+        dispatcher.dispatch({
+            action_type: Actions.FEATURE_ITEM,
+            model: model,
+        });
+        Utils.update_gui();
+
+        expect(Gtk.CssProvider.prototype.load_from_data).toHaveBeenCalled();
+    });
 });


### PR DESCRIPTION
Fallback to a default color in BackgroundModule

Rory saw object models that didn't have thumbnails.
This condition can currently break the module.

Make sure that the BackgroundModule can handle models with
no thumbnail and can fallback to a default color.

https://phabricator.endlessm.com/T10714
