### PR TITLE
Fix giant quote marks

### DIFF
--- a/data/templates/css/prensa-libre.scss
+++ b/data/templates/css/prensa-libre.scss
@@ -106,6 +106,7 @@ figure,
 
 blockquote {
     display: flex;
+    flex-wrap: wrap;
 
     p {
         font-family: $headline-font;
@@ -262,11 +263,18 @@ hr {
 
         p {
             margin: 0 $dedent 0 0;
+            flex-basis: 100%;
+        }
+
+        cite {
+            margin-left: -$dedent;
+            flex-basis: 100%;
         }
 
         &::before {
-            min-width: 3 * $body-size;
+            width: 3 * $body-size;
             height: 3 * $body-size;
+            flex-basis: 3 * $body-size;
             margin-right: calc(-3 * #{$body-size} - #{$dedent});
         }
     }


### PR DESCRIPTION
This makes sure that quote marks don't grow to cover the whole page.
Also aligns `<cite>` items below the main text in a `<blockquote>`, although
that will not be visible until content is processed with the
corresponding revision of eos-lambda-services.

https://phabricator.endlessm.com/T10720
