### PR TITLE
Don't wrap CANCELLED error in search provider

### DIFF
--- a/js/search/searchProvider.js
+++ b/js/search/searchProvider.js
@@ -153,8 +153,12 @@ const AppSearchProvider = Lang.Class({
             } catch (error) {
                 if (!error.matches(Gio.IOErrorEnum, Gio.IOErrorEnum.CANCELLED)) {
                     logError(error);
+                    invocation.return_error_literal(this._search_provider_domain,
+                        SearchProviderErrors.RetrievalError,
+                        'Error retrieving results: ' + error);
+                } else {
+                    invocation.return_gerror(error);
                 }
-                invocation.return_error_literal(this._search_provider_domain, SearchProviderErrors.RetrievalError, 'Error retrieving results: ' + error);
             }
             app.release();
         });


### PR DESCRIPTION
Our knowledge app search provider was wrapping a
Gio.IOErrorEnum.CANCELLED in our own error type, and handing that to the
shell, which logged it as a failure. Instead, if the operation is
cancelled, then hand a plain old CANCELLED error to the shell.

https://phabricator.endlessm.com/T10595
