### PR TITLE
Add margins to News app home page

### DIFF
--- a/data/compat/v1-preset-json/news.json
+++ b/data/compat/v1-preset-json/news.json
@@ -60,6 +60,8 @@
                                                 "halign": "center",
                                                 "margin-top": 50,
                                                 "margin-bottom": 50,
+                                                "margin-start": 20,
+                                                "margin-end": 20,
                                                 "support-sets": 4
                                             },
                                             "slots": {


### PR DESCRIPTION
The home page of the News app needs to have left/right margins.

https://phabricator.endlessm.com/T10816
