### PR TITLE
Filter out undefined return values from SetMap

### DIFF
--- a/js/app/articleHTMLRenderer.js
+++ b/js/app/articleHTMLRenderer.js
@@ -160,6 +160,7 @@ const ArticleHTMLRenderer = new Lang.Class({
         let featured_set = model.tags
             .filter(tag => !tag.startsWith('Ekn'))
             .map(tag => SetMap.get_set_for_tag(tag))
+            .filter(set => typeof set !== 'undefined')
             .filter(set => set.featured)[0];
         return {
             'date-published': new Date(model.published).toLocaleDateString(),


### PR DESCRIPTION
This is a workaround for a content bug. We shouldnt
really have articles tagged with tags that dont
appear in any set, but in the case where we do,
SetMap.get_set_for_tag will return undefined.

This filters out those undefined values.

https://phabricator.endlessm.com/T10717
