### PR TITLE
Make sure SetPreviewCard shows trigger button

### DIFF
--- a/js/app/modules/cardContainer.js
+++ b/js/app/modules/cardContainer.js
@@ -118,10 +118,9 @@ const CardContainer = new Lang.Class({
             this.trigger.add(trigger_box);
             this.trigger.get_style_context().add_class('trigger');
             Utils.set_hand_cursor_on_widget(this.trigger);
-            this.arrangement.bind_property('all-visible', this.trigger, 'visible',
-                GObject.BindingFlags.SYNC_CREATE | GObject.BindingFlags.INVERT_BOOLEAN);
             Utils.set_hand_cursor_on_widget(this.title_button);
             this._update_title();
+            this.trigger.show_all();
             this.attach(this.trigger, 1, 0, 1, 1);
         }
         this.show_all();


### PR DESCRIPTION
Since the title will be clickable, we ought to
show the trigger button on the right, regardless
of whether the arrangement has extra cards
which are not visible.

https://phabricator.endlessm.com/T10797
