### PR TITLE
Add link back to parent set on article page

### DIFF
--- a/data/templates/article.mst
+++ b/data/templates/article.mst
@@ -11,7 +11,7 @@
             {{#extra-header-information}}
             <div class="extra-header">
                 {{#context}}
-                <div class="context"><p>{{.}}</p></div>
+                <div class="context"><p>{{{.}}}</p></div>
                 {{/context}}
                 <div class="extra-header-right">
                     {{#date-published}}

--- a/js/app/articleHTMLRenderer.js
+++ b/js/app/articleHTMLRenderer.js
@@ -164,7 +164,7 @@ const ArticleHTMLRenderer = new Lang.Class({
             .filter(set => set.featured)[0];
         return {
             'date-published': new Date(model.published).toLocaleDateString(),
-            'context': featured_set.title.toLowerCase(),
+            'context': _to_set_link(featured_set),
             'source-link': _to_link(model.original_uri, 'Prensalibre.com'),
         };
     },
@@ -200,6 +200,10 @@ const ArticleHTMLRenderer = new Lang.Class({
         });
     },
 });
+
+function _to_set_link (model) {
+    return '<a class="eos-show-link" href="' + model.ekn_id + '">' + Mustache.escape(model.title.toLowerCase()) + '</a>';
+}
 
 function _to_link(uri, text) {
     return '<a class="eos-show-link" href="browser-' + uri + '">' + Mustache.escape(text) + '</a>';

--- a/js/app/modules/buffetInteraction.js
+++ b/js/app/modules/buffetInteraction.js
@@ -538,6 +538,12 @@ const BuffetInteraction = new Lang.Class({
                 action_type: Actions.SHOW_MEDIA,
                 model: model,
             });
+        } else if (model instanceof SetObjectModel.SetObjectModel) {
+            this._history_presenter.set_current_item_from_props({
+                page_type: Pages.SET,
+                model: model,
+                context_label: model.title,
+            });
         }
     },
 

--- a/tests/js/app/modules/testBuffetInteraction.js
+++ b/tests/js/app/modules/testBuffetInteraction.js
@@ -330,6 +330,16 @@ describe('Buffet interaction', function () {
             let payload = dispatcher.last_payload_with_type(Actions.SHOW_MEDIA);
             expect(payload.model).toBe(media_model);
         });
+
+        it('changes to the set page if link is a set', function () {
+            engine.get_object_by_id_finish.and.returnValue(set_models[0]);
+            dispatcher.dispatch({
+                action_type: Actions.ARTICLE_LINK_CLICKED,
+                ekn_id: 'ekn://foo/bar',
+            });
+            let payload = dispatcher.last_payload_with_type(Actions.SHOW_SET);
+            expect(payload.model).toBe(set_models[0]);
+        });
     });
 
     describe('when browse categories title is clicked', function () {

--- a/tests/js/app/testArticleHTMLRenderer.js
+++ b/tests/js/app/testArticleHTMLRenderer.js
@@ -170,23 +170,27 @@ describe('Article HTML Renderer', function () {
     });
 
     describe('Prensa Libre source', function () {
-        let model, html;
+        let model, html, set_models;
 
         beforeEach(function () {
-            SetMap.init_map_with_models([
+            set_models = [
                 new SetObjectModel.SetObjectModel({
                     tags: ['EknHomePageTag', 'EknSetObject'],
                     title: 'Guatemala',
                     child_tags: ['guatemala'],
                     featured: true,
+                    ekn_id: 'ekn://prensalibre/1',
                 }),
                 new SetObjectModel.SetObjectModel({
                     tags: ['guatemala', 'EknSetObject'],
                     title: 'Comunitario',
                     child_tags: ['guatemala/comunitario'],
                     featured: false,
+                    ekn_id: 'ekn://prensalibre/2',
                 }),
-            ]);
+            ];
+
+            SetMap.init_map_with_models(set_models);
             model = new ArticleObjectModel.ArticleObjectModel({
                 source_uri: 'http://www.prensalibre.com/internacional/el-papa-francisco-dice-que-trump-no-puede-proclamarse-cristiano',
                 original_uri: 'http://www.prensalibre.com/internacional/el-papa-francisco-dice-que-trump-no-puede-proclamarse-cristiano',
@@ -214,9 +218,12 @@ describe('Article HTML Renderer', function () {
             // for the existence of a div, but that's not robust.
         });
 
-        it('shows the main category the article is tagged with', function () {
+        it('shows the main category (and link) the article is tagged with', function () {
             expect(html).toMatch('guatemala');
+            expect(html).toMatch(set_models[0].ekn_id);
+
             expect(html).not.toMatch('comunitario');
+            expect(html).not.toMatch(set_models[1].ekn_id);
         });
 
         it('loads the appropriate CSS file', function () {


### PR DESCRIPTION
As per the specs, the article page should
have a link back to its parent set in the top
left.

https://phabricator.endlessm.com/T10647
