### PR TITLE
T10852

### DIFF
--- a/data/css/news.css
+++ b/data/css/news.css
@@ -1,6 +1,10 @@
 @import url("resource:///com/endlessm/knowledge/data/css/common.css");
 @import url("resource:///com/endlessm/knowledge/data/css/buffet_core.css");
 
+* {
+    -GtkScrollbar-min-slider-length: 100; /* larger than the top-menu height */
+}
+
 EknScrollingTemplate:not(.overshoot):not(.undershoot),
 EknBackgroundModule {
     background-color: #e9e5e0;


### PR DESCRIPTION
Make the scrollbar slider larger than top-menu

The GtkScrollbar slider gets smaller when more content is loaded
in the page, to the point where it gets lost behind the top menu.

This patch sets the minimum slider length to be larger than the
top menu height, so it doesn't get lost.

https://phabricator.endlessm.com/T10852
