### PR TITLE
T10208

### DIFF
--- a/js/tools/picard.js
+++ b/js/tools/picard.js
@@ -261,8 +261,12 @@ const ColorBox = new Lang.Class({
         'model': GObject.ParamSpec.override('model', Card.Card),
         'title-capitalization': GObject.ParamSpec.override('title-capitalization',
             Card.Card),
+        'context-capitalization': GObject.ParamSpec.override('context-capitalization',
+            Card.Card),
         'highlight-string': GObject.ParamSpec.override('highlight-string',
             Card.Card),
+        'text-halign': GObject.ParamSpec.override('text-halign', Card.Card),
+        'sequence': GObject.ParamSpec.override('sequence', Card.Card),
     },
 
     _init: function (props={}) {


### PR DESCRIPTION
picard: update ColorBox property overrides

We added three new properties to the card interface
since the development of picard.

Update the overrides in ColorBox to get rid of error
messages.

https://phabricator.endlessm.com/T10208
