### PR TITLE
T10890

### DIFF
--- a/data/compat/v1-preset-json/news.json
+++ b/data/compat/v1-preset-json/news.json
@@ -170,6 +170,12 @@
                                                                     "slots": {
                                                                         "card-type": {
                                                                             "type": "SearchResultCard"
+                                                                        },
+                                                                       "order": {
+                                                                            "type": "PublishedDateOrder",
+                                                                            "properties": {
+                                                                                "ascending": false
+                                                                            }
                                                                         }
                                                                     }
                                                                 },


### PR DESCRIPTION
news preset: add order type to the section-page

Articles of the section-page should be displayed in
chronological order from newer to older.

https://phabricator.endlessm.com/T10890
