### PR TITLE
Remove card-type from modules that don't use it

### DIFF
--- a/js/app/modules/readerWindow.js
+++ b/js/app/modules/readerWindow.js
@@ -32,7 +32,6 @@ const Utils = imports.app.utils;
  * Slots:
  *   archive-page
  *   back-page
- *   card-type
  *   document-arrangement
  *   front-page
  *   lightbox
@@ -393,7 +392,7 @@ const ReaderWindow = new Lang.Class({
     },
 
     get_slot_names: function () {
-        return ['archive-page', 'back-page', 'card-type', 'document-arrangement',
+        return ['archive-page', 'back-page', 'document-arrangement',
             'front-page', 'lightbox', 'navigation', 'search', 'search-page',
             'standalone-page'];
     },

--- a/js/app/modules/supplementaryArticlesModule.js
+++ b/js/app/modules/supplementaryArticlesModule.js
@@ -21,7 +21,6 @@ let _ = Gettext.dgettext.bind(null, Config.GETTEXT_PACKAGE);
  *
  * Slots:
  *   arrangement
- *   card-type
  */
 const SupplementaryArticlesModule = new Lang.Class({
     Name: 'SupplementaryArticlesModule',


### PR DESCRIPTION
It was in the documentation in two places, and as an unused slot in one
place.

https://phabricator.endlessm.com/T10901
