### PR TITLE
Don't cancel ShardFile.init_async()

### DIFF
--- a/js/search/domain.js
+++ b/js/search/domain.js
@@ -333,7 +333,9 @@ const DomainV2 = new Lang.Class({
     load: function (cancellable, callback) {
         let task = new AsyncTask.AsyncTask(this, cancellable, callback);
         let shard_file = this._get_shard_file();
-        shard_file.init_async(0, cancellable, task.catch_callback_errors((shard_file, result) => {
+        // Don't allow async_init() to be cancelled; otherwise, cancellation
+        // will spoil the object for future use.
+        shard_file.init_async(0, null, task.catch_callback_errors((shard_file, result) => {
             shard_file.init_finish(result);
             task.return_value(true);
         }));
@@ -533,7 +535,9 @@ const DomainV3 = new Lang.Class({
 
         return AsyncTask.all(this, (add_task) => {
             this._shards.forEach((shard) => {
-                add_task((cancellable, callback) => shard.init_async(0, cancellable, callback),
+                // Don't allow init_async() to be cancelled; otherwise,
+                // cancellation will spoil the object for future use.
+                add_task((cancellable, callback) => shard.init_async(0, null, callback),
                          (result) => shard.init_finish(result));
             });
         }, cancellable, callback);


### PR DESCRIPTION
This operation will get cancelled by the shell every time the user types
a new letter in the desktop search box. If it's cancelled while in the
init_async() operation, then the ShardFile object will be in an error
state, and as per the GAsyncInitable docs, this spoils the object for any
future use: subsequent method calls are programmer errors.

Instead, we make the init_async() part of the operation uncancellable.

https://phabricator.endlessm.com/T10595
