### PR TITLE
Add author info to Prensa Libre template

### DIFF
--- a/data/templates/article.mst
+++ b/data/templates/article.mst
@@ -18,7 +18,12 @@
                     <p class="date-published">{{.}}</p>
                     {{/date-published}}
                     {{#source-link}}
-                    <p class="source-link">{{{.}}}</p>
+                    <p class="source-link">
+                        {{{.}}}
+                        {{#author}}
+                        &mdash; {{.}}
+                        {{/author}}
+                    </p>
                     {{/source-link}}
                 </div>
             </div>

--- a/data/templates/css/prensa-libre.scss
+++ b/data/templates/css/prensa-libre.scss
@@ -147,7 +147,7 @@ aside {
 
     .extra-header-right {
         font-family: $caption-font;
-        max-width: 25%;
+        max-width: 50%;
         text-align: right;
     }
 

--- a/js/app/articleHTMLRenderer.js
+++ b/js/app/articleHTMLRenderer.js
@@ -166,6 +166,7 @@ const ArticleHTMLRenderer = new Lang.Class({
             'date-published': new Date(model.published).toLocaleDateString(),
             'context': _to_set_link(featured_set),
             'source-link': _to_link(model.original_uri, 'Prensalibre.com'),
+            'author': model.authors.join('—'),
         };
     },
 


### PR DESCRIPTION
This info is required for copyright reasons when displaying articles
from wire services.

https://phabricator.endlessm.com/T10922
