### PR TITLE
News App: Do not italizice context labels

### DIFF
--- a/data/css/buffet_core.css
+++ b/data/css/buffet_core.css
@@ -178,7 +178,6 @@ EknThematicModule .text-card .after {
 
 .card-context {
     font-size: 12px;
-    font-style: italic;
     color: #49bde3;
 }
 

--- a/data/css/endless_buffet.css
+++ b/data/css/endless_buffet.css
@@ -174,6 +174,10 @@ EknContextBanner {
     text-shadow: 0px 1px alpha(white, 0.004);
 }
 
+.card-context {
+    font-style: italic;
+}
+
 /* Changes for composite TVs */
 
 .composite EknSideMenuTemplate .menu .home-button,


### PR DESCRIPTION
Instead of italizicing the context labels by default and then marking it as
"normal" in other apps, we specify the context labels of the Travel app to be
italics.

https://phabricator.endlessm.com/T10934
