### PR TITLE
News App: Fix Context labels color

### DIFF
--- a/data/css/news.css
+++ b/data/css/news.css
@@ -246,6 +246,7 @@ EknSetBannerModule .card:hover .title {
 }
 
 .post-card .card-context {
+    color: #7297a7;
     font-family: 'Merriweather';
     font-weight: bold;
 }


### PR DESCRIPTION
We were missing a spec to define the color of context labels in post cards.

https://phabricator.endlessm.com/T10937
