### PR TITLE
Add highlight background to search result cards

### DIFF
--- a/data/css/news.css
+++ b/data/css/news.css
@@ -176,6 +176,10 @@ EknSearchBannerModule {
     color: #0f1b3c;
 }
 
+.search-result-card .title.highlighted {
+    background-color: rgba(114, 151, 167, 0.3);
+}
+
 .all-type-card.width-c {
     padding: 30px;
 }


### PR DESCRIPTION
We highlight the search query in search result cards, but we were missing
the highlight background, so we add it here.

https://phabricator.endlessm.com/T10951
