### PR TITLE
thumbCard: don't stomp on grid allocations

### DIFF
--- a/data/widgets/thumbCard.ui
+++ b/data/widgets/thumbCard.ui
@@ -6,72 +6,61 @@
     <property name="visible">True</property>
     <property name="can_focus">False</property>
     <property name="receives_default">False</property>
+    <style>
+      <class name="thumb-card"/>
+      <class name="card"/>
+    </style>
+  </template>
+  <object class="GtkFrame" id="thumbnail-frame">
+    <property name="can_focus">False</property>
+    <style>
+      <class name="thumbnail"/>
+    </style>
+  </object>
+  <object class="GtkFrame" id="content-frame">
+    <property name="visible">True</property>
     <child>
-      <object class="GtkGrid" id="grid">
+      <object class="GtkGrid" id="inner-grid">
+        <property name="orientation">vertical</property>
+        <property name="vexpand">True</property>
+        <property name="valign">fill</property>
         <property name="visible">True</property>
-        <property name="can_focus">False</property>
-        <property name="orientation">horizontal</property>
         <child>
-          <object class="GtkFrame" id="thumbnail-frame">
+          <object class="GtkLabel" id="title-label">
             <property name="can_focus">False</property>
+            <property name="expand">True</property>
+            <property name="halign">center</property>
+            <property name="valign">center</property>
+            <property name="xalign">0</property>
+            <property name="use_markup">True</property>
+            <property name="wrap">True</property>
+            <property name="wrap_mode">word-char</property>
+            <property name="ellipsize">end</property>
+            <property name="lines">2</property>
             <style>
-              <class name="thumbnail"/>
+              <class name="title"/>
             </style>
           </object>
         </child>
         <child>
-          <object class="GtkFrame" id="content-frame">
-            <property name="visible">True</property>
-            <child>
-              <object class="GtkGrid" id="inner-grid">
-                <property name="orientation">vertical</property>
-                <property name="vexpand">True</property>
-                <property name="valign">fill</property>
-                <property name="visible">True</property>
-                <child>
-                  <object class="GtkLabel" id="title-label">
-                    <property name="can_focus">False</property>
-                    <property name="expand">True</property>
-                    <property name="halign">center</property>
-                    <property name="valign">center</property>
-                    <property name="xalign">0</property>
-                    <property name="use_markup">True</property>
-                    <property name="wrap">True</property>
-                    <property name="wrap_mode">word-char</property>
-                    <property name="ellipsize">end</property>
-                    <property name="lines">2</property>
-                    <style>
-                      <class name="title"/>
-                    </style>
-                  </object>
-                </child>
-                <child>
-                  <object class="GtkLabel" id="synopsis-label">
-                    <property name="can_focus">False</property>
-                    <property name="expand">True</property>
-                    <property name="halign">center</property>
-                    <property name="use_markup">True</property>
-                    <property name="wrap">True</property>
-                    <property name="wrap_mode">word-char</property>
-                    <property name="ellipsize">end</property>
-                    <property name="lines">5</property>
-                    <style>
-                      <class name="card-synopsis"/>
-                    </style>
-                  </object>
-                </child>
-              </object>
-            </child>
+          <object class="GtkLabel" id="synopsis-label">
+            <property name="can_focus">False</property>
+            <property name="expand">True</property>
+            <property name="halign">center</property>
+            <property name="use_markup">True</property>
+            <property name="wrap">True</property>
+            <property name="wrap_mode">word-char</property>
+            <property name="ellipsize">end</property>
+            <property name="lines">5</property>
             <style>
-              <class name="content-frame"/>
+              <class name="card-synopsis"/>
             </style>
           </object>
         </child>
       </object>
     </child>
     <style>
-      <class name="thumb-card"/>
-      <class name="card"/>
+      <class name="content-frame"/>
     </style>
-  </template>
+  </object>
 </interface>

--- a/js/app/modules/thumbCard.js
+++ b/js/app/modules/thumbCard.js
@@ -1,5 +1,6 @@
 // Copyright 2015 Endless Mobile, Inc.
 
+const Endless = imports.gi.Endless;
 const Gdk = imports.gi.Gdk;
 const GObject = imports.gi.GObject;
 const Gtk = imports.gi.Gtk;
@@ -19,64 +20,24 @@ const SMALL_WIDTH = 190;
 const MEDIUM_WIDTH = 290;
 const LARGE_WIDTH = 390;
 
-/**
- * Class: ThumbCard
- *
- * A thumbnail card for the new reader app
- */
-const ThumbCard = new Lang.Class({
-    Name: 'ThumbCard',
-    GTypeName: 'EknThumbCard',
-    Extends: MarginButton.MarginButton,
-    Implements: [ Module.Module, Card.Card ],
+const ThumbCardLayout = new Lang.Class({
+    Name: 'ThumbCardLayout',
+    GTypeName: 'EknThumbCardLayout',
+    Extends: Endless.CustomContainer,
 
-    Properties: {
-        'factory': GObject.ParamSpec.override('factory', Module.Module),
-        'factory-name': GObject.ParamSpec.override('factory-name', Module.Module),
-        'model': GObject.ParamSpec.override('model', Card.Card),
-        'title-capitalization': GObject.ParamSpec.override('title-capitalization',
-            Card.Card),
-        'context-capitalization': GObject.ParamSpec.override('context-capitalization',
-            Card.Card),
-        'highlight-string': GObject.ParamSpec.override('highlight-string', Card.Card),
-        'text-halign': GObject.ParamSpec.override('text-halign', Card.Card),
-        'sequence': GObject.ParamSpec.override('sequence', Card.Card),
-    },
-
-    Template: 'resource:///com/endlessm/knowledge/data/widgets/thumbCard.ui',
-    InternalChildren: [ 'thumbnail-frame', 'grid', 'inner-grid', 'content-frame', 'title-label', 'synopsis-label' ],
-
-    _init: function (props={}) {
+    _init: function (thumbnail, content, props={}) {
         this.parent(props);
-
-        this.set_title_label_from_model(this._title_label);
-        this.set_thumbnail_frame_from_model(this._thumbnail_frame);
-        this.set_label_or_hide(this._synopsis_label, this.model.synopsis);
-        this._context_widget = this.create_context_widget_from_model();
-        this._inner_grid.add(this._context_widget);
-
-        this.set_size_request(Card.MinSize.B, Card.MinSize.B);
-
-        Utils.set_hand_cursor_on_widget(this);
+        this.add(thumbnail);
+        this.add(content);
+        this._thumbnail = thumbnail;
+        this._content = content;
+        this.orientation = Gtk.Orientation.HORIZONTAL;
     },
 
     vfunc_size_allocate: function (alloc) {
         this.parent(alloc);
-        let orientation;
 
-        // The orientation determines how the widgets on this card will lay
-        // themselves out.
-        if (this._should_go_horizontal(alloc.width, alloc.height)) {
-            this.text_halign = Gtk.Align.START;
-            orientation = Gtk.Orientation.HORIZONTAL;
-        } else {
-            orientation = Gtk.Orientation.VERTICAL;
-        }
-        this._title_label.halign = this._synopsis_label.halign = this._context_widget.halign = this.text_halign;
-        this._title_label.justify = Utils.alignment_to_justification(this.text_halign);
-        this._title_label.xalign = Utils.alignment_to_xalign(this.text_halign);
-
-        let [thumb_w, thumb_h, text_w, text_h] = this._get_dimensions(alloc, orientation);
+        let [thumb_w, thumb_h, content_w, content_h] = this._get_dimensions(alloc);
 
         let thumb_alloc = new Gdk.Rectangle({
             x: alloc.x,
@@ -85,36 +46,21 @@ const ThumbCard = new Lang.Class({
             height: thumb_h,
         });
 
-        let text_alloc = new Gdk.Rectangle({
-            x: alloc.x + (alloc.width - text_w),
-            y: alloc.y + (alloc.height - text_h),
-            width: text_w,
-            height: text_h,
+        let content_alloc = new Gdk.Rectangle({
+            x: alloc.x + (alloc.width - content_w),
+            y: alloc.y + (alloc.height - content_h),
+            width: content_w,
+            height: content_h,
         });
 
-        if (this._should_show_synopsis(alloc.width, alloc.height)) {
-            this.set_label_or_hide(this._synopsis_label, this.model.synopsis);
-            this._title_label.valign = Gtk.Align.END;
-        } else {
-            this._title_label.valign = Gtk.Align.CENTER;
-            this._synopsis_label.hide();
-        }
-
-        if (this._should_hide_context(alloc.width, alloc.height)) {
-            this._context_widget.hide();
-        } else {
-            this._context_widget.show_all();
-        }
-
-        this._thumbnail_frame.size_allocate(thumb_alloc);
-        this._content_frame.size_allocate(text_alloc);
-        this.update_card_sizing_classes(alloc.height, alloc.width);
+        this._thumbnail.size_allocate(thumb_alloc);
+        this._content.size_allocate(content_alloc);
     },
 
-    _get_dimensions: function (alloc, orientation) {
+    _get_dimensions: function (alloc) {
         let thumb_width, thumb_height, text_width, text_height;
         let text_scale = Utils.get_text_scaling_factor();
-        if (orientation == Gtk.Orientation.VERTICAL) {
+        if (this.orientation == Gtk.Orientation.VERTICAL) {
             thumb_width = text_width = alloc.width;
             text_height = this._get_text_height(alloc) * text_scale;
             thumb_height = alloc.height - text_height;
@@ -151,6 +97,80 @@ const ThumbCard = new Lang.Class({
         }
         return LARGE_WIDTH;
     },
+});
+
+/**
+ * Class: ThumbCard
+ *
+ * A thumbnail card for the new reader app
+ */
+const ThumbCard = new Lang.Class({
+    Name: 'ThumbCard',
+    GTypeName: 'EknThumbCard',
+    Extends: MarginButton.MarginButton,
+    Implements: [ Module.Module, Card.Card ],
+
+    Properties: {
+        'factory': GObject.ParamSpec.override('factory', Module.Module),
+        'factory-name': GObject.ParamSpec.override('factory-name', Module.Module),
+        'model': GObject.ParamSpec.override('model', Card.Card),
+        'title-capitalization': GObject.ParamSpec.override('title-capitalization',
+            Card.Card),
+        'context-capitalization': GObject.ParamSpec.override('context-capitalization',
+            Card.Card),
+        'highlight-string': GObject.ParamSpec.override('highlight-string', Card.Card),
+        'text-halign': GObject.ParamSpec.override('text-halign', Card.Card),
+        'sequence': GObject.ParamSpec.override('sequence', Card.Card),
+    },
+
+    Template: 'resource:///com/endlessm/knowledge/data/widgets/thumbCard.ui',
+    InternalChildren: [ 'thumbnail-frame', 'inner-grid', 'content-frame', 'title-label', 'synopsis-label' ],
+
+    _init: function (props={}) {
+        this.parent(props);
+
+        this.set_title_label_from_model(this._title_label);
+        this.set_thumbnail_frame_from_model(this._thumbnail_frame);
+        this.set_label_or_hide(this._synopsis_label, this.model.synopsis);
+        this._context_widget = this.create_context_widget_from_model();
+        this._inner_grid.add(this._context_widget);
+
+        this.set_size_request(Card.MinSize.B, Card.MinSize.B);
+        this._layout = new ThumbCardLayout(this._thumbnail_frame, this._content_frame, {
+            visible: true,
+        });
+        this.add(this._layout);
+
+        Utils.set_hand_cursor_on_widget(this);
+    },
+
+    vfunc_size_allocate: function (alloc) {
+        let orientation = this._get_orientation(alloc.width, alloc.height);
+
+        if (orientation === Gtk.Orientation.HORIZONTAL)
+            this.text_halign = Gtk.Align.START;
+        this._title_label.halign = this._synopsis_label.halign = this._context_widget.halign = this.text_halign;
+        this._title_label.justify = Utils.alignment_to_justification(this.text_halign);
+        this._title_label.xalign = Utils.alignment_to_xalign(this.text_halign);
+
+        if (this._should_show_synopsis(alloc.width, alloc.height, orientation)) {
+            this.set_label_or_hide(this._synopsis_label, this.model.synopsis);
+            this._title_label.valign = Gtk.Align.END;
+        } else {
+            this._title_label.valign = Gtk.Align.CENTER;
+            this._synopsis_label.hide();
+        }
+
+        if (this._should_hide_context(alloc.width, alloc.height)) {
+            this._context_widget.hide();
+        } else {
+            this._context_widget.show_all();
+        }
+
+        this._layout.orientation = orientation;
+        this.parent(alloc);
+        this.update_card_sizing_classes(alloc.height, alloc.width);
+    },
 
     vfunc_draw: function (cr) {
         this.parent(cr);
@@ -159,15 +179,16 @@ const ThumbCard = new Lang.Class({
         return Gdk.EVENT_PROPAGATE;
     },
 
-    _should_go_horizontal: function (width, height) {
-        return (width > Card.MaxSize.C && height < Card.MinSize.C) ||
+    _get_orientation: function (width, height) {
+        let horizontal = (width > Card.MaxSize.C && height < Card.MinSize.C) ||
             (width > Card.MaxSize.D && height < Card.MinSize.D) ||
             (width > Card.MaxSize.E && height < Card.MinSize.E) ||
             (width > Card.MaxSize.F);
+        return horizontal ? Gtk.Orientation.HORIZONTAL : Gtk.Orientation.VERTICAL;
     },
 
-    _should_show_synopsis: function (width, height) {
-        return height > Card.MaxSize.C && this._should_go_horizontal(width, height);
+    _should_show_synopsis: function (width, height, orientation) {
+        return height > Card.MaxSize.C && orientation == Gtk.Orientation.HORIZONTAL;
     },
 
     _should_hide_context: function (width, height) {


### PR DESCRIPTION
If we want a custom allocation routine we need to write our own
container, not use a grid and stomp on the allocation it gives its
children. Gtk is not at all built to handle that case and we were
seeing strange rendering errors.

Still a lot of work to do on this widget, we are setting things
like visibility and align inside of allocate which we don't want.
But this is a start and should fix our rendering problems.

https://phabricator.endlessm.com/T10691
