### PR TITLE
HierarchicalSetModule: force first card set load

### DIFF
--- a/js/app/modules/hierarchicalSetModule.js
+++ b/js/app/modules/hierarchicalSetModule.js
@@ -125,7 +125,10 @@ const HierarchicalSetModule = new Lang.Class({
     },
 
     _load_content: function (query) {
+        if (this._load_operation_in_progress)
+            return;
         Engine.get_default().get_objects_by_query(query, null, (engine, task) => {
+            this._load_operation_in_progress = false;
             let results;
             try {
                 [results, this._get_more] = engine.get_objects_by_query_finish(task);
@@ -152,6 +155,7 @@ const HierarchicalSetModule = new Lang.Class({
                 scroll_server: this.scroll_server,
             });
         });
+        this._load_operation_in_progress = true;
     },
 
     _belongs_to_current_set_and_not_subset: function (model) {

--- a/tests/js/app/modules/testHierarchicalSetModule.js
+++ b/tests/js/app/modules/testHierarchicalSetModule.js
@@ -140,15 +140,9 @@ describe('Hierarchical set module', function () {
         });
 
         describe('showing more content', function () {
-            let set_card;
-            beforeEach(function () {
-                set_card = set_cards[0];
-                spyOn(set_card, 'load_content');
-            });
-
             it('calls load_content', function () {
                 module.show_more_content();
-                expect(set_card.load_content).toHaveBeenCalled();
+                expect(set_cards[0].load_content).toHaveBeenCalled();
             });
         });
     });

--- a/tests/minimal.js
+++ b/tests/minimal.js
@@ -84,6 +84,7 @@ const MinimalCard = new Lang.Class({
         this.parent(props);
         // For test_card_container_compliance() below
         spyOn(this, 'fade_in').and.callThrough();
+        spyOn(this, 'load_content').and.callThrough();
     },
 
     load_content: function () {},


### PR DESCRIPTION
Previously we added set cards, but they didn't become visible until the
scroll bar was moved. That was because the scrolled window decided it
needed content before any cards were added, so the show_more_content()
call did nothing. Trigger another show_more_content() operation when we
add the first set card.

(Martin & Philip)

https://phabricator.endlessm.com/T10949
