### PR TITLE
Style no search results page

### DIFF
--- a/data/compat/v1-preset-json/news.json
+++ b/data/compat/v1-preset-json/news.json
@@ -271,6 +271,7 @@
                                     },
                                     "properties": {
                                         "halign": "fill",
+                                        "message-halign": "fill",
                                         "message-justify": "left"
                                     }
                                 }

--- a/data/css/news.css
+++ b/data/css/news.css
@@ -9,7 +9,9 @@
 @define-color context-blue #7297a7;
 
 EknScrollingTemplate:not(.overshoot):not(.undershoot),
-EknBackgroundModule {
+EknBackgroundModule,
+.no-results-message-grid,
+.scrollbar {
     background-color: #e9e5e0;
 }
 

--- a/data/widgets/searchModule.ui
+++ b/data/widgets/searchModule.ui
@@ -84,6 +84,9 @@
                     </style>
                   </object>
                 </child>
+                <style>
+                  <class name="no-results-message-grid"/>
+                </style>
               </object>
             </child>
           </object>


### PR DESCRIPTION
The no search results page was looking odd, specially because the messages were
appearing over the background module.

This is a temporary hack to try to correct things, but a bigger refactor is
needed to solve this for sure.

https://phabricator.endlessm.com/T10952
