### PR TITLE
T10998

### DIFF
--- a/data/templates/css/prensa-libre.scss
+++ b/data/templates/css/prensa-libre.scss
@@ -51,6 +51,7 @@ body {
     margin-left: 100px;
     padding-top: 5px;
     background-color: white;
+    box-shadow: 0px 2px 4px 0px rgba(0, 0, 0, 0.24);
 }
 
 main {


### PR DESCRIPTION
news preset: add box-shadow to article card

Add a box-shadow to the article card so it can visually
match the design spec.

https://phabricator.endlessm.com/T10998
