### PR TITLE
Reduce top margin in news articles' header

### DIFF
--- a/data/templates/css/prensa-libre.scss
+++ b/data/templates/css/prensa-libre.scss
@@ -216,7 +216,7 @@ hr {
     .extra-header {
         font-size: 0.8 * $body-size;
         line-height: $body-size;
-        margin: (2 * $body-unit-height) ($indent + $dedent) $body-unit-height;
+        margin: $body-unit-height ($indent + $dedent) $body-unit-height;
     }
 
     header h1 {


### PR DESCRIPTION
As per Dalio's feedback, we are reducing the top margin in the news article's
header section.

https://phabricator.endlessm.com/T11026
