### PR TITLE
Article disclaimer needs top/bottom padding

### DIFF
--- a/data/templates/css/prensa-libre.scss
+++ b/data/templates/css/prensa-libre.scss
@@ -205,7 +205,8 @@ hr {
     }
 
     .disclaimer {
-        margin: $body-unit-height $indent;
+        margin: 0 $indent;
+        padding: $body-unit-height 0;
     }
 
     .eos-modal,


### PR DESCRIPTION
The article disclaimer had some top/bottom margins that were squeezing the
section too tight, making it look misaligned. Instead, we use padding to make
it look better.

https://phabricator.endlessm.com/T10902
