### PR TITLE
kermit: Add a quick 'kermit list' subcommand

### DIFF
--- a/js/tools/kermit.js
+++ b/js/tools/kermit.js
@@ -7,6 +7,7 @@ const System = imports.system;
 
 const USAGE = [
     'usage: kermit grep <shard path> <pattern>',
+    '       kermit list <shard path>',
     '       kermit dump <shard path> <ekn id> [data|metadata]',
     '       kermit query <domain> "<querystring>"',
     '',
@@ -24,6 +25,11 @@ function main () {
         case 'grep':
             if (ARGV.length === 3) {
                 grep(ARGV[1], ARGV[2]);
+                break;
+            }
+        case 'list':
+            if (ARGV.length === 2) {
+                grep(ARGV[1], '');
                 break;
             }
         case 'dump':


### PR DESCRIPTION
To quickly list all items in a shard. This is equivalent to grepping for
the empty-string with kermit grep foo.shard '', but much easier to
remember.
