### PR TITLE
T10948

### DIFF
--- a/js/app/modules/backgroundModule.js
+++ b/js/app/modules/backgroundModule.js
@@ -35,14 +35,14 @@ const _topImageHeight = {
 };
 
 const _cssTemplate = 'EknBackgroundModule {\
-    background-image: linear-gradient(@{bottom}), linear-gradient(alpha(@{overlay}, 0.4)), url("@{image}");\
-    background-position: 0px @{small}px, 0px 0px, 0px 0px;\
+    background-image: linear-gradient(@{bottom}), linear-gradient(alpha(black, 0.3)), linear-gradient(alpha(@{overlay}, 0.4)), url("@{image}");\
+    background-position: 0px @{small}px, 0px 0px, 0px 0px, 0px 0px;\
 }\
 EknBackgroundModule.medium {\
-    background-position: 0px @{medium}px, 0px 0px, 0px 0px;\
+    background-position: 0px @{medium}px, 0px 0px, 0px 0px, 0px 0px;\
 }\
 EknBackgroundModule.big {\
-    background-position: 0px @{big}px, 0px 0px, 0px 0px;\
+    background-position: 0px @{big}px, 0px 0px, 0px 0px, 0px 0px;\
 }';
 
 /**


### PR DESCRIPTION
BackgroundModule: increase contrast with banner title

The design team mentioned that the banner title is not having
enough contrast with the background on low resolution screens.
Making it hard to read.

Add a black overlay to improve contrast with the title.

https://phabricator.endlessm.com/T10948
