### PR TITLE
Title labels are not visible in buffet apps

### DIFF
--- a/data/compat/v1-preset-json/A.json
+++ b/data/compat/v1-preset-json/A.json
@@ -166,7 +166,6 @@
                 "card-type": {
                     "type": "KnowledgeDocumentCard",
                     "properties": {
-                        "show-top-title": true,
                         "show-toc": true
                     }
                 }

--- a/data/compat/v1-preset-json/buffet.json
+++ b/data/compat/v1-preset-json/buffet.json
@@ -247,7 +247,7 @@
                         "card-type": {
                             "type": "KnowledgeDocumentCard",
                             "properties": {
-                                "show-top-title": false,
+                                "show-titles": false,
                                 "show-toc": false,
                                 "custom-css": "reader2.css"
                             }

--- a/data/compat/v1-preset-json/news.json
+++ b/data/compat/v1-preset-json/news.json
@@ -325,7 +325,7 @@
                         "card-type": {
                             "type": "KnowledgeDocumentCard",
                             "properties": {
-                                "show-top-title": false,
+                                "show-titles": false,
                                 "show-toc": false
                             }
                         },

--- a/js/app/modules/knowledgeDocumentCard.js
+++ b/js/app/modules/knowledgeDocumentCard.js
@@ -56,14 +56,13 @@ const KnowledgeDocumentCard = new Lang.Class({
         'sequence': GObject.ParamSpec.override('sequence', Card.Card),
 
         /**
-         * Property: show-top-title
+         * Property: show-titles
          *
-         * Set true if the top title label should be visible when the toc is
-         * either hidden or collapsed.
+         * Set true if the title label and top title label should be visible.
          */
-        'show-top-title':  GObject.ParamSpec.boolean('show-top-title', 'Show Top Title',
-            'Whether to show the top title label when toc is collapsed/hidden',
-            GObject.ParamFlags.READWRITE | GObject.ParamFlags.CONSTRUCT_ONLY, false),
+        'show-titles':  GObject.ParamSpec.boolean('show-titles', 'Show Title Labels',
+            'Whether to show the title label and top title label',
+            GObject.ParamFlags.READWRITE | GObject.ParamFlags.CONSTRUCT_ONLY, true),
         /**
          * Property: show-toc
          *
@@ -143,9 +142,13 @@ const KnowledgeDocumentCard = new Lang.Class({
 
         this._setup_toc();
 
-        this._title_label.bind_property('visible',
-            this._top_title_label, 'visible',
-            GObject.BindingFlags.SYNC_CREATE | GObject.BindingFlags.INVERT_BOOLEAN | GObject.BindingFlags.BIDIRECTIONAL);
+        if (this.show_titles) {
+            this._title_label.bind_property('visible',
+                this._top_title_label, 'visible',
+                GObject.BindingFlags.SYNC_CREATE | GObject.BindingFlags.INVERT_BOOLEAN | GObject.BindingFlags.BIDIRECTIONAL);
+        } else {
+            this._title_label.visible = this._top_title_label.visible = false;
+        }
     },
 
     _setup_toc: function () {

--- a/tests/minimal.js
+++ b/tests/minimal.js
@@ -232,7 +232,7 @@ const MinimalDocumentCard = new Lang.Class({
         'show-toc': GObject.ParamSpec.boolean('show-toc', '', '',
             GObject.ParamFlags.READWRITE | GObject.ParamFlags.CONSTRUCT,
             true),
-        'show-top-title': GObject.ParamSpec.boolean('show-top-title', '', '',
+        'show-titles': GObject.ParamSpec.boolean('show-titles', '', '',
             GObject.ParamFlags.READWRITE | GObject.ParamFlags.CONSTRUCT,
             true),
         'previous-card': GObject.ParamSpec.object('previous-card',


### PR DESCRIPTION
The KnowledgeDocumentCard has two title labels that are used for Preset A apps,
but both labels must be hidden in buffet-based apps.

(Rory & Fernando)

https://phabricator.endlessm.com/T11034
