### PR TITLE
Fix visuals for no search results page

### DIFF
--- a/data/compat/v1-preset-json/news.json
+++ b/data/compat/v1-preset-json/news.json
@@ -271,7 +271,7 @@
                                     },
                                     "properties": {
                                         "halign": "fill",
-                                        "message-halign": "fill",
+                                        "message-halign": "start",
                                         "message-justify": "left"
                                     }
                                 }

--- a/data/css/news.css
+++ b/data/css/news.css
@@ -10,7 +10,7 @@
 
 EknScrollingTemplate:not(.overshoot):not(.undershoot),
 EknBackgroundModule,
-.no-results-message-grid,
+.results-message-background,
 .scrollbar {
     background-color: #e9e5e0;
 }
@@ -126,11 +126,12 @@ EknSearchBannerModule {
     font-family: 'Fira Sans';
     color: @context-blue;
     font-size: 22.5px;  /* 150% * 20px * 75% (DPI correction) */
-    padding: 50px 80px 30px;
+    padding: 50px 80px 30px 160px;
 }
 
 .results-message-title {
     color: white;
+    padding-bottom: 30px;
 }
 
 .search-results .results-message-subtitle {
@@ -139,7 +140,7 @@ EknSearchBannerModule {
     color: #666666;
     font-size: 16.5px;  /* 110% * 20px * 75% (DPI correction) */
     padding-bottom: 50px;
-    padding-left: 80px;
+    padding-left: 160px;
 }
 
 .all-type-card {

--- a/data/widgets/searchModule.ui
+++ b/data/widgets/searchModule.ui
@@ -34,59 +34,64 @@
             <property name="halign">fill</property>
             <property name="hexpand">True</property>
             <child>
-              <object class="GtkGrid" id="message-grid">
-                <property name="orientation">vertical</property>
+              <object class="GtkFrame" id="message-background">
                 <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="halign">center</property>
-                <property name="valign">start</property>
-                <property name="hexpand">True</property>
+                <style>
+                  <class name="results-message-background"/>
+                </style>
                 <child>
-                  <object class="GtkLabel" id="message-title">
-                    <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <property name="halign">start</property>
-                    <property name="valign">fill</property>
-                    <property name="vexpand">True</property>
-                    <property name="label">Placeholder</property>
-                    <property name="wrap">True</property>
-                    <property name="wrap_mode">word-char</property>
-                    <property name="ellipsize">end</property>
-                    <property name="lines">5</property>
-                    <property name="use_markup">True</property>
-                    <style>
-                      <class name="results-message-title"/>
-                    </style>
-                  </object>
-                </child>
-                <child>
-                  <object class="GtkSeparator" id="separator">
-                    <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <property name="hexpand">True</property>
-                    <property name="halign">fill</property>
-                  </object>
-                </child>
-                <child>
-                  <object class="GtkLabel" id="message-subtitle">
+                  <object class="GtkGrid" id="message-grid">
+                    <property name="orientation">vertical</property>
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
                     <property name="halign">center</property>
+                    <property name="valign">start</property>
                     <property name="hexpand">True</property>
-                    <property name="label">Placeholder</property>
-                    <property name="wrap">True</property>
-                    <property name="wrap_mode">word-char</property>
-                    <property name="ellipsize">end</property>
-                    <property name="lines">5</property>
-                    <property name="use_markup">True</property>
-                    <style>
-                      <class name="results-message-subtitle"/>
-                    </style>
+                    <child>
+                      <object class="GtkLabel" id="message-title">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="halign">start</property>
+                        <property name="valign">fill</property>
+                        <property name="vexpand">True</property>
+                        <property name="label">Placeholder</property>
+                        <property name="wrap">True</property>
+                        <property name="wrap_mode">word-char</property>
+                        <property name="ellipsize">end</property>
+                        <property name="lines">5</property>
+                        <property name="use_markup">True</property>
+                        <style>
+                          <class name="results-message-title"/>
+                        </style>
+                      </object>
+                    </child>
+                    <child>
+                      <object class="GtkSeparator" id="separator">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="hexpand">True</property>
+                        <property name="halign">fill</property>
+                      </object>
+                    </child>
+                    <child>
+                      <object class="GtkLabel" id="message-subtitle">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="halign">center</property>
+                        <property name="hexpand">True</property>
+                        <property name="label">Placeholder</property>
+                        <property name="wrap">True</property>
+                        <property name="wrap_mode">word-char</property>
+                        <property name="ellipsize">end</property>
+                        <property name="lines">5</property>
+                        <property name="use_markup">True</property>
+                        <style>
+                          <class name="results-message-subtitle"/>
+                        </style>
+                      </object>
+                    </child>
                   </object>
                 </child>
-                <style>
-                  <class name="no-results-message-grid"/>
-                </style>
               </object>
             </child>
           </object>


### PR DESCRIPTION
As per Design feedback:
- We increase the bottom padding to the section title.
- We left-align the two text labels in the no search results page. To achieve
  this, we need an extra frame that we can apply the appropriate background color
  to.

https://phabricator.endlessm.com/T10952
