### PR TITLE
T11324

### DIFF
--- a/js/app/modules/articleStackModule.js
+++ b/js/app/modules/articleStackModule.js
@@ -115,7 +115,7 @@ const ArticleStackModule = new Lang.Class({
             let card = this.create_submodule('nav-card-type', {
                 model: payload.previous_model,
                 sequence: Card.Sequence.PREVIOUS,
-                navigation_context: _("Previous article"),
+                navigation_context: _("Previous Article"),
             });
             if (card !== null) {
                 document_card_props.previous_card = card;
@@ -132,7 +132,7 @@ const ArticleStackModule = new Lang.Class({
             let card = this.create_submodule('nav-card-type', {
                 model: payload.next_model,
                 sequence: Card.Sequence.NEXT,
-                navigation_context: _("Next article"),
+                navigation_context: _("Next Article"),
             });
             if (card !== null) {
                 document_card_props.next_card = card;

--- a/po/POTFILES.in
+++ b/po/POTFILES.in
@@ -6,6 +6,7 @@ data/widgets/sideMenuTemplate.ui
 data/widgets/suggestedCategoriesModule.ui
 js/app/articleHTMLRenderer.js
 js/app/modules/aisleInteraction.js
+js/app/modules/articleStackModule.js
 js/app/modules/buffetInteraction.js
 js/app/modules/cardContainer.js
 js/app/modules/contextBanner.js


### PR DESCRIPTION
ArticleStackModule: fix strings localization

Both strings for showing next and previous articles were
being displayed only in English.

This happened for two reasons:

1) articleStackModule.js was not added to POTFILES.in so
   the translation machinery was not aware of these.

2) we have almost-identical strings in sequenceCard.ui,
   but with "Article" instead of "article". Gettext is
   case sensitive, but is hard to spot the difference.

Therefore, add the missing file to POTFILES.in and change
the strings to match the ones in sequenceCard.ui so we do
not have to translate the same strings twice.

https://phabricator.endlessm.com/T11324
