### PR TITLE
Handle articles without tags

### DIFF
--- a/data/templates/article.mst
+++ b/data/templates/article.mst
@@ -10,9 +10,7 @@
         <div class="mw-body" id="bodycontents">
             {{#extra-header-information}}
             <div class="extra-header">
-                {{#context}}
-                <div class="context"><p>{{{.}}}</p></div>
-                {{/context}}
+                <div class="context"><p>{{{context}}}</p></div>
                 <div class="extra-header-right">
                     {{#date-published}}
                     <p class="date-published">{{.}}</p>

--- a/js/app/articleHTMLRenderer.js
+++ b/js/app/articleHTMLRenderer.js
@@ -185,12 +185,14 @@ const ArticleHTMLRenderer = new Lang.Class({
             .map(tag => SetMap.get_set_for_tag(tag))
             .filter(set => typeof set !== 'undefined')
             .filter(set => set.featured)[0];
-        return {
+        let retval = {
             'date-published': new Date(model.published).toLocaleDateString(),
-            'context': _to_set_link(featured_set),
             'source-link': _to_link(model.original_uri, 'Prensalibre.com'),
             'author': model.authors.join('—'),
         };
+        if (featured_set)
+            retval.context = _to_set_link(featured_set);
+        return retval;
     },
 
     set_custom_css_files: function (custom_css_files) {


### PR DESCRIPTION
Our rendering template did not deal gracefully with articles that didn't
have any tags. If that is the case, then we simply don't include a
context link (though we still do put a blank <p> in there so that the
flex layout remains the same.)

https://phabricator.endlessm.com/T11424
