### PR TITLE
Remove max-children property from search module.

### DIFF
--- a/data/compat/v1-preset-json/encyclopedia.json
+++ b/data/compat/v1-preset-json/encyclopedia.json
@@ -85,8 +85,7 @@
                                     "properties": {
                                         "margin-top": 20,
                                         "message-halign": "start",
-                                        "halign": "fill",
-                                        "max-children": 10
+                                        "halign": "fill"
                                     },
                                     "slots": {
                                         "arrangement": {

--- a/js/app/modules/searchModule.js
+++ b/js/app/modules/searchModule.js
@@ -49,18 +49,6 @@ const SearchModule = new Module.Class({
 
     Properties: {
         /**
-         * Property: max-children
-         *
-         * The maximum amount of child widgets to show.
-         *
-         * Default value:
-         *   **1000**
-         */
-        'max-children':  GObject.ParamSpec.int('max-children', 'Max children',
-            'The maximum number of children to show in this container',
-            GObject.ParamFlags.READWRITE | GObject.ParamFlags.CONSTRUCT_ONLY,
-            0, GLib.MAXINT32, 1000),
-        /**
          * Property: message-justify
          * Horizontal justification of message text
          *
@@ -134,8 +122,6 @@ const SearchModule = new Module.Class({
         let dispatcher = Dispatcher.get_default();
         if (this._arrangement instanceof InfiniteScrolledWindow.InfiniteScrolledWindow) {
             this._arrangement.connect('need-more-content', () => {
-                if (this._arrangement.get_count() >= this.max_children)
-                    return;
                 dispatcher.dispatch({
                     action_type: Actions.NEED_MORE_SEARCH,
                 });
@@ -155,7 +141,7 @@ const SearchModule = new Module.Class({
                 this._arrangement.fade_cards =
                     (this._arrangement.get_count() > 0);
                 this._arrangement.highlight_string(payload.query);
-                payload.models.forEach(this._add_card, this);
+                payload.models.forEach(this._arrangement.add_model, this._arrangement);
 
                 if (this._arrangement instanceof InfiniteScrolledWindow.InfiniteScrolledWindow) {
                     this._arrangement.new_content_added();
@@ -178,12 +164,6 @@ const SearchModule = new Module.Class({
                 break;
             }
         });
-    },
-
-    _add_card: function (model) {
-        if (this._arrangement.get_count() >= this.max_children)
-            return;
-        this._arrangement.add_model(model);
     },
 
     _finish_search: function (query) {


### PR DESCRIPTION
It was only being used by the Encyclopedia app,
which no longer needs it since we are going to allow
an unlimited number of search results for a given query,
displayed in the InfiniteScrolledWindow.

https://phabricator.endlessm.com/T11400
