### PR TITLE
Remove TextCard:underline-on-hover

### DIFF
--- a/data/compat/v1-preset-json/encyclopedia.json
+++ b/data/compat/v1-preset-json/encyclopedia.json
@@ -97,10 +97,7 @@
                                             },
                                             "slots": {
                                                 "card-type": {
-                                                    "type": "TextCard",
-                                                    "properties": {
-                                                        "underline-on-hover": true
-                                                    }
+                                                    "type": "TextCard"
                                                 }
                                             }
                                         }

--- a/data/css/endless_encyclopedia.css
+++ b/data/css/endless_encyclopedia.css
@@ -129,6 +129,10 @@ EosWindow {
     padding: 0 0 0 0;
 }
 
+.search-results .card:hover .title {
+    text-decoration: underline;
+}
+
 .search-results .card .before {
     -gtk-icon-source: -gtk-icontheme("media-record-symbolic");
     -EknThemeableImage-min-width: 6;

--- a/js/app/modules/textCard.js
+++ b/js/app/modules/textCard.js
@@ -35,14 +35,6 @@ const TextCard = new Module.Class({
 
     Properties: {
         /**
-         * Property: underline-on-hover
-         * Whether to underline the link on hover
-         */
-        'underline-on-hover': GObject.ParamSpec.boolean('underline-on-hover',
-            'Underline on hover', 'Whether to underline the link on hover',
-            GObject.ParamFlags.READWRITE | GObject.ParamFlags.CONSTRUCT_ONLY,
-            false),
-        /**
          * Property: decorate-on-highlight
          * Whether to draw a custom decoration when the card is highlighted
          */
@@ -61,18 +53,6 @@ const TextCard = new Module.Class({
         Utils.set_hand_cursor_on_widget(this);
         this.set_title_label_from_model(this._title_label);
         this._title_label_text = this._title_label.label;
-
-        // FIXME: this should be in CSS, but "text-decoration" isn't supported
-        if (this.underline_on_hover) {
-            this.connect('enter-notify-event', () => {
-                this._title_label.label = '<u>' + this._title_label_text + '</u>';
-                return Gdk.EVENT_PROPAGATE;
-            });
-            this.connect('leave-notify-event', () => {
-                this._title_label.label = this._title_label_text;
-                return Gdk.EVENT_PROPAGATE;
-            });
-        }
 
         let before = new ThemeableImage.ThemeableImage({
             visible: true,


### PR DESCRIPTION
Now GTK CSS supports text-decoration.

https://phabricator.endlessm.com/T11455
