### PR TITLE
Fix max rows logic in Thirties arrangement

### DIFF
--- a/js/app/modules/thirtiesArrangement.js
+++ b/js/app/modules/thirtiesArrangement.js
@@ -80,6 +80,8 @@ const ThirtiesArrangement = new Module.Class({
     },
 
     get_max_cards: function () {
+        if (this._max_rows === 0)
+            return -1;
         return COL_COUNT * this._max_rows;
     },
 


### PR DESCRIPTION
This arrangement would mistakenly report a maximum of 0 cards when the
max rows were set to 0 (i.e., no maximum.)

https://phabricator.endlessm.com/T11567
