### PR TITLE
T11314

### DIFF
--- a/data/templates/css/reader2.scss
+++ b/data/templates/css/reader2.scss
@@ -130,9 +130,10 @@ html {
             padding: 10px !important;
         }
 
-        /* Select special case cell(s) with world heritage site text */
-        tr:first-child > th.cabecera, /* es */
-        tr:first-child.media i {      /* pt */
+        /* Select special case cell(s) with world heritage site text and others */
+        tr:first-child > th.cabecera,   /* es */
+        tr:first-child.media i,         /* pt */
+        tr:first-child > th.topo.mapa { /* pt */
             line-height: 20px;
 
             /* Override Wikipedia's harcoded style */


### PR DESCRIPTION
Cover other corner case text in reader2 scss

This is yet another case of a white text on top of
our white background. This case was spotted during
QA, it presents the same issues as with the world
heritage site texts.

One example is "Cataratas do Iguaçu" article in the
portuguese version of the travel app.

The problem, again, was that it has hardcoded style
in the HTML element, e.g. white text color.

https://phabricator.endlessm.com/T11314
