### PR TITLE
Autobahn tests write to unique temp files

### DIFF
--- a/tests/autobahn/testautobahn.sh
+++ b/tests/autobahn/testautobahn.sh
@@ -1,8 +1,5 @@
 #!/bin/bash
 
-trap "rm -f actual.json" EXIT
-
 input="$G_TEST_SRCDIR/../$1"
 expected=${input/.yaml/.json}
-"$G_TEST_SRCDIR/../autobahn" "$input" -o actual.json
-diff -u "$expected" actual.json
+"$G_TEST_SRCDIR/../autobahn" "$input" | diff -u "$expected" -


### PR DESCRIPTION
Previously they were all writing to the same file, which was a problem
for make -j3.

https://phabricator.endlessm.com/T11660
