### PR TITLE
banner/app: don't expand by default

### DIFF
--- a/js/app/modules/banner/app.js
+++ b/js/app/modules/banner/app.js
@@ -83,6 +83,9 @@ const App = new Module.Class({
     InternalChildren: [ 'subtitle-label' ],
 
     _init: function (props={}) {
+        // We don't want the module to autoexpand, but it will unless explicitly
+        // forced not to because logo child has expand=true set.
+        props.expand = props.expand || false;
         this.parent(props);
 
         this._logo = new ImagePreviewer.ImagePreviewer({


### PR DESCRIPTION
A somewhat esoteric bit of gtk trivia, an expand explicitly set
to false behaves differently that an unset expand, despite false
being the default property value.

Things like grids will expand if there expand property is unset but
their childrens expand property is true. This was happening on
appBanner, but we probably don't want it to expand by default

We removed a explicit expand: false as part of the autobahn switch,
which broke template B layout, but I think its better to do it here
https://phabricator.endlessm.com/T11516
