### PR TITLE
v1-preset-json: fix top banner expand in encyclopedia

### DIFF
--- a/data/compat/v1-preset-json/encyclopedia.yaml
+++ b/data/compat/v1-preset-json/encyclopedia.yaml
@@ -17,7 +17,7 @@ defines:
           max-fraction: 0.2
           valign: start
           halign: center
-          vexpand: false  # FIXME: ImagePreviewer inside AppBanner expands
+          hexpand: true
       top-right:
         type: Navigation.SearchBox
         properties:


### PR DESCRIPTION
Another fallout I missed from the expand shakeup
https://phabricator.endlessm.com/T11516
