### PR TITLE
articleHTMLRenderer: Replace server-template-v1 with isServerTemplated

### DIFF
--- a/js/app/articleHTMLRenderer.js
+++ b/js/app/articleHTMLRenderer.js
@@ -210,6 +210,9 @@ const ArticleHTMLRenderer = new Knowledge.Class({
     },
 
     _render_content: function (model) {
+        if (model.is_server_templated)
+            return this._get_html(model);
+
         switch (model.source) {
         case 'wikipedia':
         case 'wikibooks':
@@ -218,8 +221,6 @@ const ArticleHTMLRenderer = new Knowledge.Class({
             return this._render_legacy_content(model);
         case 'prensa-libre':
             return this._render_prensa_libre_content(model);
-        case 'server-template-v1':
-            return this._get_html(model);
         default:
             return null;
         }

--- a/js/search/articleObjectModel.js
+++ b/js/search/articleObjectModel.js
@@ -68,6 +68,17 @@ const ArticleObjectModel = new Lang.Class({
          */
         'published': GObject.ParamSpec.string('published', 'Publication Date', 'Publication Date of the article',
             GObject.ParamFlags.READWRITE | GObject.ParamFlags.CONSTRUCT, ''),
+
+        /**
+         * Property: is-server-templated
+         * Whether the article is "server-templated". Server-templated articles
+         * are articles which don't require additional client-side, source-specific
+         * templating.
+         */
+        'is-server-templated': GObject.ParamSpec.boolean('is-server-templated',
+            'Is Server Templated', 'Is Server Templated',
+            GObject.ParamFlags.READWRITE | GObject.ParamFlags.CONSTRUCT,
+            false),
     },
 
     _init: function (props={}, json_ld=null) {
@@ -121,5 +132,8 @@ const ArticleObjectModel = new Lang.Class({
 
         if (json_ld.hasOwnProperty('published'))
             props.published = json_ld.published;
+
+        if (json_ld.hasOwnProperty('isServerTemplated'))
+            props.is_server_templated = json_ld.isServerTemplated;
     },
 });


### PR DESCRIPTION
Will objected to the use of the 'source' field to mark an article as not
requiring server templating, so let's use a separate field
here. Additionally, since I wrote this code, we have settled on the idea
of targeting an SDK version, so we don't need a "v1" marker in the
data itself, since the shard itself is for a specific SDK version.
