### PR TITLE
articleHTMLRenderer: Replace server-template-v1 with isServerTemplated

### DIFF
--- a/js/app/articleHTMLRenderer.js
+++ b/js/app/articleHTMLRenderer.js
@@ -210,18 +210,27 @@ const ArticleHTMLRenderer = new Knowledge.Class({
     },
 
     _render_content: function (model) {
-        switch (model.source) {
-        case 'wikipedia':
-        case 'wikibooks':
-        case 'wikisource':
-        case 'wikihow':
-            return this._render_legacy_content(model);
-        case 'prensa-libre':
-            return this._render_prensa_libre_content(model);
-        case 'server-template-v1':
+        // We have two code paths here. Newer content is server-templated, which means that
+        // the HTML content in the web view has been pre-styled and we don't need much
+        // additional processing.
+        //
+        // "Legacy" content, including most wiki sources and also 2.6 Prensa Libre content,
+        // is templated and styled on the client.
+
+        if (model.is_server_templated) {
             return this._get_html(model);
-        default:
-            return null;
+        } else {
+            switch (model.source) {
+            case 'wikipedia':
+            case 'wikibooks':
+            case 'wikisource':
+            case 'wikihow':
+                return this._render_legacy_content(model);
+            case 'prensa-libre':
+                return this._render_prensa_libre_content(model);
+            default:
+                return null;
+            }
         }
     },
 

--- a/js/search/articleObjectModel.js
+++ b/js/search/articleObjectModel.js
@@ -68,6 +68,17 @@ const ArticleObjectModel = new Lang.Class({
          */
         'published': GObject.ParamSpec.string('published', 'Publication Date', 'Publication Date of the article',
             GObject.ParamFlags.READWRITE | GObject.ParamFlags.CONSTRUCT, ''),
+
+        /**
+         * Property: is-server-templated
+         * Whether the article is "server-templated". Server-templated articles
+         * are articles which don't require additional client-side, source-specific
+         * templating.
+         */
+        'is-server-templated': GObject.ParamSpec.boolean('is-server-templated',
+            'Is Server Templated', 'Is Server Templated',
+            GObject.ParamFlags.READWRITE | GObject.ParamFlags.CONSTRUCT,
+            false),
     },
 
     _init: function (props={}, json_ld=null) {
@@ -121,5 +132,8 @@ const ArticleObjectModel = new Lang.Class({
 
         if (json_ld.hasOwnProperty('published'))
             props.published = json_ld.published;
+
+        if (json_ld.hasOwnProperty('isServerTemplated'))
+            props.is_server_templated = json_ld.isServerTemplated;
     },
 });

--- a/tests/js/app/testArticleHTMLRenderer.js
+++ b/tests/js/app/testArticleHTMLRenderer.js
@@ -165,4 +165,31 @@ describe('Article HTML Renderer', function () {
             expect(html).toMatch('prensa-libre.css');
         });
     });
+
+    describe('Server templated content', function () {
+        let server_templated_model, html;
+
+        beforeEach(function() {
+            server_templated_model = new ArticleObjectModel.ArticleObjectModel({
+                get_content_stream: () => { return SearchUtils.string_to_stream('<html><body><p>Excellent server templated content</p></body></html>'); },
+                content_type: 'text/html',
+                is_server_templated: true,
+                title: 'Some good server templated content',
+            });
+            let renderer = new ArticleHTMLRenderer.ArticleHTMLRenderer();
+            html = renderer.render(server_templated_model);
+        });
+
+        it('can render server-templated content', function () {
+            expect(html).toBeDefined();
+        });
+
+        it('was sent through the wrapper', function () {
+            expect(html).toMatch(/window\.LINKS/);
+        });
+
+        it('contains the body of the content as well', function () {
+            expect(html).toMatch(/Excellent server templated content/);
+        });
+    });
 });


### PR DESCRIPTION
Will objected to the use of the 'source' field to mark an article as not
requiring server templating, so let's use a separate field
here. Additionally, since I wrote this code, we have settled on the idea
of targeting an SDK version, so we don't need a "v1" marker in the
data itself, since the shard itself is for a specific SDK version.

https://phabricator.endlessm.com/T11876
