### PR TITLE
assets migration: update gresource path

### DIFF
--- a/js/app/controllerLoader.js
+++ b/js/app/controllerLoader.js
@@ -19,15 +19,11 @@ let create_controller_with_app_json = function (application, app_json, extra_pro
     return factory.create_root_module(extra_props);
 }
 
-function gresource_path_from_app_id (app_id) {
-    return 'resource:///' + app_id.replace(/\./g, '/');
-}
-
 let create_controller = function (application, resource_path) {
     let app_resource = Gio.Resource.load(resource_path);
     app_resource._register();
 
-    let gresource_path = gresource_path_from_app_id(application.application_id);
+    let gresource_path = 'resource:///app/';
     let resource_file = Gio.File.new_for_uri(gresource_path);
     let app_json_file = resource_file.get_child('app.json');
     let app_json = Utils.parse_object_from_file(app_json_file);


### PR DESCRIPTION
Resources provided by the app's gresource file
are located under the /app prefix now, e.g:

```
resource:///app/app.json
resource:///app/assets/titleImage
```

https://phabricator.endlessm.com/T12211
