### PR TITLE
Make sure top title label is visible in template A apps

### DIFF
--- a/js/app/modules/card/knowledgeDocument.js
+++ b/js/app/modules/card/knowledgeDocument.js
@@ -129,6 +129,7 @@ const KnowledgeDocument = new Module.Class({
             this._title_label.bind_property('visible',
                 this._top_title_label, 'visible',
                 GObject.BindingFlags.SYNC_CREATE | GObject.BindingFlags.INVERT_BOOLEAN | GObject.BindingFlags.BIDIRECTIONAL);
+            this._title_label.visible = this.toc.visible;
         } else {
             this._title_label.visible = this._top_title_label.visible = false;
         }


### PR DESCRIPTION
We have a property binding between the visibility of the
top title label and the visibility of the side title label
(which sits above the table of contents). Only one should
be shown at a time. However, the default, initial state is
for top title to be invisible and side title to be visible.
This will only change if we have a table of contents widget
to show. The problem arises if the first article to get
shown is one that has no table of contents, but needs its
top title to be visible. In this case, the top title
label will never get toggled to become visible.

This fixes that by making the top title label visible
by default at the beginning.

https://phabricator.endlessm.com/T12065
