### PR TITLE
compat removal: update gresource xml

### DIFF
--- a/data/compat/v1-preset-json/A.yaml
+++ b/data/compat/v1-preset-json/A.yaml
@@ -76,7 +76,7 @@ defines:
     card: 'Card.KnowledgeDocument(show-toc: true)'
 
 root:
-  shortdef: 'Controller.Mesh(theme: mesh)'
+  shortdef: 'Controller.Mesh(theme: preset_a)'
   slots:
     window:
       type: Window.Simple

--- a/data/compat/v1-preset-json/B.yaml
+++ b/data/compat/v1-preset-json/B.yaml
@@ -84,7 +84,7 @@ defines:
         item: *set-items
 
 root:
-  shortdef: 'Controller.Mesh(theme: mesh)'
+  shortdef: 'Controller.Mesh(theme: preset_b)'
   slots:
     window:
       type: Window.Simple

--- a/eos-knowledge.gresource.xml
+++ b/eos-knowledge.gresource.xml
@@ -9,9 +9,10 @@
     <file compressed="true">data/css/buffet.css</file>
     <file compressed="true">data/css/default.css</file>
     <file compressed="true">data/css/encyclopedia.css</file>
-    <file compressed="true">data/css/mesh.css</file>
     <file compressed="true">data/css/news.css</file>
     <file compressed="true">data/css/picard.css</file>
+    <file compressed="true">data/css/preset_a.css</file>
+    <file compressed="true">data/css/preset_b.css</file>
     <file>data/images/background.png</file>
     <file>data/images/pdf-background.png</file>
     <file>data/images/pdf_icon.png</file>


### PR DESCRIPTION
mesh.css is not longer a top level theme and is
replaced by preset_a and preset_b.

https://phabricator.endlessm.com/T12137
