### PR TITLE
preset_b: apply no results styling to article page

### DIFF
--- a/data/css/preset_b.scss
+++ b/data/css/preset_b.scss
@@ -32,14 +32,6 @@
             background-color: #888888;
         }
     }
-
-    .ContentGroupNoResultsMessage__title,
-    .ContentGroupNoResultsMessage__subtitle {
-        color:white;
-        font-size: 1.2em;
-        font-style: normal;
-        padding: 10px 25px;
-    }
 }
 
 .set-page,
@@ -48,6 +40,14 @@
     .ContentGroupItem,
     .ContentGroup {
         background-color: transparentize(black, 1 - 0.75);
+    }
+
+    .ContentGroupNoResultsMessage__title,
+    .ContentGroupNoResultsMessage__subtitle {
+        color:white;
+        font-size: 1.2em;
+        font-style: normal;
+        padding: 10px 25px;
     }
 }
 


### PR DESCRIPTION
There is a search content group present on the article page, which
I'm not sure can actually be shown right now, but still affects
the sidebars size request.
