### PR TITLE
domain: pass flatpak app path instead of app ID

### DIFF
--- a/js/search/domain.js
+++ b/js/search/domain.js
@@ -29,8 +29,9 @@ const Domain = new Lang.Class({
 
     _init: function (app_id, xapian_bridge) {
         this._app_id = app_id;
-        this._is_flatpak = Utils.app_is_flatpak();
         this._xapian_bridge = xapian_bridge;
+        // will be null if we're not running under flatpak
+        this._flatpak_app_path = Utils.get_flatpak_path();
 
         this._content_dir = null;
         this._shard_file = null;
@@ -291,9 +292,8 @@ const DomainV2 = new Lang.Class({
     get_domain_query_params: function () {
         let params = {};
         let path = GLib.build_filenamev([this._get_content_path(), this._DB_DIR]);
-        if (this._is_flatpak) {
-            params.flatpak_app_id = this._app_id;
-            params.flatpak_path = path;
+        if (this._flatpak_app_path) {
+            params.path = Utils.resolve_flatpak_path(path, this._flatpak_app_path);
         } else {
             params.path = path;
         }
@@ -475,9 +475,8 @@ const DomainV3 = new Lang.Class({
     get_domain_query_params: function () {
         let params = {};
         let manifest_path = this._get_manifest_file().get_path();
-        if (this._is_flatpak) {
-            params.flatpak_app_id = this._app_id;
-            params.flatpak_manifest_path = manifest_path;
+        if (this._flatpak_app_path) {
+            params.manifest_path = Utils.resolve_flatpak_path(manifest_path, this._flatpak_app_path);
         } else {
             params.manifest_path = manifest_path;
         }


### PR DESCRIPTION
This way, the xapian-bridge does not need to reconstruct the location of
the app installation.

https://phabricator.endlessm.com/T11523
