### PR TITLE
T12380

### DIFF
--- a/js/search/moltresEngine.js
+++ b/js/search/moltresEngine.js
@@ -146,8 +146,10 @@ placerat varius non id dui.',
         data.synopsis = this._SYNOPSIS;
         data.content_type = 'text/html';
         data.source = 'wikipedia';
-        data.get_content_stream = () => { return SearchUtils.string_to_stream('<html><body><p>Some content</p></body></html>'); };
-        return new ArticleObjectModel.ArticleObjectModel(data);        
+        data.license = 'CC-BY-SA 3.0';
+        let article = new ArticleObjectModel.ArticleObjectModel(data);
+        article.get_content_stream = () => { return SearchUtils.string_to_stream('<html><body><p>Some content</p></body></html>'); };
+        return article;
     },
 });
 


### PR DESCRIPTION
moltres: various fixes so it works properly again

Add get_content_stream to the model not to the properties, this
caused it to break while it was constructing the model object.

Add a license to the properties so the articles can actually
be openened, otherwise it would break on trying to get the
license file.

https://phabricator.endlessm.com/T12380
