### PR TITLE
utils: don't forget to also catch GLib.FileError.NOENT

### DIFF
--- a/js/search/utils.js
+++ b/js/search/utils.js
@@ -62,7 +62,8 @@ function get_flatpak_path () {
 
     try {
         keyfile.load_from_file(path, GLib.KeyFileFlags.NONE);
-    } catch (e if e.matches(GLib.KeyFileError, GLib.KeyFileError.NOT_FOUND)) {
+    } catch (e if (e.matches(GLib.KeyFileError, GLib.KeyFileError.NOT_FOUND) ||
+                   e.matches(GLib.FileError, GLib.FileError.NOENT))) {
         return null;
     }
 


### PR DESCRIPTION
When the file is missing, this is the actual error we get.
Fixes tests and Jenkins build.

https://phabricator.endlessm.com/T11523
