### PR TITLE
T12369

### DIFF
--- a/js/app/modules/contentGroup/contentGroup.js
+++ b/js/app/modules/contentGroup/contentGroup.js
@@ -186,6 +186,8 @@ const ContentGroup = new Module.Class({
 
     _on_history_changed: function () {
         let item = HistoryStore.get_default().get_current_item();
+        if (item.model)
+            this._arrangement.highlight(item.model);
         if (item.query)
             this._arrangement.highlight_string(item.query);
     },


### PR DESCRIPTION
ContentGroup: highlight models on history change

Models were highlighted only when selections changed,
but should also be highlighted when the history store
changes.

Fixes the issue with the Menu items in template B and
News, were the current item is not highlighted.

https://phabricator.endlessm.com/T12369
