### PR TITLE
Fix news top menu height

### DIFF
--- a/data/css/news.scss
+++ b/data/css/news.scss
@@ -151,3 +151,18 @@ $support-font: 'Fira Sans' !default;
 .ContentGroupNoResultsMessage__subtitle {
     padding-left: 160px;
 }
+
+/* Make the error message in the top menu's content group really small; the top
+menu isn't really meant to fit an error message */
+.NavigationTopMenu {
+    .ContentGroupContentGroup {
+        &__errorPage {
+            padding: 0;
+        }
+
+        &__errorMessage {
+            font-size: 1px;
+            padding: 0;
+        }
+    }
+}


### PR DESCRIPTION
The addition of content group error messages made the top menu request a
lot more space than it needed. We reduce the error size down to
basically nothing in this case, since it won't do very well in a top bar
anyhow.

https://phabricator.endlessm.com/T11266
