### PR TITLE
Separate brand page into own module

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -450,6 +450,7 @@ javascript_tests = \
 	tests/js/app/modules/filter/testUnread.js \
 	tests/js/app/modules/layout/testArticleStack.js \
 	tests/js/app/modules/layout/testBox.js \
+	tests/js/app/modules/layout/testBrandPage.js \
 	tests/js/app/modules/layout/testDynamicBackground.js \
 	tests/js/app/modules/layout/testHamburgerBasement.js \
 	tests/js/app/modules/layout/testInfiniteScrolling.js \

--- a/data/css/modules/banner/_app.scss
+++ b/data/css/modules/banner/_app.scss
@@ -9,7 +9,7 @@
         margin-top: 70px;
     }
 
-    &.brand-page .ThemeableImage {
+    .LayoutBrandPage & .ThemeableImage {
         -EknThemeableImage-sizing: "size-down";
         min-width: 200px;
         min-height: 200px;

--- a/data/preset/buffet.yaml
+++ b/data/preset/buffet.yaml
@@ -272,19 +272,22 @@ root:
       slots:
         search: Navigation.SearchBox
         content:
-          type: ContentGroup.MediaLightbox
+          type: Layout.BrandPage
           slots:
-            card: Card.Media
+            brand:
+              type: Banner.App
+              properties:
+                show-subtitle: true
+                subtitle-capitalization: uppercase
             content:
-              type: Pager.Simple
+              type: ContentGroup.MediaLightbox
               slots:
-                brand-page:
-                  type: Banner.App
-                  properties:
-                    show-subtitle: true
-                    subtitle-capitalization: uppercase
-                home-page: *home-page
-                set-page: *set-page
-                search-page: *search-page
-                all-sets-page: *all-sets-page
-                article-page: *article-page
+                card: Card.Media
+                content:
+                  type: Pager.Simple
+                  slots:
+                    home-page: *home-page
+                    set-page: *set-page
+                    search-page: *search-page
+                    all-sets-page: *all-sets-page
+                    article-page: *article-page

--- a/data/preset/news.yaml
+++ b/data/preset/news.yaml
@@ -299,14 +299,17 @@ root:
       slots:
         search: Navigation.SearchBox
         content:
-          type: ContentGroup.MediaLightbox
+          type: Layout.BrandPage
           slots:
-            card: Card.Media
+            brand: 'Banner.App(show-subtitle: true)'
             content:
-              type: Pager.Simple
+              type: ContentGroup.MediaLightbox
               slots:
-                brand-page: 'Banner.App(show-subtitle: true)'
-                home-page: *home-page
-                set-page: *set-page
-                search-page: *search-page
-                article-page: *article-page
+                card: Card.Media
+                content:
+                  type: Pager.Simple
+                  slots:
+                    home-page: *home-page
+                    set-page: *set-page
+                    search-page: *search-page
+                    article-page: *article-page

--- a/eos-knowledge.gresource.xml
+++ b/eos-knowledge.gresource.xml
@@ -133,6 +133,7 @@
     <file>js/app/modules/filter/unread.js</file>
     <file>js/app/modules/layout/articleStack.js</file>
     <file>js/app/modules/layout/box.js</file>
+    <file>js/app/modules/layout/brandPage.js</file>
     <file>js/app/modules/layout/dynamicBackground.js</file>
     <file>js/app/modules/layout/hamburgerBasement.js</file>
     <file>js/app/modules/layout/infiniteScrolling.js</file>

--- a/js/app/modules/layout/brandPage.js
+++ b/js/app/modules/layout/brandPage.js
@@ -1,0 +1,91 @@
+/* exported BrandPage */
+
+// Copyright 2016 Endless Mobile, Inc.
+
+const GLib = imports.gi.GLib;
+const Gtk = imports.gi.Gtk;
+
+const Actions = imports.app.actions;
+const Dispatcher = imports.app.dispatcher;
+const Module = imports.app.interfaces.module;
+
+/**
+ * Class: Layout.BrandPage
+ * Display a brand screen for 2 seconds
+ */
+const BrandPage = new Module.Class({
+    Name: 'Layout.BrandPage',
+    Extends: Gtk.Stack,
+
+    Slots: {
+        'brand': {},
+        'content': {},
+    },
+
+    // Overridable in tests. Brand page should be visible for 2 seconds. The
+    // transition is currently hardcoded to a slow fade over 500 ms.
+    TRANSITION_TIME_MS: 1500,
+
+    _init: function (props={}) {
+        props.transition_duration = 500;
+        props.transition_type = Gtk.StackTransitionType.CROSSFADE;
+        this.parent(props);
+
+        this._brand_shown = false;
+        this._brand_timeout_id = 0;
+        this._content_ready = false;
+
+        this._brand = this.create_submodule('brand');
+        this._content = this.create_submodule('content');
+
+        this.add(this._brand);
+        this.add(this._content);
+
+        Dispatcher.get_default().register(payload => {
+            switch (payload.action_type) {
+                case Actions.DBUS_LOAD_QUERY_CALLED:
+                case Actions.DBUS_LOAD_ITEM_CALLED:
+                    if (this._brand_timeout_id !== 0) {
+                        GLib.source_remove(this._brand_timeout_id);
+                        this._brand_timeout_id = 0;
+                    }
+                    this.visible_child = this._content;
+                    this._content_ready = true;
+                    this._brand_shown = true;
+                    break;
+            }
+        });
+    },
+
+    _reveal_content_if_ready: function () {
+        if (!this._content_ready || this._brand_timeout_id !== 0)
+            return;
+        this.visible_child = this._content;
+        this._brand_shown = true;
+    },
+
+    _start_brand_timer: function () {
+        this._brand_timeout_id = GLib.timeout_add(GLib.PRIORITY_DEFAULT, this.TRANSITION_TIME_MS, () => {
+            this._brand_timeout_id = 0;
+            this._reveal_content_if_ready();
+            return GLib.SOURCE_REMOVE;
+        });
+        this._content.make_ready(() => {
+            this._content_ready = true;
+            this._reveal_content_if_ready();
+        });
+    },
+
+    // Module override
+    make_ready: function (cb=function () {}) {
+        if (this._brand_shown) {
+            this._content.make_ready(cb);
+            return;
+        }
+        this._brand.make_ready(() => {
+            this.visible_child = this._brand;
+            cb();
+            this._start_brand_timer();
+        });
+    },
+});

--- a/tests/js/app/modules/layout/testBrandPage.js
+++ b/tests/js/app/modules/layout/testBrandPage.js
@@ -1,0 +1,73 @@
+const Gtk = imports.gi.Gtk;
+Gtk.init(null);
+
+const Actions = imports.app.actions;
+const BrandPage = imports.app.modules.layout.brandPage;
+const MockDispatcher = imports.tests.mockDispatcher;
+const MockFactory = imports.tests.mockFactory;
+const Utils = imports.tests.utils;
+
+describe('Layout.BrandPage', function () {
+    let module, factory, dispatcher, brand, content;
+
+    beforeEach(function () {
+        dispatcher = MockDispatcher.mock_default();
+        [module, factory] = MockFactory.setup_tree({
+            type: BrandPage.BrandPage,
+            slots: {
+                'brand': { type: null },
+                'content': { type: null },
+            },
+        });
+        brand = factory.get_last_created('brand');
+        content = factory.get_last_created('content');
+        spyOn(content, 'make_ready').and.callFake(function (cb) {
+            if (cb) cb();
+        });
+    });
+
+    it('starts on the brand screen', function () {
+        expect(module.visible_child).toBe(brand);
+    });
+
+    it('shows the brand until timeout has expired and content is ready', function () {
+        module.TRANSITION_TIME_MS = 0;
+        module.make_ready();
+        expect(module.visible_child).toBe(brand);
+        Utils.update_gui();
+        expect(module.visible_child).toBe(content);
+        expect(content.make_ready).toHaveBeenCalled();
+    });
+
+    it('shows the brand only once', function () {
+        module.TRANSITION_TIME_MS = 0;
+        module.make_ready();
+        Utils.update_gui();
+        expect(module.visible_child).not.toBe(brand);
+        module.make_ready();
+        expect(module.visible_child).not.toBe(brand);
+        Utils.update_gui();
+        expect(module.visible_child).not.toBe(brand);
+    });
+
+    function does_not_show_brand_page (payload) {
+        it('does not show the brand on ' + payload.action_type, function () {
+            module.BRAND_PAGE_TIME_MS = 100000;  // must be interrupted!
+            module.make_ready();
+            dispatcher.dispatch(payload);
+            Utils.update_gui();
+            expect(module.visible_child).not.toBe(brand);
+        });
+    }
+    does_not_show_brand_page({
+        action_type: Actions.DBUS_LOAD_QUERY_CALLED,
+        query: 'foo',
+        timestamp: 0,
+    });
+    does_not_show_brand_page({
+        action_type: Actions.DBUS_LOAD_ITEM_CALLED,
+        ekn_id: 'ekn:///1234512345abcdef',
+        query: 'foo',
+        timestamp: 0,
+    });
+});

--- a/tests/js/app/modules/pager/testSimple.js
+++ b/tests/js/app/modules/pager/testSimple.js
@@ -6,9 +6,7 @@ const CssClassMatcher = imports.tests.CssClassMatcher;
 const HistoryStore = imports.app.historyStore;
 const MockDispatcher = imports.tests.mockDispatcher;
 const MockFactory = imports.tests.mockFactory;
-const Pages = imports.app.pages;
 const Simple = imports.app.modules.pager.simple;
-const Utils = imports.tests.utils;
 
 describe('Pager.Simple', function () {
     let pager, factory, dispatcher, store;
@@ -18,149 +16,78 @@ describe('Pager.Simple', function () {
         dispatcher = MockDispatcher.mock_default();
         store = new HistoryStore.HistoryStore();
         HistoryStore.set_default(store);
-    });
-
-    describe('without brand page', function () {
-        beforeEach(function () {
-            [pager, factory] = MockFactory.setup_tree({
-                type: Simple.Simple,
-                slots: {
-                    'home-page': { type: null },
-                    'set-page': { type: null },
-                    'search-page': { type: null },
-                    'article-page': { type: null },
-                    'all-sets-page': { type: null },
-                },
-            });
-        });
-
-        it('updates the visible page when dispatcher says so', function () {
-            let home_page = factory.get_last_created('home-page');
-            let set_page = factory.get_last_created('set-page');
-            let search_page = factory.get_last_created('search-page');
-            let article_page = factory.get_last_created('article-page');
-            let all_sets_page = factory.get_last_created('all-sets-page');
-            store.set_current_item_from_props({ page_type: 'home' });
-            expect(pager.visible_child).toBe(home_page);
-            store.set_current_item_from_props({ page_type: 'set' });
-            expect(pager.visible_child).toBe(set_page);
-            store.set_current_item_from_props({ page_type: 'search' });
-            expect(pager.visible_child).toBe(search_page);
-            store.set_current_item_from_props({ page_type: 'article' });
-            expect(pager.visible_child).toBe(article_page);
-            store.set_current_item_from_props({ page_type: 'all-sets' });
-            expect(pager.visible_child).toBe(all_sets_page);
-        });
-
-        it('starts on home page', function () {
-            let home_page = factory.get_last_created('home-page');
-            expect(pager.visible_child).toBe(home_page);
-        });
-
-        it('makes its home page ready', function () {
-            let home_page = factory.get_last_created('home-page');
-            spyOn(home_page, 'make_ready');
-            pager.make_ready();
-            expect(home_page.make_ready).toHaveBeenCalled();
-        });
-
-        // Need a way to reliably test this without relying on timing
-        it('has the animating style class when animating');
-
-        it('does not have the animating style class when not animating', function () {
-            expect(pager).not.toHaveCssClass('PagerSimple--animating');
-        });
-
-        it('pre-shows the article page when desktop search result opened', function () {
-            dispatcher.dispatch({ action_type: Actions.DBUS_LOAD_ITEM_CALLED });
-            let article_page = factory.get_last_created('article-page');
-            expect(pager.visible_child).toBe(article_page);
-        });
-
-        it('indicates busy while showing pages', function () {
-            spyOn(pager, '_set_busy');
-            store.set_current_item_from_props({ page_type: 'set' });
-            expect(pager._set_busy).toHaveBeenCalledWith(true);
+        [pager, factory] = MockFactory.setup_tree({
+            type: Simple.Simple,
+            slots: {
+                'home-page': { type: null },
+                'set-page': { type: null },
+                'search-page': { type: null },
+                'article-page': { type: null },
+                'all-sets-page': { type: null },
+            },
         });
     });
 
-    describe('with a brand page', function () {
-        beforeEach(function () {
-            [pager, factory] = MockFactory.setup_tree({
-                type: Simple.Simple,
-                slots: {
-                    'brand-page': { type: null },
-                    'home-page': { type: null },
-                    'set-page': { type: null },
-                    'search-page': { type: null },
-                    'article-page': { type: null },
-                    'all-sets-page': { type: null },
-                },
-            });
-        });
+    it('updates the visible page when dispatcher says so', function () {
+        let home_page = factory.get_last_created('home-page');
+        let set_page = factory.get_last_created('set-page');
+        let search_page = factory.get_last_created('search-page');
+        let article_page = factory.get_last_created('article-page');
+        let all_sets_page = factory.get_last_created('all-sets-page');
+        store.set_current_item_from_props({ page_type: 'home' });
+        expect(pager.visible_child).toBe(home_page);
+        store.set_current_item_from_props({ page_type: 'set' });
+        expect(pager.visible_child).toBe(set_page);
+        store.set_current_item_from_props({ page_type: 'search' });
+        expect(pager.visible_child).toBe(search_page);
+        store.set_current_item_from_props({ page_type: 'article' });
+        expect(pager.visible_child).toBe(article_page);
+        store.set_current_item_from_props({ page_type: 'all-sets' });
+        expect(pager.visible_child).toBe(all_sets_page);
+    });
 
-        it('starts on the brand page', function () {
-            let brand_page = factory.get_last_created('brand-page');
-            expect(pager.visible_child).toBe(brand_page);
-        });
+    it('starts on home page', function () {
+        let home_page = factory.get_last_created('home-page');
+        expect(pager.visible_child).toBe(home_page);
+    });
 
-        it('shows the brand page until timeout has expired and home page is ready', function () {
-            let brand_page = factory.get_last_created('brand-page');
-            let home_page = factory.get_last_created('home-page');
-            let home_page_ready = false;
-            spyOn(home_page, 'make_ready').and.callFake(function (cb) {
-                home_page_ready = true;
-                if (cb) cb();
-            });
-            pager.BRAND_PAGE_TIME_MS = 0;
-            store.set_current_item_from_props({
-                page_type: Pages.HOME,
-            });
-            expect(pager.visible_child).toBe(brand_page);
-            Utils.update_gui();
-            expect(pager.visible_child).toBe(home_page);
-            expect(home_page_ready).toBeTruthy();
-        });
+    it('makes its home page ready', function () {
+        let home_page = factory.get_last_created('home-page');
+        spyOn(home_page, 'make_ready');
+        pager.make_ready();
+        expect(home_page.make_ready).toHaveBeenCalled();
+    });
 
-        it('shows the brand page only once', function () {
-            store.set_current_item_from_props({
-                page_type: Pages.HOME,
-            });
-            let brand_page = factory.get_last_created('brand-page');
-            expect(pager.visible_child).toBe(brand_page);
+    // Need a way to reliably test this without relying on timing
+    it('has the animating style class when animating');
 
-            store.set_current_item_from_props({
-                page_type: Pages.ARTICLE,
-            });
-            expect(pager.visible_child).not.toBe(brand_page);
-            store.set_current_item_from_props({
-                page_type: Pages.HOME,
-            });
-            expect(pager.visible_child).not.toBe(brand_page);
-        });
+    it('does not have the animating style class when not animating', function () {
+        expect(pager).not.toHaveCssClass('PagerSimple--animating');
+    });
 
-        it('does not show the brand page on other launch methods', function () {
-            store.set_current_item_from_props({
-                page_type: Pages.ARTICLE,
-            });
-            let brand_page = factory.get_last_created('brand-page');
-            expect(pager.visible_child).not.toBe(brand_page);
-        });
+    it('pre-shows the article page when desktop search result opened', function () {
+        dispatcher.dispatch({ action_type: Actions.DBUS_LOAD_ITEM_CALLED });
+        let article_page = factory.get_last_created('article-page');
+        expect(pager.visible_child).toBe(article_page);
+    });
 
-        it('adds the correct CSS classes to all its pages', function () {
-            let brand_page = factory.get_last_created('brand-page');
-            expect(brand_page).toHaveCssClass('brand-page');
-            let home_page = factory.get_last_created('home-page');
-            expect(home_page).toHaveCssClass('home-page');
-            let set_page = factory.get_last_created('set-page');
-            expect(set_page).toHaveCssClass('set-page');
-            let search_page = factory.get_last_created('search-page');
-            expect(search_page).toHaveCssClass('search-page');
-            let article_page = factory.get_last_created('article-page');
-            expect(article_page).toHaveCssClass('article-page');
-            let all_sets_page = factory.get_last_created('all-sets-page');
-            expect(all_sets_page).toHaveCssClass('all-sets-page');
-        });
+    it('indicates busy while showing pages', function () {
+        spyOn(pager, '_set_busy');
+        store.set_current_item_from_props({ page_type: 'set' });
+        expect(pager._set_busy).toHaveBeenCalledWith(true);
+    });
+
+    it('adds the correct CSS classes to all its pages', function () {
+        let home_page = factory.get_last_created('home-page');
+        expect(home_page).toHaveCssClass('home-page');
+        let set_page = factory.get_last_created('set-page');
+        expect(set_page).toHaveCssClass('set-page');
+        let search_page = factory.get_last_created('search-page');
+        expect(search_page).toHaveCssClass('search-page');
+        let article_page = factory.get_last_created('article-page');
+        expect(article_page).toHaveCssClass('article-page');
+        let all_sets_page = factory.get_last_created('all-sets-page');
+        expect(all_sets_page).toHaveCssClass('all-sets-page');
     });
 
     it('still works without all optional components', function () {


### PR DESCRIPTION
This introduces Layout.BrandPage which untangles the brand page logic out
of Pager.Simple.

Layout.BrandPage displays what's in its "brand" slot until both of the
following conditions apply: 1.5 seconds have elapsed, and the "content"
slot's make_ready method has finished. It then fades in the "content"
slot over 0.5 seconds.

If the app is started via DBus LoadQuery or LoadItem methods, then the
brand is skipped.

https://phabricator.endlessm.com/T12112
