### PR TITLE
Move top menu style fix to default theme

### DIFF
--- a/data/css/modules/layout/_topMenu.scss
+++ b/data/css/modules/layout/_topMenu.scss
@@ -9,6 +9,14 @@
             min-width: 146px;
             min-height: 30px;
         }
+
+        /* If there is a content group, make its error message really small; the
+        top menu isn't really meant to fit an error message */
+        .ContentGroupContentGroup__errorPage,
+        .ContentGroupContentGroup__errorMessage {
+            font-size: 1px;
+            padding: 0;
+        }
     }
 
     &__content {

--- a/data/css/news.scss
+++ b/data/css/news.scss
@@ -151,18 +151,3 @@ $support-font: 'Fira Sans' !default;
 .ContentGroupNoResultsMessage__subtitle {
     padding-left: 160px;
 }
-
-/* Make the error message in the top menu's content group really small; the top
-menu isn't really meant to fit an error message */
-.NavigationTopMenu {
-    .ContentGroupContentGroup {
-        &__errorPage {
-            padding: 0;
-        }
-
-        &__errorMessage {
-            font-size: 1px;
-            padding: 0;
-        }
-    }
-}


### PR DESCRIPTION
This belongs in the default theme rather than the news theme, since it
should not only apply to the news app.

https://phabricator.endlessm.com/T11266
