### PR TITLE
Arrangement.List use vertical orientation by default.

### DIFF
--- a/data/preset/buffet.yaml
+++ b/data/preset/buffet.yaml
@@ -114,7 +114,6 @@ defines:
                     arrangement:
                       type: Arrangement.List
                       properties:
-                        orientation: vertical
                         max-rows: 2
                       slots:
                         card:
@@ -165,7 +164,7 @@ defines:
                     - thematic-group
                   slots:
                     arrangement:
-                      shortdef: 'Arrangement.List(orientation: vertical, homogeneous: false, max-rows: 5)'
+                      shortdef: 'Arrangement.List(homogeneous: false, max-rows: 5)'
                       slots:
                         card:
                           type: Card.ContentGroup

--- a/data/preset/news.yaml
+++ b/data/preset/news.yaml
@@ -91,7 +91,6 @@ defines:
                         arrangement:
                           type: Arrangement.List
                           properties:
-                            orientation: vertical
                             max-rows: 2
                           slots:
                             card:
@@ -160,7 +159,6 @@ defines:
                                 card: Card.List
                               properties:
                                 row-spacing: 20
-                                orientation: vertical
                             selection:
                               type: Selection.ArticlesForSet
                               slots:
@@ -178,7 +176,7 @@ defines:
                           - hierarchical-set
                           slots:
                             arrangement:
-                              shortdef: 'Arrangement.List(max-rows: 3, orientation: vertical)'
+                              shortdef: 'Arrangement.List(max-rows: 3)'
                               slots:
                                 card:
                                   type: Card.ContentGroup

--- a/js/app/modules/arrangement/list.js
+++ b/js/app/modules/arrangement/list.js
@@ -9,11 +9,30 @@ const Gtk = imports.gi.Gtk;
 const Arrangement = imports.app.interfaces.arrangement;
 const Module = imports.app.interfaces.module;
 
+/**
+ * Class: List
+ */
 const List = new Module.Class({
     Name: 'Arrangement.List',
     Extends: Gtk.Grid,
     Implements: [Arrangement.Arrangement],
     Properties: {
+        /**
+         * Property: orientation
+         * The orientation of the list
+         *
+         * Default:
+         *   Gtk.Orientation.VERTICAL
+         */
+        /* Overrides GtkOrientable default
+         * FIXME: uncomment this once GJS supports overriding properties properly
+         *
+        'orientation': GObject.ParamSpec.enum('orientation', 'Orientation',
+            'The orientation of the list',
+            GObject.ParamFlags.READWRITE | GObject.ParamFlags.CONSTRUCT,
+            Gtk.Orientation,
+            Gtk.Orientation.VERTICAL),
+         */
         /**
          * Property: max-rows
          * Maximum number of card rows to be displayed
@@ -41,7 +60,13 @@ const List = new Module.Class({
     },
 
     _init: function (props={}) {
+
+        /* Override orientable property default if it was not specified */
+        if (props.orientation === undefined)
+          props.orientation = Gtk.Orientation.VERTICAL;
+
         this.parent(props);
+
         this._size_group = new Gtk.SizeGroup({
             mode: Gtk.SizeGroupMode.BOTH,
         });


### PR DESCRIPTION
Buffet, News presets: removed unneeded orientation parameter from Arrangement.List objects.

https://phabricator.endlessm.com/T12467
