### PR TITLE
sideMenu: hide when page is unmapped

### DIFF
--- a/js/app/modules/layout/sideMenu.js
+++ b/js/app/modules/layout/sideMenu.js
@@ -121,6 +121,11 @@ const SideMenu = new Module.Class({
         return Gdk.EVENT_PROPAGATE;
     },
 
+    vfunc_unmap: function () {
+        this._close_menu();
+        return this.parent();
+    },
+
     _on_home_clicked: function () {
         this._close_menu();
         Dispatcher.get_default().dispatch({


### PR DESCRIPTION
When we switch to a new page, we should reset the menu state
https://phabricator.endlessm.com/T12477
