### PR TITLE
Build fixes for make check in vpath build

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -583,7 +583,7 @@ YAML_LOG_COMPILER = $(top_srcdir)/tests/autobahn/testautobahn.sh
 # $(top_srcdir) for including test helper files.
 # (May need to change to AM_TESTS_ENVIRONMENT in a later version of Automake)
 TESTS_ENVIRONMENT = \
-	export GJS_PATH="$(top_srcdir):$(top_srcdir)/js"; \
+	export GJS_PATH="$(top_srcdir):$(top_srcdir)/js:$(top_builddir)/js"; \
 	export GI_TYPELIB_PATH="$(top_builddir)$${GI_TYPELIB_PATH:+:$$GI_TYPELIB_PATH}"; \
 	export LD_LIBRARY_PATH="$(top_builddir)/.libs$${LD_LIBRARY_PATH:+:$$LD_LIBRARY_PATH}"; \
 	export G_TEST_SRCDIR="$(abs_srcdir)/tests"; \

--- a/tests/autobahn/testautobahn.sh
+++ b/tests/autobahn/testautobahn.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 
-input="$G_TEST_SRCDIR/../$1"
+input=`readlink -f "$1"`
 expected=${input/.yaml/.json}
 "$G_TEST_SRCDIR/../autobahn" "$input" | diff -u "$expected" -


### PR DESCRIPTION
Due to newer jhbuild putting its build dirs elsewhere, a few build bugs
were exposed in make check.

https://phabricator.endlessm.com/T12541
