### PR TITLE
Clear arrangement when selection clears

### DIFF
--- a/js/app/modules/contentGroup/contentGroup.js
+++ b/js/app/modules/contentGroup/contentGroup.js
@@ -167,6 +167,7 @@ const ContentGroup = new Module.Class({
     _on_models_changed: function () {
         let models = this._selection.get_models();
         if (models.length === 0 && this._no_results) {
+            this._arrangement.set_models([]);
             this._stack.visible_child_name = NO_RESULTS_PAGE_NAME;
         } else {
             let max_cards = this._arrangement.get_max_cards();

--- a/tests/js/app/modules/contentGroup/testContentGroup.js
+++ b/tests/js/app/modules/contentGroup/testContentGroup.js
@@ -35,6 +35,7 @@ describe('ContentGroup.ContentGroup', function () {
                 'selection': {
                     type: Minimal.MinimalSelection,
                 },
+                'no-results': { type: null },
             },
         });
         arrangement = factory.get_last_created('arrangement');
@@ -74,6 +75,13 @@ describe('ContentGroup.ContentGroup', function () {
             context: [ model ],
         });
         expect(payload).toEqual(matcher);
+    });
+
+    it('clears the arrangement when the selection is cleared', function () {
+        selection.queue_load_more(5);
+        expect(arrangement.get_count()).not.toBe(0);
+        selection.clear();
+        expect(arrangement.get_count()).toBe(0);
     });
 
     it('displays error message on selection error state', function () {


### PR DESCRIPTION
Previously, if a content group's no-results slot was filled, clearing the
selection would cause it to switch to the no-results page but not remove
the models from the arrangement. Now it does both.

This fixes a bug where the uncleared cards were keeping the content
group's size request too large.

https://phabricator.endlessm.com/T12731
