### PR TITLE
Use the actual variable!

### DIFF
--- a/data/templates/js/chunk.js
+++ b/data/templates/js/chunk.js
@@ -10,7 +10,7 @@ function chunk_init (global_chunk_data) {
             });
 
             var p = document.createElement('p');
-            links.forEach(function (link_elem) {
+            link_elems.forEach(function (link_elem) {
                 p.appendChild(link_elem);
             });
 


### PR DESCRIPTION
We were using the wrong variable when producing the chunk data in server-
templated news articles.

This now rightfully shows the backlink to the featured set in article pages.

https://phabricator.endlessm.com/T12631