### PR TITLE
Use custom uri scheme for license links

### DIFF
--- a/js/app/articleHTMLRenderer.js
+++ b/js/app/articleHTMLRenderer.js
@@ -71,8 +71,9 @@ const ArticleHTMLRenderer = new Knowledge.Class({
             case 'wikibooks':
             case 'wikisource':
                 let original_link = _to_link(model.original_uri, model.source_name);
-                let license_link = _to_link(Endless.get_license_file(model.license).get_uri(),
-                    Endless.get_license_display_name(model.license));
+                let license_link = _to_link(_get_license_uri(Endless.get_license_file(model.license).get_uri()),
+                 Endless.get_license_display_name(model.license));
+
                 // TRANSLATORS: anything inside curly braces '{}' is going
                 // to be substituted in code. Please make sure to leave the
                 // curly braces around any words that have them and DO NOT
@@ -312,7 +313,7 @@ function _get_display_string_for_license(license) {
         // {blog-link} and it is not translated.
         return _("Content courtesy of {blog-link}. Used with kind permission.");
 
-    let license_link = _to_link(Endless.get_license_file(license).get_uri(),
+    let license_link = _to_link(_get_license_uri(Endless.get_license_file(license).get_uri()),
         Endless.get_license_display_name(license));
     // TRANSLATORS: the text inside curly braces ({blog-link}, {license-link})
     // is going to be substituted in code. Please make sure that your
@@ -320,4 +321,10 @@ function _get_display_string_for_license(license) {
     // translated.
     return _("Content courtesy of {blog-link}, licensed under {license-link}.")
         .replace('{license-link}', license_link);
+}
+
+function _get_license_uri(original_uri) {
+    // XXX replace the uri scheme with a custom license scheme
+    // to avoid having issues with recent changes in WebKit.
+    return original_uri.replace('file\:', 'license\:');
 }

--- a/js/app/widgets/eknWebview.js
+++ b/js/app/widgets/eknWebview.js
@@ -58,6 +58,7 @@ const EknWebview = new Knowledge.Class({
         'http',
         'https',
         'file',
+        'license',
     ],
 
     _init: function (params) {
@@ -171,6 +172,12 @@ const EknWebview = new Knowledge.Class({
             let uri = decision.request.uri;
             let scheme = GLib.uri_parse_scheme(uri);
             if (scheme !== null && this.EXTERNALLY_HANDLED_SCHEMES.indexOf(scheme) !== -1) {
+
+                // XXX restore the original scheme for the license
+                // uri now that we already passed checks in WebKit.
+                if (scheme === 'license')
+                    uri = uri.replace('license\:', 'file\:');
+
                 Gtk.show_uri(null, uri, Gdk.CURRENT_TIME);
                 decision.ignore();
                 return true; // handled


### PR DESCRIPTION
This is just a workaround for issue we discovered
with webkit and file uri schemes. So, we just use
a custom uri scheme for these links now.

https://phabricator.endlessm.com/T12960