### PR TITLE
utils.js: fix web extensions dbus names

### DIFF
--- a/js/app/utils.js
+++ b/js/app/utils.js
@@ -240,7 +240,7 @@ function dumb_hash (str) {
 function get_web_plugin_dbus_name () {
     let app_id = Gio.Application.get_default().application_id;
     let pid = new Gio.Credentials().get_unix_pid();
-    return app_id + pid;
+    return app_id + '.id' + pid;
 }
 
 const DBUS_WEBVIEW_EXPORT_PATH = '/com/endlessm/webview/';


### PR DESCRIPTION
Our apps own multiple dbus names, each of these names
look like:

    com.endlessm.travel.en3
    com.endlessm.travel.en3-1

But these names don't work with flatpak:

    "By default it can only own names on the bus that
     are the same as the application id, or with one
     extra level of name (i.e. org.domain.app.extra)"

     https://github.com/flatpak/flatpak/wiki/Metadata

Because of this we were not able to use web extensions
inside flatpak. Therefore, make sure we generate these
names with an extra level of name, i.e:

    com.endlessm.travel.en.id3
    com.endlessm.travel.en.id3-1

https://phabricator.endlessm.com/T12814