### PR TITLE
Retrieve the return value from Pango.parse_markup

### DIFF
--- a/js/app/widgets/formattableLabel.js
+++ b/js/app/widgets/formattableLabel.js
@@ -92,7 +92,9 @@ const FormattableLabel = new Knowledge.Class({
         if (!text)
             text = '';
         if (this.use_markup) {
-            Pango.parse_markup(text, -1, '0', null, text);
+            // Pango.parse_markup returns an array where the third
+            // element is the result of the parsing.
+            text = Pango.parse_markup(text, -1, '0', null, text)[2];
         }
 
         let formatted_label = this._format_capitals(text, transform);

--- a/tests/js/app/widgets/testFormattableLabel.js
+++ b/tests/js/app/widgets/testFormattableLabel.js
@@ -36,4 +36,23 @@ describe('Formattable Label', function () {
         label.use_markup = true;
         label.label = 'ç';
     });
+
+    it('handles entities in markup strings correctly', function () {
+        let cssProvider = new Gtk.CssProvider();
+
+        cssProvider.load_from_data ("* { \
+            -EknFormattableLabel-text-transform: 'uppercase';\
+        }");
+
+        let win = new Gtk.OffscreenWindow();
+        win.add(label);
+        win.show_all();
+        label.get_style_context().add_provider(cssProvider,
+                                                Gtk.StyleProvider.PRIORITY_APPLICATION + 10);
+
+        Utils.update_gui();
+        label.use_markup = true;
+        label.label = "Custer&apos;s Last Stand";
+        expect(label.label).toBe("CUSTER'S LAST STAND");
+    });
 });


### PR DESCRIPTION
Previously we were calling Pango.parse_markup but
not actually looking at the return value to get
the parsed text.

https://phabricator.endlessm.com/T13220