### PR TITLE
Set page and search page banners should be consistent

### DIFF
--- a/data/css/preset_a.scss
+++ b/data/css/preset_a.scss
@@ -28,7 +28,7 @@
         padding-top: 1.0em;
         padding-bottom: 1.0em;
 
-        font-size: 2.25em; /* 36pt * 1/12 * 0.75 DPI correction factor */
+        font-size: 36px;
     }
 
     separator {
@@ -42,7 +42,7 @@
     }
 }
 
-.set-page  flowbox {
+.set-page flowbox, .search-page flowbox {
     margin-top: 20px;
 }
 


### PR DESCRIPTION
As per design review. The base css file for Cards sets
a different pixel size than that of the window. As a
consequence, we cant use ems because while set banner
uses a Card.Title, search banner uses no card, so the
base pixel sizes would be different.

https://phabricator.endlessm.com/T13202