### PR TITLE
Don't let background show through article page

### DIFF
--- a/data/css/buffet.scss
+++ b/data/css/buffet.scss
@@ -401,3 +401,11 @@ $title-alt-font: 'Lato Thin' !default;
         font-family: $title-font;
     }
 }
+
+.article-page {
+    background-color: $background-light-color;
+
+    spinner {
+        color: $accent-dark-color;
+    }
+}


### PR DESCRIPTION
Previously, while the webview on the article page was loading, you could
see a flash of the app background. Now, we add a background color to the
article page so that the transition is smoother.

https://phabricator.endlessm.com/T13169