### PR TITLE
Fix search string highlighting

### DIFF
--- a/js/app/widgets/formattableLabel.js
+++ b/js/app/widgets/formattableLabel.js
@@ -91,13 +91,15 @@ const FormattableLabel = new Knowledge.Class({
     _format_label: function (text, transform) {
         if (!text)
             text = '';
+        let attrs = null;
         if (this.use_markup) {
             // Pango.parse_markup returns an array where the third
             // element is the result of the parsing.
-            text = Pango.parse_markup(text, -1, '0', null, text)[2];
+            [, attrs, text] = Pango.parse_markup(text, -1, '\0', null);
         }
 
         let formatted_label = this._format_capitals(text, transform);
         this.set_label(formatted_label);
+        this.set_attributes(attrs);
     },
 });

--- a/tests/compliance.js
+++ b/tests/compliance.js
@@ -31,22 +31,43 @@ function test_card_highlight_string_compliance(CardClass) {
                 highlight_string: 'hippo',
             });
         });
+
+        // Sadly, only works on ASCII text because Pango.Attribute indices are
+        // bytes, not characters
+        function get_spans(label) {
+            let layout = label.get_layout();
+            let attr_list = layout.get_attributes();
+            let text = layout.get_text();
+            let spans = [];
+            attr_list.filter(attr => {
+                spans.push(text.slice(attr.start_index, attr.end_index));
+                return false;
+            });
+            return spans;
+            // May return more than one element with the same text, because
+            // multiple attributes may be applied to the same span of text
+        }
+
         it('by highlighting a search string when constructed', function () {
-            expect(Gtk.test_find_label(card, '*!!!*').label).toMatch(/<span.*>hippo<\/span>/i);
-            expect(Gtk.test_find_label(card, '*@@@*').label).toMatch(/<span.*>hippo<\/span>/i);
+            expect(get_spans(Gtk.test_find_label(card, '*!!!*'))
+                .every(elem => elem === 'hippo')).toBeTruthy();
+            expect(get_spans(Gtk.test_find_label(card, '*@@@*'))
+                .every(elem => elem === 'hippo')).toBeTruthy();
         });
 
         it('by de-highlighting a search string', function () {
             card.highlight_string = '';
-            expect(Gtk.test_find_label(card, '*!!!*').label).toMatch(/ hippo$/i);
-            expect(Gtk.test_find_label(card, '*@@@*').label).toMatch(/ hippo$/i);
+            expect(get_spans(Gtk.test_find_label(card, '*!!!*'))).toEqual([]);
+            expect(get_spans(Gtk.test_find_label(card, '*@@@*'))).toEqual([]);
         });
 
         it('by highlighting a search string', function () {
             card = new CardClass({ model: model });
             card.highlight_string = 'hippo';
-            expect(Gtk.test_find_label(card, '*!!!*').label).toMatch(/<span.*>hippo<\/span>/i);
-            expect(Gtk.test_find_label(card, '*@@@*').label).toMatch(/<span.*>hippo<\/span>/i);
+            expect(get_spans(Gtk.test_find_label(card, '*!!!*'))
+                .every(elem => elem === 'hippo')).toBeTruthy();
+            expect(get_spans(Gtk.test_find_label(card, '*@@@*'))
+                .every(elem => elem === 'hippo')).toBeTruthy();
         });
     });
 }


### PR DESCRIPTION
This regressed on a previous commit because we were using
Pango.parse_markup() to get text to capitalize, which stripped all the
<span>s from the string.

This gets the Pango attribute list from Pango.parse_markup() and
reapplies it, as well as correcting a bug with the accel character. It
also replaces the existing test with a more robust one that looks at the
Pango.Layout directly instead of relying on formatting to be set using
Pango markup.

Original fix by @mattdangerw and @rmacqueen.

https://phabricator.endlessm.com/T13220