### PR TITLE
Quit gracefully if no manifest.json

### DIFF
--- a/js/search/domain.js
+++ b/js/search/domain.js
@@ -396,8 +396,16 @@ const DomainV3 = new Lang.Class({
             if (!manifest_file.query_exists(cancellable)) {
                 let bundle_dir = this._get_bundle_dir();
                 let bundle_manifest_file = bundle_dir.get_child('manifest.json');
-                if (bundle_manifest_file.query_exists(cancellable))
+                if (bundle_manifest_file.query_exists(cancellable)) {
                     manifest_file.make_symbolic_link(bundle_manifest_file.get_path(), cancellable);
+                } else {
+                    throw new Gio.IOErrorEnum({
+                        message: 'You have no manifest.json and are not ' +
+                            'running from a Flatpak bundle. You must download' +
+                            ' a content update.',
+                        code: Gio.IOErrorEnum.NOT_FOUND,
+                    });
+                }
             }
 
             this._make_bundle_symlinks(cancellable);

--- a/po/POTFILES.in
+++ b/po/POTFILES.in
@@ -4,6 +4,7 @@ data/widgets/contentGroup/contentGroup.ui
 data/widgets/contentGroup/noResultsMessage.ui
 data/widgets/layout/sideMenu.ui
 data/widgets/tooltips.ui
+js/app/application.js
 js/app/articleHTMLRenderer.js
 js/app/buffetHistoryStore.js
 js/app/modules/banner/context.js


### PR DESCRIPTION
This only happens when not running from a flatpak, so normally only
developers will encounter it. However, this change prevents the app from
getting stuck on the brand page, which is confusing for developers.

https://phabricator.endlessm.com/T12726