### PR TITLE
Knowledge lib: Added a small sanity check for getting the app datadir

### DIFF
--- a/js/search/domain.js
+++ b/js/search/domain.js
@@ -515,6 +515,12 @@ const DomainV3 = new Lang.Class({
    no EKN_VERSION file is found. This function does synchronous file I/O. */
 function get_ekn_version (app_id) {
     let dir = datadir.get_data_dir(app_id);
+
+    // Sanity check
+    if (!dir) {
+        throw new Error(Format.vprintf('Could not find data dir for app ID %s', [app_id]));
+    }
+
     let ekn_version_file = dir.get_child('EKN_VERSION');
     try {
         let [success, contents, _] = ekn_version_file.load_contents(null);

--- a/js/search/domain.js
+++ b/js/search/domain.js
@@ -522,13 +522,10 @@ function get_ekn_version (app_id) {
     }
 
     let ekn_version_file = dir.get_child('EKN_VERSION');
-    try {
-        let [success, contents, _] = ekn_version_file.load_contents(null);
-        let version_string = contents.toString();
-        return parseInt(version_string);
-    } catch (e) {
-        return 1;
-    }
+    let [success, contents, _] = ekn_version_file.load_contents(null);
+    let version_string = contents.toString();
+
+    return parseInt(version_string);
 }
 
 function get_domain_impl (app_id, xapian_bridge) {

--- a/tests/js/search/testDomain.js
+++ b/tests/js/search/testDomain.js
@@ -2,6 +2,7 @@ const Gio = imports.gi.Gio;
 
 const ArticleObjectModel = imports.search.articleObjectModel;
 const ContentObjectModel = imports.search.contentObjectModel;
+const Datadir = imports.search.datadir;
 const Domain = imports.search.domain;
 const Engine = imports.search.engine;
 const QueryObject = imports.search.queryObject;
@@ -117,6 +118,18 @@ function create_mock_shard_with_link_table (link_table_hash) {
 
     return mock_shard_file;
 }
+
+describe('Domain', function () {
+    describe('get_ekn_version', function () {
+        it('should throw an exception when datadir can\'t be found', function () {
+            spyOn(Datadir, 'get_data_dir').and.returnValue(undefined);
+
+            let expectedError = new Error("Could not find data dir for app ID abc");
+
+            expect(() => Domain.get_ekn_version("abc")).toThrow(expectedError);
+        });
+    });
+});
 
 describe('DomainV2', function () {
     let domain, mock_shard_file, mock_shard_record, mock_data, mock_metadata;


### PR DESCRIPTION
Old error message was not intuitive and did not describe the actual
fault so now we include a better one.