### PR TITLE
Better user-facing error state for Xapian queries

### DIFF
--- a/data/css/modules/contentGroup/_contentGroup.scss
+++ b/data/css/modules/contentGroup/_contentGroup.scss
@@ -64,6 +64,36 @@
         font-weight: bold;
         padding-bottom: 12px;
     }
+
+    &__logButton {
+        padding: 10px;
+        border: 1px solid $accent-dark-color;
+        border-radius: 5px;
+
+        transition: all 250ms ease;
+        background-image: linear-gradient(to bottom,
+                                          $accent-dark-color,
+                                          darken($accent-light-color, 10%));
+
+        color: white;
+        text-shadow: 0 1px transparentize(black, 0.4);
+        -gtk-icon-shadow: 0 1px transparentize(black, 0.4);
+
+        &:hover {
+            background-image: linear-gradient(to bottom,
+                                              lighten($accent-light-color, 5%),
+                                              darken($accent-light-color, 5%));
+        }
+
+        &:active {
+            background-image: linear-gradient(to bottom,
+                                              darken($accent-dark-color, 20%),
+                                              darken($accent-dark-color, 10%));
+            transition-duration: 50ms;
+            text-shadow: none;
+            -gtk-icon-shadow: none;
+        }
+    }
 }
 
 .search-results {

--- a/data/widgets/contentGroup/contentGroup.ui
+++ b/data/widgets/contentGroup/contentGroup.ui
@@ -2,6 +2,11 @@
 <!-- Generated with glade 3.20.0 -->
 <interface>
   <requires lib="gtk+" version="3.20"/>
+  <object class="GtkImage" id="image1">
+    <property name="visible">True</property>
+    <property name="can_focus">False</property>
+    <property name="icon_name">go-down-symbolic</property>
+  </object>
   <object class="GtkStack" id="stack">
     <property name="visible">True</property>
     <property name="can_focus">False</property>
@@ -27,6 +32,27 @@
           <packing>
             <property name="left_attach">0</property>
             <property name="top_attach">0</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkButton" id="log-button">
+            <property name="label" translatable="yes">Download support info</property>
+            <property name="visible">True</property>
+            <property name="can_focus">True</property>
+            <property name="receives_default">True</property>
+            <property name="tooltip_text" translatable="yes">Click here to download a file with information that will help us track down the problem.</property>
+            <property name="halign">start</property>
+            <property name="valign">start</property>
+            <property name="image">image1</property>
+            <property name="image_position">right</property>
+            <property name="always_show_image">True</property>
+            <style>
+              <class name="ContentGroupContentGroup__logButton"/>
+            </style>
+          </object>
+          <packing>
+            <property name="left_attach">0</property>
+            <property name="top_attach">1</property>
           </packing>
         </child>
         <style>

--- a/js/app/modules/selection/selection.js
+++ b/js/app/modules/selection/selection.js
@@ -139,4 +139,12 @@ const Selection = new Module.Class({
             });
         }
     },
+
+    /**
+     * Method: get_error
+     * Retrieve exception object from last encountered error
+     *
+     * This will return null if the selection is not in an error state.
+     */
+    get_error: Lang.UNIMPLEMENTED,
 });

--- a/js/app/modules/selection/xapian.js
+++ b/js/app/modules/selection/xapian.js
@@ -17,6 +17,7 @@ const Xapian = new Module.Class({
         this._get_more = null;
         this._query_index = 0;
         this._error_state = false;
+        this._exception = null;
 
         this.parent(props);
     },
@@ -76,6 +77,7 @@ const Xapian = new Module.Class({
                 logError(e, 'Failed to load content from engine');
                 results = [];
                 info = { more_results: null };
+                this._exception = e;
                 if (!this._error_state) {
                     this._error_state = true;
                     this.notify('in-error-state');
@@ -109,6 +111,11 @@ const Xapian = new Module.Class({
         this._query_index = 0;
         this._can_load_more = true;
         this._error_state = false;
+        this._exception = null;
         this.parent();
+    },
+
+    get_error: function () {
+        return this._exception;
     },
 });

--- a/js/search/domain.js
+++ b/js/search/domain.js
@@ -233,6 +233,14 @@ const Domain = new Lang.Class({
     check_for_updates: function () {
         // By default, do nothing.
     },
+
+    /**
+     * Method: get_subscription_entries
+     * Return the entries from
+     */
+    get_subscription_entries: function () {
+        return [];
+    },
 });
 
 // XXX Note that DomainV2 apps are no longer going to be generated in
@@ -306,13 +314,10 @@ const DomainV3 = new Lang.Class({
 
     _get_subscription_entry: function () {
         if (this._subscription_entry === undefined) {
-            let file = this._get_content_dir().get_child('subscriptions.json');
-            let [success, data] = file.load_contents(null);
-            let subscriptions = JSON.parse(data);
+            let entries = this.get_subscription_entries();
 
             // XXX: For now, we only support the first subscription.
-            let subscription_entry = subscriptions.subscriptions[0];
-            this._subscription_entry = subscription_entry;
+            this._subscription_entry = entries[0];
         }
 
         return this._subscription_entry;
@@ -320,6 +325,13 @@ const DomainV3 = new Lang.Class({
 
     _get_subscription_id: function () {
         return this._get_subscription_entry().id;
+    },
+
+    get_subscription_entries: function () {
+        let file = this._get_content_dir().get_child('subscriptions.json');
+        let [, data] = file.load_contents(null);
+        let subscriptions = JSON.parse(data);
+        return subscriptions.subscriptions.slice();
     },
 
     _get_subscription_dir: function () {

--- a/tests/compliance.js
+++ b/tests/compliance.js
@@ -343,5 +343,13 @@ function test_xapian_selection_compliance(SelectionClass, setup=function () {}, 
             Utils.update_gui();
             expect(selection.in_error_state).toBeTruthy();
         });
+
+        it('saves the exception that was thrown', function () {
+            spyOn(window, 'logError');  // silence console message
+            engine.get_objects_by_query_finish.and.throwError('asplode');
+            selection.queue_load_more(1);
+            Utils.update_gui();
+            expect(selection.get_error().message).toEqual('asplode');
+        });
     });
 }

--- a/tests/minimal.js
+++ b/tests/minimal.js
@@ -161,6 +161,10 @@ const MinimalSelection = new Module.Class({
         this.in_error_state = true;
         this.notify('in-error-state');
     },
+
+    get_error: function () {
+        return new Error('this string should show up in the backtrace');
+    },
 });
 
 const MinimalOrder = new Module.Class({


### PR DESCRIPTION
This allows users to download an error report instead of just getting the
"Oops! There was an error" message that we previously had. Hopefully this
will allow us to diagnose failures from the field faster.

https://phabricator.endlessm.com/T12422