### PR TITLE
Card.LegacyPost only one line in composite mode

### DIFF
--- a/data/preset/buffet.yaml
+++ b/data/preset/buffet.yaml
@@ -8,6 +8,17 @@ defines:
 - &set-card
   type: Card.Deck
 
+- &see-more-trigger
+  shortdef: 'Layout.Box(orientation: horizontal, halign: end, valign: end)'
+  slots:
+    contents:
+    - type: ContentGroup.DynamicTitle
+      properties:
+        format-string: !translate "See more from %s"
+        ellipsize: end
+        hexpand: true
+    - shortdef: 'Decoration.ThemeableImage(valign: end, halign: end)'
+
 - &article-suggestions
   type: ContentGroup.ContentGroup
   styles:
@@ -113,15 +124,7 @@ defines:
                         card:
                           type: Card.ContentGroup
                           slots:
-                            trigger:
-                              shortdef: 'Layout.Box(orientation: horizontal, halign: end, valign: end)'
-                              slots:
-                                contents:
-                                - shortdef: 'ContentGroup.DynamicTitle(format-string: !translate "See more from %s")'
-                                - type: Decoration.ThemeableImage
-                                  properties:
-                                    valign: end
-                                    halign: end
+                            trigger: *see-more-trigger
                             title:
                               type: ContentGroup.DynamicTitle
                               properties:
@@ -173,15 +176,7 @@ defines:
                               properties:
                                 format-string: '%s'
                                 halign: start
-                            trigger:
-                              shortdef: 'Layout.Box(orientation: horizontal, halign: end, valign: end)'
-                              slots:
-                                contents:
-                                - shortdef: 'ContentGroup.DynamicTitle(format-string: !translate "See more from %s")'
-                                - type: Decoration.ThemeableImage
-                                  properties:
-                                    valign: end
-                                    halign: end
+                            trigger: *see-more-trigger
                             selection:
                               type: Selection.ArticlesForSetCrossSection
                     selection:

--- a/data/preset/news.yaml
+++ b/data/preset/news.yaml
@@ -33,6 +33,17 @@ defines:
                   slots:
                     filter: Filter.Featured
 
+- &see-more-trigger
+  shortdef: 'Layout.Box(orientation: horizontal, halign: end, valign: end)'
+  slots:
+    contents:
+    - type: ContentGroup.DynamicTitle
+      properties:
+        format-string: !translate "see more from %s"
+        ellipsize: end
+        hexpand: true
+    - shortdef: 'Decoration.ThemeableImage(valign: end, halign: end)'
+
 - &suggestions-arrangement
   shortdef: 'Arrangement.SquareGuys(max-rows: 1)'
   slots:
@@ -89,15 +100,7 @@ defines:
                                   type: ContentGroup.DynamicTitle
                                   properties:
                                     halign: start
-                                trigger:
-                                  shortdef: 'Layout.Box(orientation: horizontal, halign: end, valign: end)'
-                                  slots:
-                                    contents:
-                                    - shortdef: 'ContentGroup.DynamicTitle(format-string: !translate "see more from %s")'
-                                    - type: Decoration.ThemeableImage
-                                      properties:
-                                        valign: end
-                                        halign: end
+                                trigger: *see-more-trigger
                                 arrangement:
                                   shortdef: 'Arrangement.Thirties(max-rows: 1)'
                                   slots:
@@ -155,15 +158,7 @@ defines:
                                       type: ContentGroup.DynamicTitle
                                       properties:
                                         halign: start
-                                    trigger:
-                                      shortdef: 'Layout.Box(orientation: horizontal, halign: end, valign: end)'
-                                      slots:
-                                        contents:
-                                        - shortdef: 'ContentGroup.DynamicTitle(format-string: !translate "see more from %s")'
-                                        - type: Decoration.ThemeableImage
-                                          properties:
-                                            valign: end
-                                            halign: end
+                                    trigger: *see-more-trigger
                                     arrangement:
                                       shortdef: 'Arrangement.Thirties(max-rows: 1)'
                                       slots:

--- a/js/app/modules/card/legacyPost.js
+++ b/js/app/modules/card/legacyPost.js
@@ -1,6 +1,8 @@
 // Copyright 2016 Endless Mobile, Inc.
 
+const Endless = imports.gi.Endless;
 const Gtk = imports.gi.Gtk;
+const Pango = imports.gi.Pango;
 
 const Card = imports.app.interfaces.card;
 const Module = imports.app.interfaces.module;
@@ -26,5 +28,11 @@ const LegacyPost = new Module.Class({
 
         this.set_title_label_from_model(this._title_label);
         this.set_thumbnail_frame_from_model(this._thumbnail_frame);
+
+        if (Endless.is_composite_tv_screen(null)) {
+            this._title_label.lines = 1;
+            this._title_label.wrap = false;
+            this._title_label.ellipsize = Pango.EllipsizeMode.END;
+        }
     }
 });


### PR DESCRIPTION
In composite TV mode, we should not let the title of the cards on the
Preset B home page take up more than one line.

https://phabricator.endlessm.com/T13527