### PR TITLE
Reduce logo size and padding on Preset A composite

### DIFF
--- a/data/css/mesh.scss
+++ b/data/css/mesh.scss
@@ -74,10 +74,6 @@ $display-font-composite: 'Roboto' !default;
     }
 }
 
-.home-page .ArrangementOverflow {
-    margin-top: 40px;
-}
-
 .set-page,
 .search-page {
     .ContentGroupContentGroup__title,

--- a/data/css/preset_a.scss
+++ b/data/css/preset_a.scss
@@ -4,6 +4,10 @@
     padding: 9px 0px;
 }
 
+.home-page .ArrangementOverflow {
+    margin-top: 40px;
+}
+
 .CardTitle__title,
 .CardKnowledgeDocument__title {
     color: white;

--- a/data/css/preset_a.scss
+++ b/data/css/preset_a.scss
@@ -80,6 +80,14 @@
 }
 
 .composite {
+    .BannerApp .ThemeableImage {
+        min-height: 50px;
+    }
+
+    .home-page .ArrangementOverflow {
+        margin-top: 0px;
+    }
+
     .set-page,
     .search-page {
         .ContentGroupContentGroup__title,

--- a/data/css/preset_a.scss
+++ b/data/css/preset_a.scss
@@ -90,6 +90,7 @@
 
     .set-page,
     .search-page {
+        padding: 0px;
         .ContentGroupContentGroup__title,
         .BannerSearch__title {
             font-size: 16.4px;  /* 14px spec * 88% */


### PR DESCRIPTION
For composite TVs, we reduce the padding under the search entry, and
reduce the minimum size of the logo to quite small.

Unfortunately we make things quite ugly at the expense of fitting
everything on the screen at 720x480.

https://phabricator.endlessm.com/T13449