### PR TITLE
Remove moltres files from debian install

### DIFF
--- a/debian/eos-knowledge-0-dev.install
+++ b/debian/eos-knowledge-0-dev.install
@@ -1,7 +1,5 @@
 usr/bin/autobahn
-usr/bin/moltres
 usr/bin/picard
 usr/lib/pkgconfig/*
-usr/share/eos-knowledge/moltres.gresource
 usr/share/eos-knowledge/theme/*
 usr/share/eos-knowledge/preset/*


### PR DESCRIPTION
Since moltres got replaced by a more feature
rich command line.

https://phabricator.endlessm.com/T13538