### PR TITLE
Knowledge lib: Return the excluded_ids and excluded_tags filtering

### DIFF
--- a/js/search/queryObject.js
+++ b/js/search/queryObject.js
@@ -373,9 +373,21 @@ const QueryObject = Lang.Class({
         return id_clauses.join(_XAPIAN_OP_OR);
     },
 
+    _exclusion_clause: function () {
+        let prefixed_tags = this.excluded_tags.map(Utils.quote).map((tag) => {
+            return _XAPIAN_OP_NOT + _XAPIAN_PREFIX_TAG + tag;
+        });
+
+        let excluded_ids = this.excluded_ids.map(this._uri_to_xapian_id.bind(this)).map((id) => {
+            return _XAPIAN_OP_NOT + id;
+        });
+        return prefixed_tags.concat(excluded_ids).join(_XAPIAN_OP_AND);
+    },
+
     get_query_parser_string: function () {
         let clauses = [];
         clauses.push(this._query_clause());
+        clauses.push(this._exclusion_clause());
         clauses.push(this._tags_clause(this.tags_match_any, _XAPIAN_OP_OR));
         clauses.push(this._tags_clause(this.tags_match_all, _XAPIAN_OP_AND));
         clauses.push(this._ids_clause());

--- a/tests/js/search/testQueryObject.js
+++ b/tests/js/search/testQueryObject.js
@@ -234,6 +234,22 @@ describe('QueryObject', function () {
             expect(result).toMatch('tag:"cat zombies"');
         });
 
+        it('filters unwanted tags and ids', function () {
+            let query_obj = new QueryObject.QueryObject({
+                query: 'tyrion wins',
+                excluded_ids: [
+                    'ekn://fake-domain/cleganebowlfever',
+                    'ekn://fake-domain/errybodygethyped'
+                ],
+                excluded_tags: ['chicken', 'shop'],
+            });
+            let result = query_obj.get_query_parser_string(query_obj);
+            expect(result).toMatch('NOT id:cleganebowlfever');
+            expect(result).toMatch('NOT id:errybodygethyped');
+            expect(result).toMatch('NOT tag:"chicken"');
+            expect(result).toMatch('NOT tag:"shop"');
+        });
+
         it('should handle large queries', function () {
             let long_query = 'q'.repeat(300);
             let query_obj = new QueryObject.QueryObject({


### PR DESCRIPTION
Our knowledge library does use the excluded_ids and excluded_tags not
just for explicit terms but also for "further reading" articles and the
new "featured" listings so we put this functionality back into the
codebase (with exclusion of blacklisting).

Original git hash:
- ded4149754c8f437dcc7b5004d74b8413f1df397

Removal git hash:
- 514e6db37040f360636cab937e76c42c106e53e2

https://phabricator.endlessm.com/T13727