### PR TITLE
ekn-app-runner: fix --help option

### DIFF
--- a/ekn-app-runner.in
+++ b/ekn-app-runner.in
@@ -39,6 +39,9 @@ let application = new Application.Application({
     application_id: '$APP_ID',
     resource_path: '$RESOURCE_PATH',
 });
-application.run(['$0'].concat(ARGV));"
+application.run(ARGV);"
 
-exec $DEBUG_COMMAND gjs -c "$SCRIPT" "$@"
+# $APP_ID will become ARGV[0], when passed to application.run, the real argv[0]
+# is stripped by gjs. This also prevents gjs from eating any arguments intended
+# for the application such as --help
+exec $DEBUG_COMMAND gjs -c "$SCRIPT" "$APP_ID" "$@"


### PR DESCRIPTION
By passing the app_id as the first argument, which will in turn get
passed to g_application_run as the zeroth argument, we prevent
gjs from parsing the other options specified on the command line
https://phabricator.endlessm.com/T13792