### PR TITLE
Never add more than the num_desired results to content group

### DIFF
--- a/js/app/modules/selection/xapian.js
+++ b/js/app/modules/selection/xapian.js
@@ -4,8 +4,24 @@
 
 const Engine = imports.search.engine;
 const Module = imports.app.interfaces.module;
+const QueryObject = imports.search.queryObject;
 const Selection = imports.app.modules.selection.selection;
 
+/**
+ * Class: Selection.Xapian
+ * A general, superclass for populating selection content using xapian
+ * queries. Note that this superclass cannot be used directly itself. You must
+ * subclass it and implement the construct_query_object method, which should
+ * return a <QueryObject.QueryObject> determining what content to fetch from
+ * a xapian database.
+ *
+ * This superclass handles continuation-passing on the queue_load_more method.
+ * If the selection determines that both more results are available
+ * (by examining the result set metadata returned from xapian) and that more
+ * results are required, it will automatically create a new query and fetch
+ * more content.
+ *
+ */
 const Xapian = new Module.Class({
     Name: 'Selection.Xapian',
     Extends: Selection.Selection,
@@ -84,23 +100,55 @@ const Xapian = new Module.Class({
                 }
                 return;
             }
-            let more = info.more_results;
 
-            if (!more) {
-                this._query_index++;
-                more = this.construct_query_object(num_desired, this._query_index);
+            // Since above, in the case of having a filter present, we
+            // request 3 times our original num_desired, it is possible
+            // that we end up with more results than we originally requested!
+            // In that case we do not want to add those superfluous results to
+            // the models map.
+            let offset_for_next_query;
+            let num_results_added = results.reduce((count, model, idx) => {
+                if (count < num_desired) {
+                    count += this.add_model(model) ? 1 : 0;
+                    offset_for_next_query = idx + 1;
+                }
+                return count;
+            }, 0);
+
+            // If we got back less than we even asked for, then obviously there
+            // are no more results to be fetched.
+            let more_results_query;
+            if (results.length < query.limit) {
+                more_results_query = null;
+            } else {
+                // If we got back at least what we asked for, there is the
+                // possibility that there are more results to be fetched. In
+                // this case, we want the new offset to be equal to the old
+                // offset plus however many models we had to step through
+                // in order to obtain num_desired amount of filter-accepting
+                // models. E.g. If we desired 5 models, and, out of the 10 we
+                // got back, the first 5 passed the filter, then our new offset
+                // is 5. But if, out of those 10, it was the latter 5 which
+                // passed the filter, then our new offset should be 10.
+                more_results_query = QueryObject.QueryObject.new_from_object(query, {
+                    offset: query.offset + offset_for_next_query,
+                });
             }
 
-            this._get_more = more;
-            let can_load_more = !!more && (info.upper_bound > results.length);
+            if (!more_results_query) {
+                this._query_index++;
+                more_results_query = this.construct_query_object(num_desired, this._query_index);
+            }
+
+            this._get_more = more_results_query;
+            let can_load_more = !!more_results_query && (info.upper_bound > results.length);
             if (can_load_more !== this._can_load_more) {
                 this._can_load_more = can_load_more;
                 this.notify('can-load-more');
             }
 
-            let results_added = results.filter(this.add_model, this);
-            if (results_added.length < num_desired && this._can_load_more)
-                this.queue_load_more(num_desired - results_added.length);
+            if (num_results_added < num_desired && this._can_load_more)
+                this.queue_load_more(num_desired - num_results_added);
 
             this.emit_models_when_not_animating();
         });

--- a/js/search/engine.js
+++ b/js/search/engine.js
@@ -152,18 +152,6 @@ const Engine = Lang.Class({
                         return;
                     }
 
-                    let more_results_query;
-                    if (results.length < query_obj.limit) {
-                        more_results_query = null;
-                    } else {
-                        more_results_query = QueryObject.QueryObject.new_from_object(query_obj, {
-                            offset: results.length + query_obj.offset,
-                        });
-                    }
-                    Object.defineProperty(info, 'more_results', {
-                        value: more_results_query,
-                    });
-
                     task.return_value([results, info]);
                 }));
             };

--- a/js/search/moltresEngine.js
+++ b/js/search/moltresEngine.js
@@ -88,16 +88,7 @@ const MoltresEngine = new Lang.Class({
             for (let i = 0; i < Math.min(10, query.limit); i++) {
                 this._to_return.push(generation_func());
             }
-            let more_results_query;
-            if (query.offset === 0) {
-                more_results_query = QueryObject.QueryObject.new_from_object(query, {
-                    offset: 11,
-                });
-            } else {
-                more_results_query = null;
-            }
             this._info = {
-                more_results: more_results_query,
                 upper_bound: 20,
             };
         }

--- a/js/tools/kermit.js
+++ b/js/tools/kermit.js
@@ -355,7 +355,10 @@ function perform_query (engine, query_obj) {
             if (results.length < BATCH_SIZE) {
                 System.exit(0);
             } else {
-                perform_query(engine, info.more_results);
+                let more_results_query = QueryObject.QueryObject.new_from_object(query_obj, {
+                    offset: query_obj.offset + results.length,
+                });
+                perform_query(engine, more_results_query);
             }
         } catch (e) {
             fail_with_error(e);


### PR DESCRIPTION
When we have a filter present, we naively request three times
the original num_desired value, to account for the filter.
This results in us sometimes getting back more results than
we originally asked for. In that case we don't want to add those
extra results to the models map.

https://phabricator.endlessm.com/T13535