### PR TITLE
Make sure exception is not null before retrieving stack trace

### DIFF
--- a/js/app/modules/contentGroup/contentGroup.js
+++ b/js/app/modules/contentGroup/contentGroup.js
@@ -242,7 +242,7 @@ const ContentGroup = new Module.Class({
             'Error message: ' + (exception ? exception.message : 'none'),
             '',
         ].join('\n');
-        log += exception.stack;
+        log += exception ? exception.stack : '';
         let os = new Gio.DataOutputStream({
             base_stream: stream.output_stream,
         });


### PR DESCRIPTION
Otherwise we can get a null reference error.

https://phabricator.endlessm.com/T13535