### PR TITLE
kermit: use get_packed_content_size instead of get_blob_size

### DIFF
--- a/js/tools/kermit.js
+++ b/js/tools/kermit.js
@@ -146,7 +146,7 @@ function stat (path) {
     let content_type_sizes = {};
     function tallyBlob (blob) {
         let offset = blob.get_offset();
-        let length = blob.get_blob_size();
+        let length = blob.get_packed_content_size();
         let content_type = blob.get_content_type();
 
         if (offset > last_offset) {


### PR DESCRIPTION
Due to shard format changes, we store blob headers separately from the
data, so just rely on the size of the blob data.