### PR TITLE
Autobahn README

### DIFF
--- a/tools/README.md
+++ b/tools/README.md
@@ -36,8 +36,27 @@ in the com.endless.Platform flatpak runtime.
 
 Autobahn
 --------
-Autobahn is a utility for compiling yaml preset descriptions to json. It is
-included in the com.endlessm.Sdk flatpak runtime.
+Autobahn is a utility for compiling YAML app descriptions, such as those included in the `data/preset/` directory, to the JSON format loaded by eos-knowledge-lib.
+It is included in the com.endlessm.Sdk flatpak runtime.
+
+The YAML app description format is meant to be easy to write by hand, and includes some shorthands for convenience.
+Autobahn compiles it into the more machine-readable JSON format.
+
+Usually you will not have to use this tool yourself, it will be called automatically when starting an app with a custom app description.
+
+#### Using
+Simple command to see how it works:
+```
+autobahn data/preset/encyclopedia.yaml
+```
+The above command spits out a big JSON object that is meant to be supplied to eos-knowledge-lib at the `resource:///app/app.json` path.
+
+If you want to write your own YAML app description that imports one of the YAML presets, you will need to use the `--include` option:
+```
+echo '!import encyclopedia' | autobahn -I data/preset
+```
+
+There are other options for internationalizing app descriptions, see `autobahn --help`.
 
 Picard
 ------


### PR DESCRIPTION
This adds a section in the tools README documenting Autobahn.

https://phabricator.endlessm.com/T13981