### PR TITLE
Use GLib idle_add instead of Mainloop in async task

### DIFF
--- a/js/search/asyncTask.js
+++ b/js/search/asyncTask.js
@@ -2,7 +2,6 @@ const Gio = imports.gi.Gio;
 const GLib = imports.gi.GLib;
 const GObject = imports.gi.GObject;
 const Lang = imports.lang;
-const Mainloop = imports.mainloop;
 
 /**
  * Class: AsyncTask
@@ -26,12 +25,13 @@ const AsyncTask = Lang.Class({
     GTypeName: 'EknAsyncTask',
     Extends: GObject.Object,
 
-    _init: function (source, cancellable, callback) {
+    _init: function (source, cancellable, callback, priority=GLib.PRIORITY_DEFAULT) {
         this.parent();
 
         this._source = source;
         this._callback = callback;
         this._done = false;
+        this._priority = priority;
 
         if (cancellable) {
             let handle_cancel = () => {
@@ -130,7 +130,7 @@ const AsyncTask = Lang.Class({
 
     _callback_in_idle: function () {
         this._done = true;
-        Mainloop.idle_add(() => {
+        GLib.idle_add(this._priority, () => {
             this._callback(this._source, this);
             return GLib.SOURCE_REMOVE;
         });

--- a/js/search/xapianBridge.js
+++ b/js/search/xapianBridge.js
@@ -118,7 +118,7 @@ const XapianBridge = new Lang.Class({
     // Queues a SoupMessage for *uri* to the current http session. Calls
     // *callback* on any errors encountered and the parsed JSON.
     _send_json_ld_request: function (uri, cancellable, callback) {
-        let task = new AsyncTask.AsyncTask(this, cancellable, callback);
+        let task = new AsyncTask.AsyncTask(this, cancellable, callback, GLib.PRIORITY_HIGH);
         task.catch_errors(() => {
             let request = new Soup.Message({
                 method: 'GET',


### PR DESCRIPTION
Mainloop.idle_add always adds its callbacks with DEFAULT
priority. In the capacitate app, this has resulted
in cases where the callback is not invoked if many of
them are queued at once. Instead we should use GLib.idle_add,
which allows us to specify a higher priority.

https://phabricator.endlessm.com/T14072