### PR TITLE
Initialize Engine with an app-id

### DIFF
--- a/js/app/application.js
+++ b/js/app/application.js
@@ -70,7 +70,7 @@ const Application = new Knowledge.Class({
         this._knowledge_search_impl = Gio.DBusExportedObject.wrapJSObject(KnowledgeSearchIface, this);
         this.image_attribution_file = Gio.File.new_for_uri(CREDITS_URI);
 
-        Engine.get_default().default_app_id = this.application_id;
+        Engine.get_default(this.application_id);
 
         this.add_main_option('theme-name', 't'.charCodeAt(), GLib.OptionFlags.NONE, GLib.OptionArg.STRING,
                              'Use a stock theme with given name instead of any application theme overrides', null);

--- a/js/search/engine.js
+++ b/js/search/engine.js
@@ -233,12 +233,13 @@ const Engine = Lang.Class({
 });
 
 let the_engine = null;
-let get_default = function () {
+let get_default = function (app_id='') {
     if (the_engine === null) {
         // try to create an engine configured with the current locale
         var language = Utils.get_current_language();
         the_engine = new Engine({
             language: language,
+            default_app_id: app_id,
         });
     }
     return the_engine;


### PR DESCRIPTION
Engine needs an app-id to load the shards in its
constructor. So let's pass the app-id to the
get_default() function when we first call it.

https://phabricator.endlessm.com/T14073