### PR TITLE
contentObjectModel: don't depend on reading history store

### DIFF
--- a/js/app/historyStore.js
+++ b/js/app/historyStore.js
@@ -13,6 +13,7 @@ const Dispatcher = imports.app.dispatcher;
 const HistoryItem = imports.app.historyItem;
 const MediaObjectModel = imports.search.mediaObjectModel;
 const Pages = imports.app.pages;
+const ReadingHistoryModel = imports.app.readingHistoryModel;
 const SetObjectModel = imports.search.setObjectModel;
 const Utils = imports.app.utils;
 
@@ -100,7 +101,7 @@ const HistoryStore = new Lang.Class({
                     this.go_forward();
                     break;
                 case Actions.ITEM_CLICKED:
-                    payload.model.mark_read();
+                    ReadingHistoryModel.get_default().mark_article_read(payload.model.ekn_id);
                     break;
             }
         });

--- a/js/app/modules/card/list.js
+++ b/js/app/modules/card/list.js
@@ -7,6 +7,7 @@ const Gtk = imports.gi.Gtk;
 const Card = imports.app.interfaces.card;
 const NavigationCard = imports.app.interfaces.navigationCard;
 const Module = imports.app.interfaces.module;
+const ReadingHistoryModel = imports.app.readingHistoryModel;
 const ThemeableImage = imports.app.widgets.themeableImage;
 const Utils = imports.app.utils;
 
@@ -48,9 +49,13 @@ const List = new Module.Class({
         this.update_card_sizing_classes(Card.MinSize.A, Card.MinSize.D);
         this._synopsis_label.visible = this.show_synopsis;
         this._title_label.vexpand = !this.show_synopsis;
-        this.model.bind_property('read', this._checkmark, 'visible',
-            GObject.BindingFlags.SYNC_CREATE);
+        this._sync_checkmark_state();
+        ReadingHistoryModel.get_default().connect('changed', this._sync_checkmark_state.bind(this));
         Utils.set_hand_cursor_on_widget(this);
+    },
+
+    _sync_checkmark_state: function () {
+        this._checkmark.visible = ReadingHistoryModel.get_default().is_read_article(this.model.ekn_id);
     },
 
     _IMAGE_WIDTH_RATIO: 1.5,

--- a/js/app/readingHistoryModel.js
+++ b/js/app/readingHistoryModel.js
@@ -38,6 +38,15 @@ const ReadingHistoryModel= new Knowledge.Class({
             GObject.Object.$gtype),
     },
 
+    Signals: {
+        /**
+         * Event: changed
+         *
+         * Emitted when the history item changes.
+         */
+        'changed': {},
+    },
+
     _init: function (props={}) {
         this.parent(props);
 
@@ -65,6 +74,8 @@ const ReadingHistoryModel= new Knowledge.Class({
 
         try {
             this._read_articles = new Set(JSON.parse(json_contents));
+            if (this._read_articles)
+                this.emit('changed');
         } catch (error) {
             logError(error, 'Unexpected contents in reading history file');
         }
@@ -83,6 +94,7 @@ const ReadingHistoryModel= new Knowledge.Class({
     mark_article_read: function (article_id) {
         this._read_articles.add(article_id);
         this._save_reading_history_file();
+        this.emit('changed');
     },
 
     is_read_article: function (article_id) {

--- a/js/search/contentObjectModel.js
+++ b/js/search/contentObjectModel.js
@@ -4,8 +4,6 @@ const GLib = imports.gi.GLib;
 const GObject = imports.gi.GObject;
 const Lang = imports.lang;
 
-const ReadingHistoryModel = imports.app.readingHistoryModel;
-
 /**
  * Class: ContentObjectModel
  * This is the base class for all content objects in the knowledge app.
@@ -119,13 +117,6 @@ const ContentObjectModel = new Lang.Class({
             'Whether this content should be given priority in the UI',
             GObject.ParamFlags.READWRITE | GObject.ParamFlags.CONSTRUCT_ONLY,
             false),
-        /**
-         * Property: read
-         * Whether this content has already been read/consumed by current user
-         */
-        'read': GObject.ParamSpec.boolean('read', 'Read',
-            'Whether this content has already been read/consumed by current user',
-            GObject.ParamFlags.READABLE),
     },
 
     _init: function (props={}, json_ld=null) {
@@ -162,19 +153,6 @@ const ContentObjectModel = new Lang.Class({
             props.ekn_id = 'ekn:///' + GLib.compute_checksum_for_string(GLib.ChecksumType.SHA1, this.toString(), -1);
         }
         this.parent(props);
-    },
-
-    get read () {
-        return ReadingHistoryModel.get_default().is_read_article(this.ekn_id);
-    },
-
-    // Note: ReadingHistoryModel does not yet expose API to mark an article
-    // 'unread' after it has been read.
-    mark_read: function () {
-        if (this.read)
-            return;
-        ReadingHistoryModel.get_default().mark_article_read(this.ekn_id);
-        this.notify('read');
     },
 
     _content_props_from_json_ld: function (props, json_ld) {

--- a/tests/js/app/modules/card/testList.js
+++ b/tests/js/app/modules/card/testList.js
@@ -6,10 +6,15 @@ Utils.register_gresource();
 const Compliance = imports.tests.compliance;
 const ContentObjectModel = imports.search.contentObjectModel;
 const List = imports.app.modules.card.list;
+const MockReadingHistoryModel = imports.tests.mockReadingHistoryModel;
 
 Gtk.init(null);
 
 describe('Card.List', function () {
+    beforeEach(function () {
+        MockReadingHistoryModel.mock_default();
+    });
+
     it('has labels that understand Pango markup', function () {
         let card = new List.List({
             model: new ContentObjectModel.ContentObjectModel({
@@ -22,6 +27,7 @@ describe('Card.List', function () {
         expect(Gtk.test_find_label(card, '*@@@*').use_markup).toBeTruthy();
         expect(Gtk.test_find_label(card, '*???*').use_markup).toBeTruthy();
     });
+
+    Compliance.test_card_compliance(List.List);
 });
 
-Compliance.test_card_compliance(List.List);

--- a/tests/js/app/testHistoryStore.js
+++ b/tests/js/app/testHistoryStore.js
@@ -2,15 +2,17 @@ const Actions = imports.app.actions;
 const ContentObjectModel = imports.search.contentObjectModel;
 const HistoryStore = imports.app.historyStore;
 const MockDispatcher = imports.tests.mockDispatcher;
+const MockReadingHistoryModel = imports.tests.mockReadingHistoryModel;
 const Pages = imports.app.pages;
 const SetObjectModel = imports.search.setObjectModel;
 
 describe('History Store', function () {
     let history_store;
-    let dispatcher;
+    let dispatcher, reading_history;
 
     beforeEach(function () {
         dispatcher = MockDispatcher.mock_default();
+        reading_history = MockReadingHistoryModel.mock_default();
 
         history_store = new HistoryStore.HistoryStore();
     });
@@ -100,14 +102,14 @@ describe('History Store', function () {
     });
 
     it('marks items as read', function () {
-        let item = new ContentObjectModel.ContentObjectModel({ title: 'blah' });
-        spyOn(item, 'mark_read');
+        let item = new ContentObjectModel.ContentObjectModel({ ekn_id: 'foo', title: 'blah' });
+        spyOn(reading_history, 'mark_article_read');
 
         dispatcher.dispatch({
             action_type: Actions.ITEM_CLICKED,
             model: item,
         });
-        expect(item.mark_read).toHaveBeenCalled();
+        expect(reading_history.mark_article_read).toHaveBeenCalledWith('foo');
     });
 
     it('resets the article-search-visible state when changing', function () {

--- a/tests/mockReadingHistoryModel.js
+++ b/tests/mockReadingHistoryModel.js
@@ -9,12 +9,17 @@ const MockReadingHistoryModel = new Knowledge.Class({
     Name: 'MockReadingHistoryModel',
     Extends: GObject.Object,
 
+    Signals: {
+        'changed': {},
+    },
+
     _init: function (props={}) {
         this.parent(props);
         this._read_articles = new Set();
     },
 
     mark_article_read: function (article_id) {
+        this.emit('changed');
         this._read_articles.add(article_id);
     },
 


### PR DESCRIPTION
Having search libraries depend on app code is incorrect and with
the impending port to C about to become impossible.

The implementation to cover the existing functionality is not very
efficient, but I doubt it will be the bottleneck in terms of
performance.
https://phabricator.endlessm.com/T13418