### PR TITLE
Fixed tests

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -654,6 +654,7 @@ TESTS_ENVIRONMENT = \
 	export GJS_PATH="$(top_srcdir):$(top_srcdir)/js:$(top_builddir)/js"; \
 	export GI_TYPELIB_PATH="$(top_builddir)$${GI_TYPELIB_PATH:+:$$GI_TYPELIB_PATH}"; \
 	export LD_LIBRARY_PATH="$(top_builddir)/.libs$${LD_LIBRARY_PATH:+:$$LD_LIBRARY_PATH}"; \
+	export GIO_EXTRA_MODULES="$(top_builddir)/.libs"; \
 	export G_TEST_SRCDIR="$(abs_srcdir)/tests"; \
 	export G_TEST_BUILDDIR="$(abs_builddir)/tests"; \
 	export LC_ALL=C; \


### PR DESCRIPTION
Added GIO_EXTRA_MODULES to test environment to load eknvfs.so without having to install it.

https://phabricator.endlessm.com/T14402