### PR TITLE
Fix jasmine test runners

### DIFF
--- a/ekncontent/jasmine.json
+++ b/ekncontent/jasmine.json
@@ -1,0 +1,11 @@
+{
+    "spec_files": ["tests"],
+    "options": "--verbose",
+    "environment": {
+        "GJS_PATH": ".:js",
+        "GI_TYPELIB_PATH": ".",
+        "LD_LIBRARY_PATH": ".libs",
+        "GIO_EXTRA_MODULES": ".libs",
+        "LC_ALL": "C"
+    }
+}

--- a/jasmine.json
+++ b/jasmine.json
@@ -1,10 +1,11 @@
 {
-    "include_paths": [".", "js"],
-    "spec_files": ["tests/eosknowledgeprivate", "tests/js"],
+    "spec_files": ["tests/js"],
     "options": "--verbose",
     "environment": {
-        "GI_TYPELIB_PATH": ".",
-        "LD_LIBRARY_PATH": ".libs",
+        "GJS_PATH": ".:js",
+        "GI_TYPELIB_PATH": ".:ekncontent",
+        "LD_LIBRARY_PATH": ".libs:ekncontent/.libs",
+        "GIO_EXTRA_MODULES": "ekncontent/.libs",
         "LC_ALL": "C"
     }
 }


### PR DESCRIPTION
We won't run the ekncontent tests from the main directory. Those
can just be trigger by runing jasmine in the ekncontent repo.

That should make it a little easier to handle import paths and
decouple the two test suites.
https://phabricator.endlessm.com/T13418