### PR TITLE
eos-knowledge-0-dev: don't include ekncontent pkgconfig

### DIFF
--- a/debian/eos-knowledge-0-dev.install
+++ b/debian/eos-knowledge-0-dev.install
@@ -1,5 +1,5 @@
 usr/bin/autobahn
 usr/bin/picard
-usr/lib/*/pkgconfig/*
+usr/lib/*/pkgconfig/eos-knowledge-0.pc
 usr/share/eos-knowledge/theme/*
 usr/share/eos-knowledge/preset/*


### PR DESCRIPTION
Our selector was two generic now that we build two libraries from
this package.
https://phabricator.endlessm.com/T13418