### PR TITLE
build: include ekncontent builddir for g-ir-scanner

### DIFF
--- a/ekncontent/Makefile.am
+++ b/ekncontent/Makefile.am
@@ -138,7 +138,12 @@ AM_TESTS_ENVIRONMENT = \
 
 -include $(INTROSPECTION_MAKEFILE)
 INTROSPECTION_GIRS =
-INTROSPECTION_SCANNER_ARGS = --add-include-path=$(srcdir) --warn-all $(EKN_CONTENT_CFLAGS)
+INTROSPECTION_SCANNER_ARGS = \
+	--add-include-path=$(srcdir) \
+	--warn-all \
+	$(EKN_CONTENT_CFLAGS) \
+	-I ekncontent \
+	$(NULL)
 INTROSPECTION_COMPILER_ARGS = --includedir=$(srcdir)
 
 introspection_sources = \


### PR DESCRIPTION
This is necessary to make the build work when srcdir != builddir,
otherwise eknc-version.h can't be found during the g-ir-scanner step.

https://phabricator.endlessm.com/T13418