### PR TITLE
T13418 kill domain v2

### DIFF
--- a/js/app/courseHistoryStore.js
+++ b/js/app/courseHistoryStore.js
@@ -84,10 +84,10 @@ const CourseHistoryStore = new GObject.Class({
             tags_match_all: ['EknSetObject'],
             sort: QueryObject.QueryObjectSort.SEQUENCE_NUMBER,
         });
-        Engine.get_default().get_objects_by_query(query, null, (engine, task) => {
+        Engine.get_default().get_objects_for_query(query, null, (engine, task) => {
             let results, info;
             try {
-                [results, info] = engine.get_objects_by_query_finish(task);
+                [results, info] = engine.get_objects_for_query_finish(task);
             } catch (error) {
                 logError(error);
                 return;

--- a/js/app/historyStore.js
+++ b/js/app/historyStore.js
@@ -262,10 +262,10 @@ const HistoryStore = new Lang.Class({
     // the same after a link click, factoring out this common function. When we
     // diverge in future interactions we should revisit this decomposition.
     show_ekn_id: function (ekn_id) {
-        Engine.get_default().get_object_by_id(ekn_id, null, (engine, task) => {
+        Engine.get_default().get_object(ekn_id, null, (engine, task) => {
             let model;
             try {
-                model = engine.get_object_by_id_finish(task);
+                model = engine.get_object_finish(task);
             } catch (error) {
                 logError(error);
                 return;
@@ -295,9 +295,9 @@ const HistoryStore = new Lang.Class({
     },
 
     load_dbus_item: function (ekn_id, query, timestamp) {
-        Engine.get_default().get_object_by_id(ekn_id, null, (engine, task) => {
+        Engine.get_default().get_object(ekn_id, null, (engine, task) => {
             try {
-                let model = engine.get_object_by_id_finish(task);
+                let model = engine.get_object_finish(task);
                 if (model instanceof Eknc.ArticleObjectModel) {
                     this.set_current_item_from_props({
                         page_type: Pages.ARTICLE,

--- a/js/app/interfaces/card.js
+++ b/js/app/interfaces/card.js
@@ -316,10 +316,10 @@ const Card = new Lang.Interface({
             tags_match_any: set_obj.child_tags,
             limit: -1,
         });
-        Engine.get_default().get_objects_by_query(query, null, (engine, task) => {
+        Engine.get_default().get_objects_for_query(query, null, (engine, task) => {
             let results, info;
             try {
-                [results, info] = engine.get_objects_by_query_finish(task);
+                [results, info] = engine.get_objects_for_query_finish(task);
                 let reached_bottom = true;
                 results.forEach((obj) => {
                     if (obj instanceof Eknc.SetObjectModel) {

--- a/js/app/interfaces/controller.js
+++ b/js/app/interfaces/controller.js
@@ -92,13 +92,13 @@ const Controller = new Lang.Interface({
     initialize_set_map: function (cb) {
         // Load all sets, with which to populate the set map
         // FIXME: deduplicate this with Selection.AllSets
-        Engine.get_default().get_objects_by_query(new QueryObject.QueryObject({
+        Engine.get_default().get_objects_for_query(new QueryObject.QueryObject({
             limit: -1,
             tags_match_all: ['EknSetObject'],
         }), null, (engine, res) => {
             let models;
             try {
-                [models] = engine.get_objects_by_query_finish(res);
+                [models] = engine.get_objects_for_query_finish(res);
             } catch (e) {
                 logError(e, 'Failed to load sets from database');
                 return;

--- a/js/app/modules/contentGroup/mediaLightbox.js
+++ b/js/app/modules/contentGroup/mediaLightbox.js
@@ -84,11 +84,11 @@ const MediaLightbox = new Module.Class({
             this._preview_media_object(resource);
             this._loading_new_lightbox = false;
         } else {
-            Engine.get_default().get_object_by_id(resource, null, (engine, task) => {
+            Engine.get_default().get_object(resource, null, (engine, task) => {
                 this._loading_new_lightbox = false;
                 let media_object;
                 try {
-                    media_object = engine.get_object_by_id_finish(task);
+                    media_object = engine.get_object_finish(task);
                 } catch (error) {
                     logError(error);
                     return;

--- a/js/app/modules/layout/articleStack.js
+++ b/js/app/modules/layout/articleStack.js
@@ -246,10 +246,10 @@ const ArticleStack = new Module.Class({
 
     _on_show_tooltip: function (tooltip_presenter, tooltip, uri) {
         if (GLib.uri_parse_scheme(uri) === 'ekn') {
-            Engine.get_default().get_object_by_id(uri, null, (engine, task) => {
+            Engine.get_default().get_object(uri, null, (engine, task) => {
                 let article_model;
                 try {
-                    article_model = engine.get_object_by_id_finish(task);
+                    article_model = engine.get_object_finish(task);
                 } catch (error) {
                     logError(error, 'Could not get article model');
                     return;

--- a/js/app/modules/navigation/searchBox.js
+++ b/js/app/modules/navigation/searchBox.js
@@ -109,7 +109,7 @@ const SearchBox = new Module.Class({
             limit: RESULTS_SIZE,
             tags_match_any: ['EknArticleObject'],
         });
-        Engine.get_default().get_objects_by_query(query_obj,
+        Engine.get_default().get_objects_for_query(query_obj,
                                          this._cancellable,
                                          (engine, task) => {
             this._cancellable = null;
@@ -117,7 +117,7 @@ const SearchBox = new Module.Class({
                 return;
 
             try {
-                [this._autocomplete_models] = engine.get_objects_by_query_finish(task);
+                [this._autocomplete_models] = engine.get_objects_for_query_finish(task);
             } catch (error) {
                 if (!error.matches(Gio.IOErrorEnum, Gio.IOErrorEnum.CANCELLED))
                     logError(error);

--- a/js/app/modules/selection/xapian.js
+++ b/js/app/modules/selection/xapian.js
@@ -76,14 +76,14 @@ const Xapian = new Module.Class({
 
         this._loading = true;
         this.notify('loading');
-        engine.get_objects_by_query(query, null, (engine, task) => {
+        engine.get_objects_for_query(query, null, (engine, task) => {
             this._loading = false;
             this._set_needs_refresh(false);
             this.notify('loading');
 
             let results, info;
             try {
-                [results, info] = engine.get_objects_by_query_finish(task);
+                [results, info] = engine.get_objects_for_query_finish(task);
                 this._exception = null;
                 if (this._error_state) {
                     this._error_state = false;

--- a/js/app/widgets/eknWebview.js
+++ b/js/app/widgets/eknWebview.js
@@ -119,8 +119,8 @@ const EknWebview = new Knowledge.Class({
 
     _load_object: function (id, cancellable, callback) {
         let task = new AsyncTask.AsyncTask(this, cancellable, callback);
-        Engine.get_default().get_object_by_id(id, cancellable, task.catch_callback_errors((engine, load_task) => {
-            let model = engine.get_object_by_id_finish(load_task);
+        Engine.get_default().get_object(id, cancellable, task.catch_callback_errors((engine, load_task) => {
+            let model = engine.get_object_finish(load_task);
             if (model instanceof Eknc.ArticleObjectModel) {
                 let html = this.renderer.render(model);
                 let bytes = ByteArray.fromString(html).toGBytes();

--- a/js/search/domain.js
+++ b/js/search/domain.js
@@ -230,7 +230,7 @@ const Domain = new Lang.Class({
         return false;
     },
 
-    get_object_by_id: function (id, cancellable, callback) {
+    get_object: function (id, cancellable, callback) {
         let task = new AsyncTask.AsyncTask(this, cancellable, callback);
         task.catch_errors(() => {
             let [hash] = Utils.components_from_ekn_id(id);
@@ -245,7 +245,7 @@ const Domain = new Lang.Class({
         return task;
     },
 
-    get_object_by_id_finish: function (task) {
+    get_object_finish: function (task) {
         return task.finish();
     },
 
@@ -295,7 +295,7 @@ const Domain = new Lang.Class({
         return task.finish();
     },
 
-    get_objects_by_query: function (query_obj, cancellable, callback) {
+    get_objects_for_query: function (query_obj, cancellable, callback) {
         let task = new AsyncTask.AsyncTask(this, cancellable, callback);
         task.catch_errors(() => {
             let domain_params = this._get_domain_query_params();
@@ -314,8 +314,8 @@ const Domain = new Lang.Class({
 
                 AsyncTask.all(this, (add_task) => {
                     json_ld.results.forEach((result) => {
-                        add_task((cancellable, callback) => this.get_object_by_id(result, cancellable, callback),
-                                 (task) => this.get_object_by_id_finish(task));
+                        add_task((cancellable, callback) => this.get_object(result, cancellable, callback),
+                                 (task) => this.get_object_finish(task));
                     });
                 }, cancellable, task.catch_callback_errors((source, resolve_task) => {
                     let results = AsyncTask.all_finish(resolve_task);
@@ -326,7 +326,7 @@ const Domain = new Lang.Class({
         return task;
     },
 
-    get_objects_by_query_finish: function (task) {
+    get_objects_for_query_finish: function (task) {
         return task.finish();
     },
 });

--- a/js/search/domain.js
+++ b/js/search/domain.js
@@ -8,7 +8,6 @@ const Gio = imports.gi.Gio;
 const Lang = imports.lang;
 
 const AsyncTask = imports.search.asyncTask;
-const Downloader = imports.search.downloader;
 const Utils = imports.search.utils;
 
 // This hash is derived from sha1('link-table'), and for now is the hardcoded
@@ -329,37 +328,6 @@ const Domain = new Lang.Class({
 
     get_objects_by_query_finish: function (task) {
         return task.finish();
-    },
-
-    /**
-     * Function: check_for_updates
-     *
-     * Synchronously check for updates to the domain.
-     */
-    check_for_updates: function () {
-        let subscription_entry = this._get_subscription_entry();
-        let id = subscription_entry.id;
-        let disable_updates = !!subscription_entry.disable_updates;
-
-        if (disable_updates)
-            return;
-
-        let downloader = Downloader.get_default();
-
-        // Synchronously apply any update we have.
-        downloader.apply_update(id, null, (downloader, result) => {
-            downloader.apply_update_finish(result);
-
-            // Regardless of whether or not we applied an update,
-            // let's see about fetching a new one...
-            downloader.fetch_update(id, null, (downloader, result) => {
-                try {
-                    downloader.fetch_update_finish(result);
-                } catch(e) {
-                    logError(e, Format.vprintf("Could not update subscription ID: %s", [id]));
-                }
-            });
-        });
     },
 });
 

--- a/js/search/engine.js
+++ b/js/search/engine.js
@@ -1,8 +1,5 @@
 // Copyright 2014 Endless Mobile, Inc.
 
-const Eknc = imports.gi.EosKnowledgeContent;
-const GLib = imports.gi.GLib;
-const Gio = imports.gi.Gio;
 const GObject = imports.gi.GObject;
 const Lang = imports.lang;
 
@@ -62,7 +59,8 @@ const Engine = Lang.Class({
     /**
      * Function: get_object_by_id
      *
-     * Asynchronously fetches an object with ID.
+     * Asynchronously fetches an object with ID. Only works with ekn ids that
+     * are part of the default app id's content.
      *
      * Parameters:
      *   id - The unique ID for this object, of the form ekn://domain/sha
@@ -176,23 +174,13 @@ const Engine = Lang.Class({
         return this._domain_cache[app_id];
     },
 
+    /**
+     * Method: get_default_domain
+     *
+     * Get the domain object for the default app id.
+     */
     get_default_domain: function () {
         return this._get_domain(this.default_app_id);
-    },
-
-    /**
-     * Method: update_and_preload_default_domain
-     *
-     * Synchronously checks for updates to apply to the current domain.
-     */
-    update_and_preload_default_domain: function () {
-        let domain = this.get_default_domain();
-
-        if (!GLib.getenv('EKN_DISABLE_UPDATES'))
-            domain.check_for_updates();
-
-        // Append shards to default EknVfs for ekn:// uri to work
-        Eknc.default_vfs_set_shards(domain.get_shards());
     },
 
     test_link: function (link) {

--- a/js/search/moltresEngine.js
+++ b/js/search/moltresEngine.js
@@ -46,7 +46,7 @@ const MoltresEngine = new Lang.Class({
 
     get_ekn_id: function () {},
 
-    get_object_by_id: function (ekn_id, cancellable, callback) {
+    get_object: function (ekn_id, cancellable, callback) {
         let set = this._set_models.filter((model) => {
             return model.ekn_id === ekn_id;
         })[0];
@@ -74,7 +74,7 @@ const MoltresEngine = new Lang.Class({
         callback(this);
     },
 
-    get_object_by_id_finish: function () {
+    get_object_finish: function () {
         return this._to_return;
     },
 
@@ -120,7 +120,7 @@ const MoltresEngine = new Lang.Class({
         }
     },
 
-    get_objects_by_query: function (query, cancellable, callback) {
+    get_objects_for_query: function (query, cancellable, callback) {
         let generation_func;
         if (query.tags_match_all.indexOf('EknSetObject') >= 0) {
             this._get_sets(query);
@@ -131,7 +131,7 @@ const MoltresEngine = new Lang.Class({
         callback(this);
     },
 
-    get_objects_by_query_finish: function () {
+    get_objects_for_query_finish: function () {
         return [this._to_return, this._info];
     },
 

--- a/js/search/queryObject.js
+++ b/js/search/queryObject.js
@@ -70,7 +70,7 @@ const QueryObjectOrder = Utils.define_enum(['ASCENDING', 'DESCENDING']);
  * Class: QueryObject
  *
  * The QueryObject class allows you to describe a query to a knowledge app
- * database for articles. Use this with <Engine.get_object_by_id> to retrieve
+ * database for articles. Use this with <Engine.get_object> to retrieve
  * article from the database.
  *
  * This class has no functionality, but is just a bag of properties to tweak

--- a/js/search/searchProvider.js
+++ b/js/search/searchProvider.js
@@ -149,11 +149,11 @@ const AppSearchProvider = Lang.Class({
             limit: this.NUM_RESULTS,
             app_id: this.application_id,
         });
-        this._engine.get_objects_by_query(query_obj,
+        this._engine.get_objects_for_query(query_obj,
                                           this._cancellable,
                                           (engine, query_task) => {
             try {
-                let [results] = engine.get_objects_by_query_finish(query_task);
+                let [results] = engine.get_objects_for_query_finish(query_task);
                 this._add_results_to_cache(results);
                 let ids = results.map(function (result) { return result.ekn_id; });
                 invocation.return_value(new GLib.Variant('(as)', [ids]));

--- a/tests/compliance.js
+++ b/tests/compliance.js
@@ -245,7 +245,7 @@ function test_selection_compliance (SelectionClass, setup=function () {}, extra_
             // Not all Selections might use the Xapian engine, but I can't think
             // of a better place to put this
             let engine = MockEngine.mock_default();
-            engine.get_objects_by_query_finish.and.returnValue([[], {
+            engine.get_objects_for_query_finish.and.returnValue([[], {
                 more_results: null,
             }]);
         });
@@ -361,7 +361,7 @@ function test_xapian_selection_compliance(SelectionClass, setup=function () {}, 
             jasmine.addMatchers(WidgetDescendantMatcher.customMatchers);
 
             engine = MockEngine.mock_default();
-            engine.get_objects_by_query_finish.and.returnValue([[], {
+            engine.get_objects_for_query_finish.and.returnValue([[], {
                 info: {upper_bound: 0},
             }]);
         });
@@ -373,25 +373,25 @@ function test_xapian_selection_compliance(SelectionClass, setup=function () {}, 
                 let model = Eknc.ContentObjectModel.new_from_props();
                 models.push(model);
             }
-            engine.get_objects_by_query_finish.and.returnValue([models, {
+            engine.get_objects_for_query_finish.and.returnValue([models, {
                 info: {upper_bound: 10},
             }]);
             selection.queue_load_more(3);
-            let first_query = engine.get_objects_by_query.calls.mostRecent().args[0];
+            let first_query = engine.get_objects_for_query.calls.mostRecent().args[0];
             // Since we requested 3, we should only add three models to the
             // selection, regardless of how many actually came back.
             expect(selection.add_model.calls.count()).toBe(3);
             selection.queue_load_more(10);
             // When we request more models, we should start the offset from
             // where we left off
-            let second_query = engine.get_objects_by_query.calls.mostRecent().args[0];
+            let second_query = engine.get_objects_for_query.calls.mostRecent().args[0];
             expect(second_query.offset).toEqual(first_query.offset + 3);
         });
 
         it('by going into an error state when the engine throws an exception', function () {
             spyOn(window, 'logError');  // silence console message
             expect(selection.in_error_state).toBeFalsy();
-            engine.get_objects_by_query_finish.and.throwError('asplode');
+            engine.get_objects_for_query_finish.and.throwError('asplode');
             selection.queue_load_more(1);
             Utils.update_gui();
             expect(selection.in_error_state).toBeTruthy();
@@ -399,7 +399,7 @@ function test_xapian_selection_compliance(SelectionClass, setup=function () {}, 
 
         it('saves the exception that was thrown', function () {
             spyOn(window, 'logError');  // silence console message
-            engine.get_objects_by_query_finish.and.throwError('asplode');
+            engine.get_objects_for_query_finish.and.throwError('asplode');
             selection.queue_load_more(1);
             Utils.update_gui();
             expect(selection.get_error().message).toEqual('asplode');

--- a/tests/js/app/modules/controller/testBuffet.js
+++ b/tests/js/app/modules/controller/testBuffet.js
@@ -41,7 +41,7 @@ describe('Controller.Buffet', function () {
         set_models.push(parent);
 
         engine = MockEngine.mock_default();
-        engine.get_objects_by_query_finish.and.returnValue([set_models, {
+        engine.get_objects_for_query_finish.and.returnValue([set_models, {
             more_results: null,
         }]);
 

--- a/tests/js/app/modules/controller/testCourse.js
+++ b/tests/js/app/modules/controller/testCourse.js
@@ -41,7 +41,7 @@ describe('Controller.Course', function () {
         set_models.push(parent);
 
         engine = MockEngine.mock_default();
-        engine.get_objects_by_query_finish.and.returnValue([set_models, {
+        engine.get_objects_for_query_finish.and.returnValue([set_models, {
             more_results: null,
         }]);
 

--- a/tests/js/app/modules/navigation/testSearchBox.js
+++ b/tests/js/app/modules/navigation/testSearchBox.js
@@ -64,11 +64,11 @@ describe('Navigation.SearchBox', function () {
     });
 
     it('calls into engine for auto complete results', function () {
-        engine.get_objects_by_query_finish.and.returnValue([[], {
+        engine.get_objects_for_query_finish.and.returnValue([[], {
             more_results: null,
         }]);
         box.text = 'foo';
-        expect(engine.get_objects_by_query).toHaveBeenCalled();
+        expect(engine.get_objects_for_query).toHaveBeenCalled();
     });
 
     it('dispatches autocomplete-selected when a item is selected', function () {
@@ -76,7 +76,7 @@ describe('Navigation.SearchBox', function () {
             ekn_id: 'ekn://aaaabbbbccccdddd',
             title: 'foo',
         });
-        engine.get_objects_by_query_finish.and.returnValue([[model], {
+        engine.get_objects_for_query_finish.and.returnValue([[model], {
             more_results: null,
         }]);
         box.text = 'foo';

--- a/tests/js/app/testBuffetHistoryStore.js
+++ b/tests/js/app/testBuffetHistoryStore.js
@@ -100,7 +100,7 @@ describe('BuffetHistoryStore', function () {
             let model = Eknc.ArticleObjectModel.new_from_props({
                 ekn_id: 'ekn://foo/bar',
             });
-            engine.get_object_by_id_finish.and.returnValue(model);
+            engine.get_object_finish.and.returnValue(model);
             dispatcher.dispatch({
                 action_type: Actions.ARTICLE_LINK_CLICKED,
                 ekn_id: 'ekn://foo/bar',
@@ -112,7 +112,7 @@ describe('BuffetHistoryStore', function () {
             let model = Eknc.MediaObjectModel.new_from_props({
                 ekn_id: 'ekn://foo/pix',
             });
-            engine.get_object_by_id_finish.and.returnValue(model);
+            engine.get_object_finish.and.returnValue(model);
             dispatcher.dispatch({
                 action_type: Actions.ARTICLE_LINK_CLICKED,
                 ekn_id: 'ekn://foo/pix',
@@ -175,7 +175,7 @@ describe('BuffetHistoryStore', function () {
             model = Eknc.ArticleObjectModel.new_from_props({
                 ekn_id: 'ekn:///foo',
             });
-            engine.get_object_by_id_finish.and.returnValue(model);
+            engine.get_object_finish.and.returnValue(model);
             dispatcher.dispatch({
                 action_type: Actions.DBUS_LOAD_ITEM_CALLED,
                 query: 'foo',
@@ -184,8 +184,8 @@ describe('BuffetHistoryStore', function () {
         });
 
         it('loads an item', function () {
-            expect(engine.get_object_by_id).toHaveBeenCalled();
-            expect(engine.get_object_by_id.calls.mostRecent().args[0])
+            expect(engine.get_object).toHaveBeenCalled();
+            expect(engine.get_object.calls.mostRecent().args[0])
                 .toBe('ekn:///foo');
         });
 

--- a/tests/js/app/testCourseHistoryStore.js
+++ b/tests/js/app/testCourseHistoryStore.js
@@ -32,7 +32,7 @@ describe('CourseHistoryStore', function () {
             },
         ];
         let sets = data.map((obj) => Eknc.SetObjectModel.new_from_props(obj));
-        engine.get_objects_by_query_finish.and.returnValue([sets, {
+        engine.get_objects_for_query_finish.and.returnValue([sets, {
             more_results: null,
         }]);
         SetMap.init_map_with_models(sets);
@@ -131,7 +131,7 @@ describe('CourseHistoryStore', function () {
             model = Eknc.ArticleObjectModel.new_from_props({
                 ekn_id: 'ekn:///foo',
             });
-            engine.get_object_by_id_finish.and.returnValue(model);
+            engine.get_object_finish.and.returnValue(model);
             dispatcher.dispatch({
                 action_type: Actions.DBUS_LOAD_ITEM_CALLED,
                 query: 'foo',
@@ -140,8 +140,8 @@ describe('CourseHistoryStore', function () {
         });
 
         it('loads an item', function () {
-            expect(engine.get_object_by_id).toHaveBeenCalled();
-            expect(engine.get_object_by_id.calls.mostRecent().args[0])
+            expect(engine.get_object).toHaveBeenCalled();
+            expect(engine.get_object.calls.mostRecent().args[0])
                 .toBe('ekn:///foo');
         });
 

--- a/tests/js/app/testMeshHistoryStore.js
+++ b/tests/js/app/testMeshHistoryStore.js
@@ -175,7 +175,7 @@ describe('MeshHistoryStore', function () {
             let model = Eknc.ArticleObjectModel.new_from_props({
                 ekn_id: 'ekn://foo/bar',
             });
-            engine.get_object_by_id_finish.and.returnValue(model);
+            engine.get_object_finish.and.returnValue(model);
             dispatcher.dispatch({
                 action_type: Actions.ARTICLE_LINK_CLICKED,
                 ekn_id: 'ekn://foo/bar',
@@ -187,7 +187,7 @@ describe('MeshHistoryStore', function () {
             let model = Eknc.MediaObjectModel.new_from_props({
                 ekn_id: 'ekn://foo/pix',
             });
-            engine.get_object_by_id_finish.and.returnValue(model);
+            engine.get_object_finish.and.returnValue(model);
             dispatcher.dispatch({
                 action_type: Actions.ARTICLE_LINK_CLICKED,
                 ekn_id: 'ekn://foo/pix',
@@ -203,15 +203,15 @@ describe('MeshHistoryStore', function () {
             model = Eknc.ArticleObjectModel.new_from_props({
                 ekn_id: 'ekn:///foo',
             });
-            engine.get_object_by_id_finish.and.returnValue(model);
+            engine.get_object_finish.and.returnValue(model);
             dispatcher.dispatch({
                 action_type: Actions.DBUS_LOAD_ITEM_CALLED,
                 query: 'foo',
                 ekn_id: 'ekn:///foo',
             });
 
-            expect(engine.get_object_by_id).toHaveBeenCalled();
-            expect(engine.get_object_by_id.calls.mostRecent().args[0])
+            expect(engine.get_object).toHaveBeenCalled();
+            expect(engine.get_object.calls.mostRecent().args[0])
                 .toBe('ekn:///foo');
         });
 
@@ -219,7 +219,7 @@ describe('MeshHistoryStore', function () {
             model = Eknc.ArticleObjectModel.new_from_props({
                 ekn_id: 'ekn:///foo',
             });
-            engine.get_object_by_id_finish.and.returnValue(model);
+            engine.get_object_finish.and.returnValue(model);
             dispatcher.dispatch({
                 action_type: Actions.DBUS_LOAD_ITEM_CALLED,
                 query: 'foo',
@@ -233,7 +233,7 @@ describe('MeshHistoryStore', function () {
             model = Eknc.SetObjectModel.new_from_props({
                 ekn_id: 'ekn:///foo',
             });
-            engine.get_object_by_id_finish.and.returnValue(model);
+            engine.get_object_finish.and.returnValue(model);
             dispatcher.dispatch({
                 action_type: Actions.DBUS_LOAD_ITEM_CALLED,
                 query: 'foo',

--- a/tests/js/search/testEngine.js
+++ b/tests/js/search/testEngine.js
@@ -11,25 +11,25 @@ describe('Engine', function () {
         engine.default_app_id = 'foo';
 
         mock_domain = {
-            get_object_by_id: jasmine.createSpy(),
-            get_object_by_id_finish: jasmine.createSpy(),
+            get_object: jasmine.createSpy(),
+            get_object_finish: jasmine.createSpy(),
         };
         spyOn(engine, '_get_domain').and.returnValue(mock_domain);
     });
 
     describe('domain wrap behavior', function () {
         it('calls get_object_by_id correctly', function (done) {
-            mock_domain.get_object_by_id.and.callFake(function (id, cancellable, callback) {
+            mock_domain.get_object.and.callFake(function (id, cancellable, callback) {
                 callback(mock_domain, 'testing whether this was called');
             });
-            mock_domain.get_object_by_id_finish.and.callFake(function (task) {
+            mock_domain.get_object_finish.and.callFake(function (task) {
                 return task;
             });
 
-            engine.get_object_by_id('ekn:///1234567890abcdef', null, function (engine, task) {
-                let res = engine.get_object_by_id_finish(task);
+            engine.get_object('ekn:///1234567890abcdef', null, function (engine, task) {
+                let res = engine.get_object_finish(task);
                 expect(res).toEqual('testing whether this was called');
-                expect(mock_domain.get_object_by_id).toHaveBeenCalled();
+                expect(mock_domain.get_object).toHaveBeenCalled();
                 done();
             });
         });

--- a/tests/mockEngine.js
+++ b/tests/mockEngine.js
@@ -15,16 +15,16 @@ const MockEngine = new Lang.Class({
         this.port = 3003;
         this.language = '';
 
-        // get_object_by_id() and get_objects_by_query() are spies to begin
+        // get_object() and get_objects_for_query() are spies to begin
         // with, since that is how they will usually be used.
         // Use like so, for example:
-        // engine.get_object_by_id_finish.and.returnValue(my_object);
-        // engine.get_objects_by_query_finish.and.returnValue([[object1,
+        // engine.get_object_finish.and.returnValue(my_object);
+        // engine.get_objects_for_query_finish.and.returnValue([[object1,
         //    object2], {}])
-        spyOn(this, 'get_object_by_id').and.callThrough();
-        spyOn(this, 'get_object_by_id_finish');
-        spyOn(this, 'get_objects_by_query').and.callThrough();
-        spyOn(this, 'get_objects_by_query_finish');
+        spyOn(this, 'get_object').and.callThrough();
+        spyOn(this, 'get_object_finish');
+        spyOn(this, 'get_objects_for_query').and.callThrough();
+        spyOn(this, 'get_objects_for_query_finish');
         spyOn(this, '_lookup_ekn_uri');
 
         let vfs = Gio.Vfs.get_default();
@@ -37,17 +37,17 @@ const MockEngine = new Lang.Class({
     // in testAisleController expect it currently. Would be good to rewrite
     // those tests to tolerate a mock object that was actually async.
 
-    get_object_by_id: function (query, cancellable, callback) {
+    get_object: function (query, cancellable, callback) {
         callback(this);
     },
 
-    get_object_by_id_finish: function () {},
+    get_object_finish: function () {},
 
-    get_objects_by_query: function (query, cancellable, callback) {
+    get_objects_for_query: function (query, cancellable, callback) {
         callback(this);
     },
 
-    get_objects_by_query_finish: function () {},
+    get_objects_for_query_finish: function () {},
 
     _lookup_ekn_uri: function (uri) {
     },

--- a/tools/kermit.js
+++ b/tools/kermit.js
@@ -472,9 +472,9 @@ function query (app_id, query_string) {
 }
 
 function perform_query (engine, query_obj) {
-    engine.get_objects_by_query(query_obj, null, (engine, task) => {
+    engine.get_objects_for_query(query_obj, null, (engine, task) => {
         try {
-            let [results, info] = engine.get_objects_by_query_finish(task);
+            let [results, info] = engine.get_objects_for_query_finish(task);
             results.forEach(function (result) {
                 let id = normalize_ekn_id(result.ekn_id);
                 print_result(id, result.content_type, result.title);


### PR DESCRIPTION
Don't merge this till tests have been fixed!!!

Here's some API changes I'm planning to make the rest of the C port easier and generally clean up our content API a bit.

Plenty of different ways we could go about this, so putting this up quickly without looking at tests (or testing much) to get feedback.

Major changes
 - Kill domain object v2
 - Application calls downloader directly (needed to port domain to C but leave downloader in js for the time being)
 - Remove broken command line option setting datadir
 - Some general cleanups

Probably a bit easier to go commit by commit. The diff on domain is kinda terrible, but its basically just moving things around.

https://phabricator.endlessm.com/T13418