### PR TITLE
eknvfs: Fix for missing schemes

### DIFF
--- a/ekncontent/eknvfs/ekn-vfs.c
+++ b/ekncontent/eknvfs/ekn-vfs.c
@@ -275,12 +275,14 @@ ekn_vfs_get_file_for_uri (GVfs *self, const char *uri)
     }
   else if (uri && priv->extensions)
     {
-      gchar *scheme   = g_uri_parse_scheme (uri);
-      GVfs  *delegate = g_hash_table_lookup (priv->extensions, scheme);
+      gchar *scheme = g_uri_parse_scheme (uri);
+      if (scheme)
+        {
+          GVfs  *delegate = g_hash_table_lookup (priv->extensions, scheme);
 
-      if (delegate)
-        retval = g_vfs_get_file_for_uri (delegate, uri);
-
+          if (delegate)
+            retval = g_vfs_get_file_for_uri (delegate, uri);
+        }
       g_free (scheme);
     }
 


### PR DESCRIPTION
Some code, like file-roller, first tries to open any inputs with
g_file_new_for_uri, and then if that returns NULL, uses
g_file_new_for_path.

If we try to open a string without a scheme, we'll segfault here when we
look it up in the hash table. Just do a quick test first.

https://phabricator.endlessm.com/T14613