### PR TITLE
ekncontent: Add EkncQueryResults object

### DIFF
--- a/ekncontent/Makefile.am
+++ b/ekncontent/Makefile.am
@@ -67,6 +67,7 @@ ekncontent_private_installed_headers = \
 	ekncontent/eknc-media-object-model.h \
 	ekncontent/eknc-object-model.h \
 	ekncontent/eknc-query-object.h \
+	ekncontent/eknc-query-results.h \
 	ekncontent/eknc-set-object-model.h \
 	ekncontent/eknc-subtree-dispatcher.h \
 	ekncontent/eknc-utils.h \
@@ -82,6 +83,7 @@ ekncontent_sources = \
 	ekncontent/eknc-media-object-model.c \
 	ekncontent/eknc-object-model.c \
 	ekncontent/eknc-query-object.c \
+	ekncontent/eknc-query-results.c \
 	ekncontent/eknc-set-object-model.c \
 	ekncontent/eknc-subtree-dispatcher.c \
 	ekncontent/eknc-utils-private.h \
@@ -148,6 +150,7 @@ javascript_tests = \
 	tests/ekncontent/testMediaObjectModels.js \
 	tests/ekncontent/testObjectModel.js \
 	tests/ekncontent/testQueryObject.js \
+	tests/ekncontent/testQueryResults.js \
 	tests/ekncontent/testSetObjectModel.js \
 	tests/ekncontent/testUtils.js \
 	tests/ekncontent/testXapianBridge.js \

--- a/ekncontent/docs/reference/ekncontent/eos-knowledge-content-docs.xml
+++ b/ekncontent/docs/reference/ekncontent/eos-knowledge-content-docs.xml
@@ -25,6 +25,7 @@
     <xi:include href="xml/video-object-model.xml"/>
     <xi:include href="xml/image-object-model.xml"/>
     <xi:include href="xml/query-object.xml"/>
+    <xi:include href="xml/query-results.xml"/>
     <xi:include href="xml/utils.xml"/>
     <xi:include href="xml/subtree-dispatcher.xml"/>
     <xi:include href="xml/xapian-bridge.xml"/>

--- a/ekncontent/docs/reference/ekncontent/eos-knowledge-content-sections.txt
+++ b/ekncontent/docs/reference/ekncontent/eos-knowledge-content-sections.txt
@@ -97,6 +97,18 @@ EKNC_TYPE_QUERY_OBJECT_SORT
 </SECTION>
 
 <SECTION>
+<FILE>query-results</FILE>
+eknc_query_results_get_models
+eknc_query_results_get_upper_bound
+<SUBSECTION Standard>
+EkncQueryResults
+EkncQueryResultsClass
+EKNC_TYPE_QUERY_RESULTS
+<SUBSECTION Private>
+eknc_query_results_new_for_testing
+</SECTION>
+
+<SECTION>
 <FILE>utils</FILE>
 eknc_utils_parallel_init
 eknc_utils_id_get_hash

--- a/ekncontent/ekncontent/eknc-query-results.c
+++ b/ekncontent/ekncontent/eknc-query-results.c
@@ -1,0 +1,188 @@
+/* Copyright 2016 Endless Mobile, Inc. */
+
+#include "eknc-query-results.h"
+#include "eknc-content-object-model.h"
+
+/**
+ * SECTION:query-results
+ * @title: Query Results
+ * @short_description: Results and metadata from Xapian
+ *
+ * The #QueryResults class is returned from search operations.
+ * It provides a list of search results, as well as metadata about the search,
+ * such as the number of total search results.
+ *
+ * This class has no functionality, but is just a bag of properties.
+ * Instances are immutable after creation and all properties must be passed in
+ * on construction.
+ *
+ * You are not intended to create instances of this class; it is returned as
+ * a result of search operations.
+ */
+struct _EkncQueryResults
+{
+  GObject parent_instance;
+
+  GSList *models;
+  gint upper_bound;  /* One would think guint, but Xapian::doccount == int */
+};
+
+G_DEFINE_TYPE (EkncQueryResults, eknc_query_results, G_TYPE_OBJECT)
+
+enum {
+  PROP_0,
+  PROP_MODELS,
+  PROP_UPPER_BOUND,
+  NPROPS
+};
+
+static GParamSpec *eknc_query_results_props[NPROPS] = { NULL, };
+
+
+static void
+eknc_query_results_get_property (GObject    *object,
+                                 guint       prop_id,
+                                 GValue     *value,
+                                 GParamSpec *pspec)
+{
+  EkncQueryResults *self = EKNC_QUERY_RESULTS (object);
+
+  switch (prop_id)
+    {
+    case PROP_MODELS:
+      g_value_set_pointer (value, self->models);
+      break;
+
+    case PROP_UPPER_BOUND:
+      g_value_set_int (value, self->upper_bound);
+      break;
+
+    default:
+      G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
+    }
+}
+
+
+static void
+eknc_query_results_set_property (GObject      *object,
+                                 guint         prop_id,
+                                 const GValue *value,
+                                 GParamSpec   *pspec)
+{
+  EkncQueryResults *self = EKNC_QUERY_RESULTS (object);
+
+  switch (prop_id)
+    {
+    case PROP_MODELS:
+      g_assert(self->models == NULL);
+      self->models = g_slist_copy_deep (g_value_get_pointer (value),
+                                        (GCopyFunc) g_object_ref, NULL);
+      break;
+
+    case PROP_UPPER_BOUND:
+      self->upper_bound = g_value_get_int (value);
+      break;
+
+    default:
+      G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
+    }
+}
+
+static void
+eknc_query_results_finalize (GObject *object)
+{
+  EkncQueryResults *self = EKNC_QUERY_RESULTS (object);
+
+  g_slist_free_full (self->models, g_object_unref);
+}
+
+
+static void
+eknc_query_results_class_init (EkncQueryResultsClass *klass)
+{
+  GObjectClass *object_class = G_OBJECT_CLASS (klass);
+
+  object_class->get_property = eknc_query_results_get_property;
+  object_class->set_property = eknc_query_results_set_property;
+  object_class->finalize = eknc_query_results_finalize;
+
+  /**
+   * EkncQueryResults:models: (type GSList(EkncContentObjectModel))
+   *
+   * A list of the content object models making up the batch of search results
+   * returned from a search operation.
+   */
+  eknc_query_results_props[PROP_MODELS] =
+    g_param_spec_pointer ("models", "Models",
+      "Batch of content object models in search results",
+      G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY | G_PARAM_STATIC_STRINGS);
+
+  /**
+   * EkncQueryObject:upper-bound:
+   *
+   * An upper bound on the total number of results for the query.
+   * (This is often different from the number of results in
+   * #EkncQueryObject:results, since the results can be paginated.)
+   */
+  eknc_query_results_props[PROP_UPPER_BOUND] =
+    g_param_spec_int ("upper-bound", "Upper bound",
+      "Upper bound on total number of results",
+      G_MININT, G_MAXINT, 0,
+      G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY | G_PARAM_STATIC_STRINGS);
+
+  g_object_class_install_properties (object_class, NPROPS,
+                                     eknc_query_results_props);
+}
+
+static void
+eknc_query_results_init (EkncQueryResults *self)
+{
+}
+
+/**
+ * eknc_query_results_get_models:
+ * @self: the #EkncQueryResults
+ *
+ * See #EkncQueryResults:models.
+ *
+ * Returns: (element-type EkncContentObjectModel) (transfer none): list of models
+ */
+GSList *
+eknc_query_results_get_models (EkncQueryResults *self)
+{
+  g_return_val_if_fail (EKNC_IS_QUERY_RESULTS (self), NULL);
+  return self->models;
+}
+
+/**
+ * eknc_query_results_get_upper_bound:
+ * @self: the #EkncQueryResults
+ *
+ * See #EkncQueryResults:upper-bound.
+ *
+ * Returns: the upper bound on the number of results
+ */
+gint
+eknc_query_results_get_upper_bound (EkncQueryResults *self)
+{
+  g_return_val_if_fail (EKNC_IS_QUERY_RESULTS (self), 0);
+  return self->upper_bound;
+}
+
+/**
+ * eknc_query_results_new_for_testing:
+ * @models: (element-type EkncContentObjectModel) (transfer none):
+ *
+ * For testing within eos-knowledge-content only.
+ *
+ * Returns: (transfer full):
+ */
+EkncQueryResults *
+eknc_query_results_new_for_testing (GSList *models)
+{
+  return EKNC_QUERY_RESULTS (g_object_new (EKNC_TYPE_QUERY_RESULTS,
+                                           "upper-bound", 42,
+                                           "models", models,
+                                           NULL));
+
+}

--- a/ekncontent/ekncontent/eknc-query-results.h
+++ b/ekncontent/ekncontent/eknc-query-results.h
@@ -1,0 +1,21 @@
+/* Copyright 2016 Endless Mobile, Inc. */
+
+#pragma once
+
+#include <glib-object.h>
+
+G_BEGIN_DECLS
+
+#define EKNC_TYPE_QUERY_RESULTS eknc_query_results_get_type ()
+G_DECLARE_FINAL_TYPE (EkncQueryResults, eknc_query_results, EKNC, QUERY_RESULTS, GObject)
+
+GSList *
+eknc_query_results_get_models (EkncQueryResults *self);
+
+gint
+eknc_query_results_get_upper_bound (EkncQueryResults *self);
+
+EkncQueryResults *
+eknc_query_results_new_for_testing (GSList *models);
+
+G_END_DECLS

--- a/ekncontent/ekncontent/eos-knowledge-content.h
+++ b/ekncontent/ekncontent/eos-knowledge-content.h
@@ -14,6 +14,7 @@ G_BEGIN_DECLS
 #include "eknc-image-object-model.h"
 #include "eknc-media-object-model.h"
 #include "eknc-query-object.h"
+#include "eknc-query-results.h"
 #include "eknc-set-object-model.h"
 #include "eknc-subtree-dispatcher.h"
 #include "eknc-utils.h"

--- a/ekncontent/overrides/EosKnowledgeContent.js
+++ b/ekncontent/overrides/EosKnowledgeContent.js
@@ -181,4 +181,11 @@ function _init() {
         }
         return Eknc.QueryObject.new_from_props(props);
     };
+
+    // FIXME: Can be removed when GJS supports pointer-valued properties.
+    define_property(Eknc.QueryResults, 'models', {
+        get: function () {
+            return this.get_models();
+        },
+    });
 }

--- a/ekncontent/tests/ekncontent/testQueryResults.js
+++ b/ekncontent/tests/ekncontent/testQueryResults.js
@@ -1,0 +1,30 @@
+const Eknc = imports.gi.EosKnowledgeContent;
+
+const EXPECTED_EKN_IDS = ['ekn:///12345678', 'ekn:///87654321'];
+
+describe('Query results', function () {
+    let results;
+    beforeEach(function () {
+        let models = EXPECTED_EKN_IDS.map(id =>
+            new Eknc.ContentObjectModel({ ekn_id: id }));
+        results = Eknc.QueryResults.new_for_testing(models);
+    });
+
+    it('can access its upper bound by getter', function () {
+        expect(results.get_upper_bound()).toEqual(42);
+    });
+
+    it('can access its upper bound by property', function () {
+        expect(results.upper_bound).toEqual(42);
+    });
+
+    it('can access its results list by getter', function () {
+        let list = results.get_models();
+        expect(list.map(model => model.ekn_id)).toEqual(EXPECTED_EKN_IDS);
+    });
+
+    it('can access its results list by property', function () {
+        let list = results.models;
+        expect(list.map(model => model.ekn_id)).toEqual(EXPECTED_EKN_IDS);
+    });
+});


### PR DESCRIPTION
This object is a replacement for the property bag that's returned in the
JS version of Engine.get_objects_for_query(). It is immutable and also
does not expose any constructor API other than g_object_new.

https://phabricator.endlessm.com/T13418