### PR TITLE
Destroy lightbox widget when closing lightbox

### DIFF
--- a/js/app/modules/contentGroup/mediaLightbox.js
+++ b/js/app/modules/contentGroup/mediaLightbox.js
@@ -57,6 +57,10 @@ const MediaLightbox = new Module.Class({
     },
 
     _on_close: function () {
+        if (this.lightbox_widget instanceof EosKnowledgePrivate.MediaBin) {
+            this.lightbox_widget.stop();
+        }
+        this.lightbox_widget = null;
         Dispatcher.get_default().dispatch({
             action_type: Actions.LIGHTBOX_CLOSED,
         });
@@ -115,8 +119,13 @@ const MediaLightbox = new Module.Class({
         if (this._current_index === -1)
             return;
 
-        if (this.lightbox_widget)
+        if (this.lightbox_widget) {
+            if (this.lightbox_widget instanceof EosKnowledgePrivate.MediaBin) {
+                this.lightbox_widget.stop();
+            }
             this.drop_submodule(this.lightbox_widget);
+            this.lightbox_widget = null;
+        }
 
         let widget = this.create_submodule('card', {
             model: media_object


### PR DESCRIPTION
Currently, if the lightbox widget is a video, it will
keep playing in the background after the lightbox has
closed. So we need to destroy the widget when lightbox
closes or when we switch to another piece of content.

https://phabricator.endlessm.com/T14931