### PR TITLE
Fix i18n of "See more" label

### DIFF
--- a/js/app/modules/contentGroup/contentGroup.js
+++ b/js/app/modules/contentGroup/contentGroup.js
@@ -153,7 +153,7 @@ const ContentGroup = new Module.Class({
         if (this.paginate) {
             let see_more_button = new Gtk.Button({
                 halign: Gtk.Align.CENTER,
-                label: _('See more'),
+                label: _("See more"),
                 no_show_all: true,
                 visible: this.paginate,
             });

--- a/po/POTFILES.in
+++ b/po/POTFILES.in
@@ -10,6 +10,7 @@ js/app/buffetHistoryStore.js
 js/app/interfaces/card.js
 js/app/modules/banner/context.js
 js/app/modules/banner/search.js
+js/app/modules/contentGroup/contentGroup.js
 js/app/modules/contentGroup/noResultsMessage.js
 js/app/modules/controller/buffet.js
 js/app/modules/layout/articleStack.js


### PR DESCRIPTION
contentGroup.js needs to go in POTFILES.in, and the string should be in
double quotes because otherwise xgettext gets confused.

https://phabricator.endlessm.com/T14969