### PR TITLE
Don't rely on integer overflow!

### DIFF
--- a/ekncontent/ekncontent/eknc-xapian-bridge.c
+++ b/ekncontent/ekncontent/eknc-xapian-bridge.c
@@ -238,14 +238,14 @@ get_xapian_query_uri (EkncXapianBridge *self,
 
   guint limit, offset;
   g_object_get (query, "limit", &limit, "offset", &offset, NULL);
-  g_autofree gchar *offset_string = g_strdup_printf ("%d", offset);
-  g_autofree gchar *limit_string = g_strdup_printf ("%d", limit);
+  g_autofree gchar *offset_string = g_strdup_printf ("%u", offset);
+  g_autofree gchar *limit_string = g_strdup_printf ("%u", limit);
   if (limit > 0)
     g_hash_table_insert (params, "limit", limit_string);
   g_hash_table_insert (params, "offset", offset_string);
 
   guint cutoff = eknc_query_object_get_cutoff (query);
-  g_autofree gchar *cutoff_string = g_strdup_printf ("%d", cutoff);
+  g_autofree gchar *cutoff_string = g_strdup_printf ("%u", cutoff);
   g_hash_table_insert (params, "cutoff", cutoff_string);
 
   gint sort_value = eknc_query_object_get_sort_value (query);

--- a/js/app/interfaces/card.js
+++ b/js/app/interfaces/card.js
@@ -311,7 +311,7 @@ const Card = new Lang.Interface({
     _count_set: function (set_obj, callback) {
         let query = Eknc.QueryObject.new_from_props({
             tags_match_any: set_obj.child_tags,
-            limit: -1,
+            limit: GLib.MAXUINT32,
         });
         Eknc.Engine.get_default().query(query, null, (engine, task) => {
             let results;

--- a/js/app/interfaces/controller.js
+++ b/js/app/interfaces/controller.js
@@ -2,6 +2,7 @@
 
 const Eknc = imports.gi.EosKnowledgeContent;
 const Gdk = imports.gi.Gdk;
+const GLib = imports.gi.GLib;
 const GObject = imports.gi.GObject;
 const Gtk = imports.gi.Gtk;
 const Lang = imports.lang;
@@ -92,7 +93,7 @@ const Controller = new Lang.Interface({
         // Load all sets, with which to populate the set map
         // FIXME: deduplicate this with Selection.AllSets
         Eknc.Engine.get_default().query(Eknc.QueryObject.new_from_props({
-            limit: -1,
+            limit: GLib.MAXUINT32,
             tags_match_all: ['EknSetObject'],
         }), null, (engine, res) => {
             let results;


### PR DESCRIPTION
Previously we were implicitly relying on integer
overflow to convert -1 to a large int. This is dangerous
and was partly responsible for a serious bug we found on
ARM. Instead we should explicitly set the integer
to be the max int.

https://phabricator.endlessm.com/T15009