### PR TITLE
application: css file supersedes theme

### DIFF
--- a/js/app/application.js
+++ b/js/app/application.js
@@ -235,8 +235,9 @@ const Application = new Knowledge.Class({
             };
             if (this._theme)
                 controller_props.theme = this._theme;
-            else
-                controller_props.css = this._get_overrides_css();
+            let css = this._get_overrides_css();
+            if (css)
+                controller_props.css = css;
             this._controller = factory.create_root_module(controller_props);
             this._controller.make_ready();
         }


### PR DESCRIPTION
If both a css/scss file and a theme are specified via the command
line, let the manual theme override the theme.

https://phabricator.endlessm.com/T15008