### PR TITLE
control: content dev package depends on shard dev package

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -141,6 +141,7 @@ Section: non-free/libdevel
 Architecture: any
 Multi-Arch: same
 Depends: ${misc:Depends},
+         libeos-shard-0-dev,
          libglib2.0-dev,
          libeos-knowledge-content-0-0 (= ${binary:Version})
 Description: Endless Knowledge Content development files


### PR DESCRIPTION
The content library now serves up shards as part of its public
api, so we should add this dependency
https://phabricator.endlessm.com/T15211