### PR TITLE
eknc-domain: make robust to parallel initialization

### DIFF
--- a/ekncontent/ekncontent/eknc-domain.c
+++ b/ekncontent/ekncontent/eknc-domain.c
@@ -285,8 +285,11 @@ eknc_domain_initable_init (GInitable *initable,
   EkncDomain *self = EKNC_DOMAIN (initable);
 
   if (self->app_id == NULL || *self->app_id == '\0')
-    g_set_error (error, EKNC_DOMAIN_ERROR, EKNC_DOMAIN_ERROR_APP_ID_NOT_SET,
-                 "You must set an app id to initialize a domain object");
+    {
+      g_set_error (error, EKNC_DOMAIN_ERROR, EKNC_DOMAIN_ERROR_APP_ID_NOT_SET,
+                   "You must set an app id to initialize a domain object");
+      return FALSE;
+    }
 
   self->content_dir = eknc_get_data_dir (self->app_id);
   if (!eknc_parse_subscription_id (self, cancellable, error))


### PR DESCRIPTION
There's a few places where we had code which looked like
if (!g_file_exists)
  create_the_file;
We can run into problems here if two domains are racing to setup
directories and symlinks for the same subscriptions at the same
time. In that case you might make it through the existence check,
but by the time you get to actual file creation another domain
in another process has already completed the check.

I believe this is happening with multi-threaded make in our test
runner on ci at the moment, and could also happen when spinning up
the global search provider at the same time as an application.

Instead we move to
create_the_file;
if (!error matches G_IO_ERROR_EXISTS)
  error out;
This way if another domain has one the file creation race, we can
still proceed as normal.
https://phabricator.endlessm.com/T14909