### PR TITLE
Makefile: properly set XDG_DATA_DIRS in the test environment

### DIFF
--- a/ekncontent/Makefile.am
+++ b/ekncontent/Makefile.am
@@ -196,7 +196,7 @@ AM_TESTS_ENVIRONMENT = \
 	export LD_LIBRARY_PATH="$(top_builddir)/.libs$${LD_LIBRARY_PATH:+:$$LD_LIBRARY_PATH}"; \
 	export G_TEST_SRCDIR="$(abs_srcdir)/tests"; \
 	export G_TEST_BUILDDIR="$(abs_builddir)/tests"; \
-	export XDG_DATA_DIRS="$(abs_srcdir)/tests/testcontent$${XDG_DATA_DIRS:+:$$XDG_DATA_DIRS}"; \
+	export XDG_DATA_DIRS="$(abs_srcdir)/tests/testcontent:$${XDG_DATA_DIRS:-/usr/local/share/:/usr/share/}"; \
 	export LC_ALL=C; \
 	$(NULL)
 


### PR DESCRIPTION
If we are setting XDG_DATA_DIRS we need to make sure we provide
some defaults in case the variable is empty, as described here
https://standards.freedesktop.org/basedir-spec/basedir-spec-latest.html
https://phabricator.endlessm.com/T14909