### PR TITLE
T15368

### DIFF
--- a/data/css/modules/card/_legacyPolaroid.scss
+++ b/data/css/modules/card/_legacyPolaroid.scss
@@ -1,5 +1,5 @@
 .CardLegacyPolaroid {
-    padding: 10px 10px 0px 10px;
+    padding: 10px;
     margin: 7px;
     background-color: white;
 


### PR DESCRIPTION
Card.LegacyPolaroid padding changed padding to 10px all around in _mesh.scss. See phabricator ticket for rationale and related ticket

https://phabricator.endlessm.com/T15368