### PR TITLE
Horizontally center the app banner

### DIFF
--- a/data/preset/A.yaml
+++ b/data/preset/A.yaml
@@ -23,7 +23,7 @@ defines:
         source-id: sets-group
         property: has-more-content
   slots:
-    top: Banner.App
+    top: 'Banner.App(halign: center)'
     middle: 'Navigation.SearchBox(halign: center, focus-on-map: true)'
     bottom:
       type: ContentGroup.ContentGroup


### PR DESCRIPTION
I think we never noticed this before because we used
to always have app banner images which were wider
than the search bar.

https://phabricator.endlessm.com/T15530