### PR TITLE
T16085

### DIFF
--- a/tools/picard.js
+++ b/tools/picard.js
@@ -20,6 +20,7 @@ const DummyReadingHistoryModel = new Knowledge.Class({
     Signals: {
         'changed': {},
     },
+    Extends: GObject.Object,
 
     mark_article_read: function () { },
     is_read_article: function () { return false; },
@@ -284,6 +285,7 @@ function build_ui () {
 
     widgets.scroll = new Gtk.ScrolledWindow({
         hscrollbar_policy: Gtk.PolicyType.NEVER,
+        expand: true,
     });
     widgets.window = new Gtk.Window({
         title: 'Picard',


### PR DESCRIPTION
Picard: DummyReadingHistoryModel GObject, ScrolledWindow expand

- DummyReadingHistoryModel wasn't extending from GObject, which was
  messing up Card.List being shown
- Gtk.ScrolledWindow didn't have an expand: true option, which prevented
  Card.List be able to expand within various arrangements

https://phabricator.endlessm.com/T16085