### PR TITLE
EknMediaBin: set background color to black.

### DIFF
--- a/lib/eosknowledgeprivate/ekn-media-bin.css
+++ b/lib/eosknowledgeprivate/ekn-media-bin.css
@@ -37,7 +37,7 @@ ekn-media-bin *.show {
   opacity: 1;
 }
 
-ekn-media-bin > stack > image {
+ekn-media-bin {
   background: black;
 }
 


### PR DESCRIPTION
On ARM the video widget uses alpha for performance reasons which makes
video padding bars transparent instead of black.

https://phabricator.endlessm.com/T16107