### PR TITLE
Layout.ArticleStack: explicitly destroy children.

### DIFF
--- a/js/app/modules/layout/articleStack.js
+++ b/js/app/modules/layout/articleStack.js
@@ -124,7 +124,13 @@ const ArticleStack = new Module.Class({
         for (let child of this.get_children()) {
             if (child !== this.visible_child) {
                 [child.previous_card, child.next_card, child].forEach(this.drop_submodule, this);
-                this.remove(child);
+
+                /* FIXME: Calling this.remove(child) does not destroy the widget
+                 * probably because we are holding a JS reference to it.
+                 * So to avoid having a WebKitWebView leak each time we show a
+                 * new article, we destroy the widget explicitly.
+                 */
+                child.destroy();
             }
         }
     },


### PR DESCRIPTION
To avoid leaking an article content widget (WebkitWebView) each time
we switch to a new one we explicitly destroy the child with child.destroy()
instead of removing it from the hierarchy and relaying on GC. (Which never
happens because we are probably holding a reference in JS)

https://phabricator.endlessm.com/T15913