### PR TITLE
control: Make eos-knowledge-0-bin arch-dependent

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -96,8 +96,8 @@ Description: EndlessOS Knowledge Library Debug package
 
 Package: eos-knowledge-0-bin
 Section: non-free/utils
-Architecture: all
-Multi-Arch: foreign
+Architecture: any
+Multi-Arch: same
 Depends: eos-knowledge-0 (= ${binary:Version}),
          ${misc:Depends}
 Description: EndlessOS Knowledge Library Tools package


### PR DESCRIPTION
It writes an arch-dependent library path into its scripts, so it can't be
arch-independent.

https://phabricator.endlessm.com/T14833