### PR TITLE
T16788

### DIFF
--- a/data/preset/B.yaml
+++ b/data/preset/B.yaml
@@ -51,7 +51,8 @@ defines:
     content:
       shortdef: 'Banner.Set(valign: center)'
       slots:
-        card: Card.Title
+        card:
+          shortdef: 'Card.Title(max-title-lines: 5)'
     sidebar:
       type: Layout.InfiniteScrolling
       references:

--- a/data/preset/library-list.yaml
+++ b/data/preset/library-list.yaml
@@ -75,7 +75,8 @@ defines:
     content:
       shortdef: 'Banner.Set(valign: center)'
       slots:
-        card: Card.Title
+        card: 
+          shortdef: 'Card.Title(max-title-lines: 5)'
     sidebar:
       type: Layout.InfiniteScrolling
       references:

--- a/data/widgets/card/title.ui
+++ b/data/widgets/card/title.ui
@@ -31,12 +31,10 @@
             <property name="no_show_all">True</property>
             <property name="hexpand">True</property>
             <property name="use_markup">True</property>
-            <property name="wrap">False</property>
+            <property name="wrap">True</property>
             <property name="wrap_mode">word-char</property>
-            <property name="max_width_chars">50</property>
             <property name="ellipsize">end</property>
             <property name="width_chars">1</property>
-            <property name="lines">1</property>
             <property name="xalign">0</property>
             <style>
               <class name="CardTitle__title"/>

--- a/js/app/modules/card/title.js
+++ b/js/app/modules/card/title.js
@@ -1,6 +1,7 @@
 // Copyright 2014 Endless Mobile, Inc.
 
 const Gdk = imports.gi.Gdk;
+const GLib = imports.gi.GLib;
 const GObject = imports.gi.GObject;
 const Gtk = imports.gi.Gtk;
 
@@ -41,6 +42,19 @@ const Title = new Module.Class({
             'Decorate on highlight', 'Whether to draw a custom decoration when the card is highlighted',
             GObject.ParamFlags.READWRITE | GObject.ParamFlags.CONSTRUCT_ONLY,
             false),
+
+        /**
+         * Property: max-title-lines
+         *
+         * The maximum numer of lines that the title label can wrap (given that
+         * it is ellipsizing and wrapping)
+         *
+         * A value of -1 allows unlimited number of lines.
+         */
+        'max-title-lines': GObject.ParamSpec.int('max-title-lines', 'Max Title Lines',
+            'The maximum number of lines that the title label can wrap (given that it is ellipsizing and wrapping)',
+            GObject.ParamFlags.READWRITE | GObject.ParamFlags.CONSTRUCT_ONLY,
+            -1, GLib.MAXINT32, 1),
     },
 
     Template: 'resource:///com/endlessm/knowledge/data/widgets/card/title.ui',
@@ -52,6 +66,8 @@ const Title = new Module.Class({
         Utils.set_hand_cursor_on_widget(this);
         this.set_title_label_from_model(this._title_label);
         this._title_label_text = this._title_label.label;
+
+        this._title_label.lines = this.max_title_lines;
     },
 
     vfunc_draw: function (cr) {


### PR DESCRIPTION
This allows Card.Title's title to wrap by adding a proxy property called "max-title-lines" to Card.Title, so setting the property on Card.Title will change the card's internal title_label's "lines" property.
Default value of max-title-lines = 1, for most uses of Card.Title.

Also added the max-title-lines property to Banner.Set's Card.Title in library-list & Preset B's set-page.

https://phabricator.endlessm.com/T16788