### PR TITLE
build: Fail when SCSS compilation fails

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -161,7 +161,7 @@ $(scss_targets): $(scss_partials)
 
 # scss build rule
 .scss.css:
-	$(scss_verbose) $(MKDIR_P) $(dir $@) && $(SCSS) -a $< $@ || rm -f $@
+	$(scss_verbose)$(MKDIR_P) $(@D) && $(SCSS) -a $< $@
 
 EXTRA_DIST += $(scss_template_toplevels) $(scss_template_partials)
 CLEANFILES += $(scss_targets)


### PR DESCRIPTION
The "|| rm -f $@" was causing the make recipe to succeed even if the
SCSS compilation failed. I don't think we needed the rm command anyway,
so just remove it.

https://phabricator.endlessm.com/T16939