### PR TITLE
Adjust so Xapian stopword handling kicks in

### DIFF
--- a/ekncontent/ekncontent/eknc-query-object.c
+++ b/ekncontent/ekncontent/eknc-query-object.c
@@ -543,7 +543,9 @@ get_title_clause (EkncQueryObject *self, gchar **terms)
       title_terms[i] = maybe_add_wildcard (self, title_term);
     }
   title_terms[length] = NULL;
-  return g_strjoinv (XAPIAN_OP_AND, title_terms);
+  // Join with spaces and let the query parser implicitly AND - that way
+  // stopwords get removed.
+  return g_strjoinv (" ", title_terms);
 }
 
 static gchar *
@@ -556,7 +558,9 @@ get_body_clause (EkncQueryObject *self, gchar **terms)
       body_terms[i] = maybe_add_wildcard (self, terms[i]);
     }
   body_terms[length] = NULL;
-  return g_strjoinv (XAPIAN_OP_AND, body_terms);
+  // Join with spaces and let the query parser implicitly AND - that way
+  // stopwords get removed.
+  return g_strjoinv (" ", body_terms);
 }
 
 static gchar *

--- a/ekncontent/ekncontent/eknc-xapian-bridge.c
+++ b/ekncontent/ekncontent/eknc-xapian-bridge.c
@@ -220,6 +220,9 @@ get_xapian_fix_uri (EkncXapianBridge *self,
   g_object_get (query, "query", &query_string, NULL);
   g_hash_table_insert (params, "q", query_string);
 
+  // We rely on the default op being AND within each field (title, body).
+  g_hash_table_insert (params, "defaultOp", "and");
+
   if (extra_params)
     g_hash_table_foreach (extra_params, add_to_hash_table, params);
 
@@ -257,6 +260,9 @@ get_xapian_query_uri (EkncXapianBridge *self,
   g_object_get (query, "order", &order, NULL);
   g_hash_table_insert (params, "order",
                        order == EKNC_QUERY_OBJECT_ORDER_ASCENDING ? "asc" : "desc");
+
+  // We rely on the default op being AND within each field (title, body).
+  g_hash_table_insert (params, "defaultOp", "and");
 
   if (extra_params)
     g_hash_table_foreach (extra_params, add_to_hash_table, params);


### PR DESCRIPTION
Instead of joining terms within each field with " AND ", join them
with a space and set the new defaultOp option to "and".

Currently untested, and needs PRs to be merged in 2 other repos first - for now I'm mostly putting this up to show how the pieces will fit together.