### PR TITLE
presets: Switch to Banner.Dynamic in A, B, Buffet

### DIFF
--- a/data/preset/A.yaml
+++ b/data/preset/A.yaml
@@ -23,7 +23,7 @@ defines:
         source-id: sets-group
         property: has-more-content
   slots:
-    top: 'Banner.App(halign: center)'
+    top: 'Banner.Dynamic(mode: full, halign: center)'
     middle: 'Navigation.SearchBox(halign: center, focus-on-map: true)'
     bottom:
       type: ContentGroup.ContentGroup

--- a/data/preset/B.yaml
+++ b/data/preset/B.yaml
@@ -27,8 +27,9 @@ defines:
     - shortdef: 'Layout.Box(homogeneous: true, valign: start)'
       slots:
         contents:
-        - type: Banner.App
+        - type: Banner.Dynamic
           properties:
+            mode: full
             valign: center
             halign: center
         - type: Navigation.SearchBox

--- a/data/preset/buffet.yaml
+++ b/data/preset/buffet.yaml
@@ -302,7 +302,13 @@ root:
         content:
           type: Layout.BrandPage
           slots:
-            brand: 'Banner.App(show-subtitle: true, halign: center, valign: center)'
+            brand:
+              type: Banner.Dynamic
+              properties:
+                mode: full
+                show-subtitle: true
+                halign: center
+                valign: center
             content:
               type: ContentGroup.MediaLightbox
               slots:


### PR DESCRIPTION
These presets will use Banner.Dynamic instead of Banner.App going
forward, in order to keep them easily internationalizable.

https://phabricator.endlessm.com/T16725