### PR TITLE
Bugfix for Default theme fixes

### DIFF
--- a/data/css/buffet.scss
+++ b/data/css/buffet.scss
@@ -134,10 +134,9 @@ $logo-font: Lato !default;
             &:active,
             &.highlighted {
                 .CardTitle {
-                    background-color: transparent;
-
                     &__title {
                         color: $accent-dark-color;
+                        background-color: transparent;
                         font-weight: bold;
                     }
                 }

--- a/data/css/news.scss
+++ b/data/css/news.scss
@@ -26,10 +26,6 @@ $support-font: 'Fira Sans' !default;
             font-weight: normal;
             -EknFormattableLabel-text-transform: 'lowercase';
         }
-        &.highlighted,
-        &:active {
-            background-color: darken($background-dark-color, 5%);
-        }
     }
 }
 


### PR DESCRIPTION
- In News & Travel menus (Layout.SideMenu and Layout.TopMenu) weren't correctly applying
  :active and .highlighted states & colors