### PR TITLE
Bugfixes from default theme: Buffet/News highlighted state, Card.Deck hover state

### DIFF
--- a/data/css/buffet.scss
+++ b/data/css/buffet.scss
@@ -134,10 +134,9 @@ $logo-font: Lato !default;
             &:active,
             &.highlighted {
                 .CardTitle {
-                    background-color: transparent;
-
                     &__title {
                         color: $accent-dark-color;
+                        background-color: transparent;
                         font-weight: bold;
                     }
                 }

--- a/data/css/modules/card/_deck.scss
+++ b/data/css/modules/card/_deck.scss
@@ -27,6 +27,10 @@
         min-height: 40px;  /* 80px, compensated for 20px padding */
     }
 
+    &:hover &__title {
+        color: $accent-light-color;
+    }
+
     &:hover &__thumbnail,
     &:active &__thumbnail {
         outline: 1px solid $primary-light-color;

--- a/data/css/news.scss
+++ b/data/css/news.scss
@@ -26,10 +26,6 @@ $support-font: 'Fira Sans' !default;
             font-weight: normal;
             -EknFormattableLabel-text-transform: 'lowercase';
         }
-        &.highlighted,
-        &:active {
-            background-color: darken($background-dark-color, 5%);
-        }
     }
 }
 


### PR DESCRIPTION
Fixing 3 quick things that were overlooked in the default theme PR:

- In Buffet template, `Layout.SideMenu` had incorrect highlighted/active state background-color
- In News template, `Layout.TopMenu` (`Arrangement.SideBySide`) had incorrect highlighted/active state background-color
- `Card.Deck` had no hover state