### PR TITLE
Move comment to correct place

### DIFF
--- a/ekncontent/ekncontent/eknc-engine.c
+++ b/ekncontent/ekncontent/eknc-engine.c
@@ -355,7 +355,6 @@ on_query_fixed_finished (GObject *source,
       return;
     }
 
-  /* We're searching for tags without a query string. */
   eknc_domain_query (domain, query, cancellable, on_domain_query_finished, g_steal_pointer (&task));
 }
 
@@ -408,6 +407,7 @@ eknc_engine_query (EkncEngine *self,
       return;
     }
 
+  /* We're searching for tags without a query string. */
   eknc_domain_query (domain, query, cancellable, on_domain_query_finished, g_steal_pointer (&task));
 }
 


### PR DESCRIPTION
The comment I added in fce3237a23dade71bc6b27612a635e317e6e4b06 was
in the wrong function - move it to the correct one.