### PR TITLE
Allow DEBUG_COMMAND to be specified directly

### DIFF
--- a/ekn-app-runner.in
+++ b/ekn-app-runner.in
@@ -17,7 +17,6 @@ if [[ "$(uname -m)" == arm* ]]; then
     export LOW_PERFORMANCE_MODE=1
 fi
 
-DEBUG_COMMAND=""
 if [ "$RUN_DEBUG" != "" ]; then
     DEBUG_COMMAND="gdb --args"
 fi

--- a/tools/eminem.in
+++ b/tools/eminem.in
@@ -11,7 +11,6 @@ if [ "$GJS_DEBUG_TOPICS" == "" ]; then
     export GJS_DEBUG_TOPICS="JS ERROR;JS LOG"
 fi
 
-DEBUG_COMMAND=""
 if [ "$RUN_DEBUG" != "" ]; then
     DEBUG_COMMAND="gdb --args"
 fi

--- a/tools/introspect.in
+++ b/tools/introspect.in
@@ -11,7 +11,6 @@ if [ "$GJS_DEBUG_TOPICS" == "" ]; then
     export GJS_DEBUG_TOPICS="JS ERROR;JS LOG"
 fi
 
-DEBUG_COMMAND=""
 if [ "$RUN_DEBUG" != "" ]; then
     DEBUG_COMMAND="gdb --args"
 fi

--- a/tools/kermit.in
+++ b/tools/kermit.in
@@ -11,7 +11,6 @@ if [ "$GJS_DEBUG_TOPICS" == "" ]; then
     export GJS_DEBUG_TOPICS="JS ERROR;JS LOG"
 fi
 
-DEBUG_COMMAND=""
 if [ "$RUN_DEBUG" != "" ]; then
     DEBUG_COMMAND="gdb --args"
 fi

--- a/tools/picard.in
+++ b/tools/picard.in
@@ -11,7 +11,6 @@ if [ "$GJS_DEBUG_TOPICS" == "" ]; then
     export GJS_DEBUG_TOPICS="JS ERROR;JS LOG"
 fi
 
-DEBUG_COMMAND=""
 if [ "$RUN_DEBUG" != "" ]; then
     DEBUG_COMMAND="gdb --args"
 fi


### PR DESCRIPTION
Don't explicitly set DEBUG_COMMAND to an empty value in the wrapper
scripts, to allow specifying tools other than gdb, e.g.
DEBUG_COMMAND=valgrind