### PR TITLE
Refactoring some News CSS & YAML

### DIFF
--- a/data/css/modules/arrangement/_sideBySide.scss
+++ b/data/css/modules/arrangement/_sideBySide.scss
@@ -1,32 +1,51 @@
 .ArrangementSideBySide {
-    .CardTitle {
-        padding: .2em 1em;
+    .CardTitle__title,
+    &__dropdown_button {
+        font-family: $title-font;
+        color: transparentize(white, 1 - 0.60);
+        font-size: 18px;
+    }
 
-        &__title {
-            font-family: $title-font;
-            font-weight: bold;
-            color: transparentize(white, 1 - 0.60);
-            font-size: 18px;
-        }
+    .CardTitle__title {
+        font-weight: bold;
+    }
 
-        &:hover .CardTitle__title {
+    .CardTitle,
+    &__dropdown_button {
+        &:hover .CardTitle__title,
+        &:hover {
             color: $accent-light-color;
         }
 
         &.highlighted,
         &:active {
-            background-color: darken($primary-dark-color, 5%);
-
-            .CardTitle__title {
+            .CardTitle__title,
+            .ArrangementSideBySide__dropdown_button {
                 color: white;
             }
         }
     }
-    &__popover {
-        background-color: $primary-medium-color;
-        box-shadow: 2px 2px 6px black;
-        color: transparentize(white, 1 - 0.60);
-        padding: .5em 0em;
+
+    .CardTitle.highlighted,
+    .CardTitle:active {
+        background-color: darken($primary-dark-color, 5%);
+    }
+
+    .CardTitle {
+        padding: .2em 2em;
+    }
+
+    &__dropdown_button {
+        font-size: 1.7em;
+        padding-left: .5em;
+    }
+
+    &__dropdown_menu {
+        background-color: $primary-dark-color;
+        box-shadow: 0px 0px 5px 0px transparentize(black, 1 - 0.60);
         min-width: 10em;
+        .CardTitle {
+            padding: 1em 2em;
+        }
     }
 }

--- a/data/css/modules/layout/_topMenu.scss
+++ b/data/css/modules/layout/_topMenu.scss
@@ -15,9 +15,18 @@
             min-width: 146px;
             min-height: 30px;
         }
+
+        .BannerApp,
+        .BannerDynamic {
+            padding-right: 50px;
+        }
     }
 
     &__content {
         margin-top: 50px;
     }
+
+    /* FIXME: All CSS for the menu buttons & text are in Arrangement.SideBySide.
+    This seems a little unintuitive; we should move the code from
+    Arrangement.SideBySide to Layout.TopMenu in the future. */
 }

--- a/data/css/news.scss
+++ b/data/css/news.scss
@@ -20,11 +20,9 @@ $support-font: 'Fira Sans' !default;
 }
 
 .LayoutTopMenu__menu {
-    background-color: #050c20;
     .CardTitle {
         &__title {
             font-weight: normal;
-            -EknFormattableLabel-text-transform: 'lowercase';
         }
     }
 }
@@ -35,24 +33,13 @@ $support-font: 'Fira Sans' !default;
         margin-top: 95px;
     }
 
-    .BannerSet .FormattableLabel,
-    .BannerSearch .FormattableLabel {
-        -EknFormattableLabel-text-transform: 'lowercase';
+    .ContentGroup--outercontainer {
+        margin-top: 100px;
+        .ContentGroup--articles {
+            margin-left: 100px;
+            margin-right: 100px;
+        }
     }
-}
-
-.ContentGroup--complementarycontent {
-  .ContentGroupContentGroup__title {
-    font-size: 46px;
-    font-weight: 900;
-    color: $primary-medium-color;
-    margin: 30px 0px 20px 0px;
-  }
-}
-
-.set-page .ContentGroup--outercontainer,
-.search-page .ContentGroup--outercontainer {
-    margin-top: 100px;
 }
 
 .ContentGroup--outercontainer {
@@ -63,20 +50,6 @@ $support-font: 'Fira Sans' !default;
 
         &__trigger {
             margin-right: 10px;
-        }
-
-        &__title .FormattableLabel,
-        &__trigger .FormattableLabel {
-            -EknFormattableLabel-text-transform: 'lowercase';
-        }
-
-        &__title--clickable,
-        &__trigger {
-            color: $primary-dark-color;
-
-            &:hover {
-                color: $primary-light-color;
-            }
         }
     }
 
@@ -90,10 +63,12 @@ $support-font: 'Fira Sans' !default;
     }
 }
 
+.ContentGroup--complementarycontent,
 .LayoutResponsiveMargins--complementarycontent {
     background-color: $background-dark-color;
 
     .ContentGroupContentGroup__title {
+        font-size: 46px;
         color: white;
     }
 }
@@ -129,17 +104,16 @@ $support-font: 'Fira Sans' !default;
     }
     .ContentGroup--complementarycontent {
         background-color: $background-light-color;
+        // margin-right is to leave room for scrollbar
         margin-right: 14px;
-        padding: 0px 50px 20px 50px;
+        padding: 30px 50px 50px 50px;
+
+        .ContentGroupContentGroup__title {
+            color: transparentize(black, 1 - 0.60);
+        }
 
         .composite & {
           padding: 0px 0px 20px 0px;
         }
-    }
-}
-
-.CardDefault {
-    &__context .FormattableLabel {
-        -EknFormattableLabel-text-transform: 'lowercase';
     }
 }

--- a/data/preset/news.yaml
+++ b/data/preset/news.yaml
@@ -42,7 +42,7 @@ defines:
     contents:
     - type: ContentGroup.DynamicTitle
       properties:
-        format-string: !translate "see more from %s"
+        format-string: !translate "See more from %s"
         ellipsize: end
         hexpand: true
     - shortdef: 'Decoration.ThemeableImage(valign: end, halign: end)'

--- a/js/app/modules/arrangement/sideBySide.js
+++ b/js/app/modules/arrangement/sideBySide.js
@@ -12,7 +12,7 @@ const Knowledge = imports.app.knowledge;
 const Module = imports.app.interfaces.module;
 const Utils = imports.app.utils;
 
-const SPACING_MAX = 50;
+const SPACING_MAX = 0;
 
 /**
  * Class: SideBySide
@@ -48,10 +48,11 @@ const SideBySide = new Module.Class({
         this._popover_button.connect("clicked", () => {
             this._popover.popup();
         });
+        this._popover_button.get_style_context().add_class(Utils.get_element_style_class(SideBySide, 'dropdown_button'));
 
         /* Classes needed for cards to have the same style */
         let context = this._popover.get_style_context();
-        context.add_class(Utils.get_element_style_class(SideBySide, 'popover'));
+        context.add_class(Utils.get_element_style_class(SideBySide, 'dropdown_menu'));
         context.add_class(SideBySide.get_style_class());
 
         /* Dropdown contents */

--- a/js/app/modules/arrangement/sideBySide.js
+++ b/js/app/modules/arrangement/sideBySide.js
@@ -12,8 +12,6 @@ const Knowledge = imports.app.knowledge;
 const Module = imports.app.interfaces.module;
 const Utils = imports.app.utils;
 
-const SPACING_MAX = 0;
-
 /**
  * Class: SideBySide
  * Arrangement to be used in horizontal menus
@@ -91,10 +89,10 @@ const SideBySide = new Module.Class({
 
         nat += all_cards.slice(1).reduce((accum, card) => {
             let [, card_nat] = card.get_preferred_width();
-            return accum + card_nat + SPACING_MAX;
+            return accum + card_nat;
         }, 0);
 
-        return [min, SPACING_MAX * 2 + nat];
+        return [min, nat];
     },
 
     _ensure_card_parent: function (card, parent) {
@@ -150,18 +148,13 @@ const SideBySide = new Module.Class({
             cards_width += this._button_nat;
         }
 
-        /* Calculate proper spacing */
-        let leftover = width - cards_width;
-        let n_spacing = visible.length - 1;
-
-        let spacing = Math.min(Math.floor(leftover/(n_spacing + 2)), SPACING_MAX);
-        let x = alloc.x + (leftover - spacing * n_spacing);
+        /* Allocate children */
+        let x = alloc.x + (width - cards_width);
         let y = alloc.y;
 
-        /* Allocate children */
         visible.forEach ((child) => {
             Arrangement.place_card(child.child, x, y, child.nat, alloc.height);
-            x += child.nat + spacing;
+            x += child.nat;
         });
 
         this.parent(alloc);


### PR DESCRIPTION
Some extra CSS removal from the News template that is not necessary on the template level.
- Deleted CSS having to do with text-transform, color, and some margin on content groups that
  should inherit from other content group styling
- Moved .ContentGroup--outercontainer upward in code for readability
- Combined CSS for .ContentGroup--complementarycontent and .LayoutResponsiveMargins--complementarycontent
- Changed trigger text to "More news from ...."

And, some default theme design QA on the Layout.TopMenu and its new dropdown menu for news template

https://phabricator.endlessm.com/T17424