### PR TITLE
Make sure that va_end() is called on early exit

### DIFF
--- a/ekncontent/ekncontent/eknc-query-object.c
+++ b/ekncontent/ekncontent/eknc-query-object.c
@@ -986,6 +986,7 @@ eknc_query_object_new_from_object (EkncQueryObject *source,
       if (!pspec)
         {
           g_critical ("Failed to find property: %s", name);
+          va_end (args);
           return NULL;
         }
 
@@ -994,6 +995,7 @@ eknc_query_object_new_from_object (EkncQueryObject *source,
       if (error != NULL)
         {
           g_critical ("Failed to retrieve va_list value: %s", error);
+          va_end (args);
           return NULL;
         }
     }


### PR DESCRIPTION
The man page says "Each invocation of va_start() must be matched by
a corresponding invocation of va_end() in the same function."