### PR TITLE
build: Ignore eknc-enums.h correctly

### DIFF
--- a/ekncontent/docs/reference/ekncontent/Makefile.am
+++ b/ekncontent/docs/reference/ekncontent/Makefile.am
@@ -48,7 +48,7 @@ EXTRA_HFILES=
 
 # Header files or dirs to ignore when scanning. Use base file/dir names
 # e.g. IGNORE_HFILES=gtkdebug.h gtkintl.h private_code
-IGNORE_HFILES=$(top_srcdir)/ekncontent/eknc-enums.h
+IGNORE_HFILES=eknc-enums.h
 
 # Images to copy into HTML directory.
 # e.g. HTML_IMAGES=$(top_srcdir)/gtk/stock-icons/stock_about_24.png


### PR DESCRIPTION
Gtk-doc needs to have base file names in IGNORE_HFILES, not full paths.
(Once again, I'm not sure how this worked before! Maybe we upgraded
gtk-doc on the autobuilder?)

https://phabricator.endlessm.com/T17601