### PR TITLE
Add TravisCI script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,18 @@
+language: c
+dist: trusty
+sudo: false
+cache: ccache
+group: edge
+
+services: docker
+
+before_install:
+    - docker pull ebassi/endlessci:sdk
+
+before_script:
+    - echo 'FROM ebassi/endlessci:sdk' > Dockerfile
+    - echo 'ADD . /root/source/eos-knowledge-lib' >> Dockerfile
+    - docker build -t withgit .
+
+script:
+    - docker run --volume $HOME/.ccache:/root/.ccache withgit /bin/sh -c '/usr/bin/endless-build-module --check --with-xvfb eos-knowledge-lib'


### PR DESCRIPTION
We want to use Travis to perform CI on the Endless apps SDK modules; in
order to achieve that, we use pre-built Docker images with the required
build dependencies.