### PR TITLE
navigation: Only show the back button if we have > 1 page on stack

### DIFF
--- a/js/app/modules/layout/navigation.js
+++ b/js/app/modules/layout/navigation.js
@@ -40,7 +40,7 @@ const Navigation = new Module.Class({
     },
 
     _on_history_changed: function () {
-        let item = HistoryStore.get_default().get_current_item();
-        this.back_visible = (item.page_type != Pages.HOME);
+        // The back button should only be visible if we can go back
+        this.back_visible = HistoryStore.get_default().can_go_back();
     },
 });

--- a/tests/js/app/modules/layout/testNavigation.js
+++ b/tests/js/app/modules/layout/testNavigation.js
@@ -32,12 +32,20 @@ describe('Layout.Navigation', function () {
         expect(layout.forward_visible).toBeFalsy();
     });
 
-    it('disables the back arrow on the home page', function () {
+    it('disables the back arrow when the first page is an article', function () {
+        store.set_current_item_from_props({ page_type: Pages.ARTICLE });
+        expect(layout.back_visible).toBeFalsy();
+    });
+
+    it('disables the back arrow when the first page is home', function () {
         store.set_current_item_from_props({ page_type: Pages.HOME });
         expect(layout.back_visible).toBeFalsy();
     });
 
     it('enables the back arrow on other pages', function () {
+        // Note that we need to have at least one page on the history
+        // stack before this will work.
+        store.set_current_item_from_props({ page_type: Pages.HOME });
         store.set_current_item_from_props({ page_type: Pages.SET });
         expect(layout.back_visible).toBeTruthy();
         store.set_current_item_from_props({ page_type: Pages.SEARCH });
@@ -46,5 +54,11 @@ describe('Layout.Navigation', function () {
         expect(layout.back_visible).toBeTruthy();
         store.set_current_item_from_props({ page_type: Pages.ALL_SETS });
         expect(layout.back_visible).toBeTruthy();
+    });
+
+    it('enables the back button on the homepage if it appears later', function() {
+        store.set_current_item_from_props({ page_type: Pages.HOME });
+        store.set_current_item_from_props({ page_type: Pages.SET });
+        store.set_current_item_from_props({ page_type: Pages.HOME });
     });
 });


### PR DESCRIPTION
Previously we were only hiding it when we were on the homepage,
though that assumed that the homepage was the first page on the
stack. If we open an article from a search provider, then we're
going to end up with that being the first page. Also, the user
should be able to press 'back' if they went to the homepage by
clicking on the home button.

https://phabricator.endlessm.com/T17573