### PR TITLE
ekncontent: Add temporal-coverage property to ArticleObjectModel

### DIFF
--- a/ekncontent/docs/reference/ekncontent/eos-knowledge-content-docs.xml
+++ b/ekncontent/docs/reference/ekncontent/eos-knowledge-content-docs.xml
@@ -41,6 +41,7 @@
 
   <index id="api-index-full">
     <title>API Index</title>
+    <xi:include href="xml/api-index-2.xml"/>
     <xi:include href="xml/api-index-full.xml"><xi:fallback /></xi:include>
   </index>
 

--- a/ekncontent/docs/reference/ekncontent/eos-knowledge-content-sections.txt
+++ b/ekncontent/docs/reference/ekncontent/eos-knowledge-content-sections.txt
@@ -65,6 +65,7 @@ eknc_content_object_model_add_json_to_params
 <SECTION>
 <FILE>article-object-model</FILE>
 eknc_article_object_model_get_authors
+eknc_article_object_model_get_temporal_coverage
 eknc_article_object_model_get_outgoing_links
 eknc_article_object_model_get_table_of_contents
 eknc_article_object_model_new_from_json_node

--- a/ekncontent/ekncontent/eknc-article-object-model.c
+++ b/ekncontent/ekncontent/eknc-article-object-model.c
@@ -19,6 +19,7 @@ typedef struct {
   guint word_count;
   gboolean is_server_templated;
   GVariant *authors;
+  GVariant *temporal_coverage;
   GVariant *outgoing_links;
   GVariant *table_of_contents;
 } EkncArticleObjectModelPrivate;
@@ -35,6 +36,7 @@ enum {
   PROP_WORD_COUNT,
   PROP_IS_SERVER_TEMPLATED,
   PROP_AUTHORS,
+  PROP_TEMPORAL_COVERAGE,
   PROP_OUTGOING_LINKS,
   PROP_TABLE_OF_CONTENTS,
   NPROPS
@@ -75,6 +77,10 @@ eknc_article_object_model_get_property (GObject    *object,
 
     case PROP_AUTHORS:
       g_value_set_variant (value, priv->authors);
+      break;
+
+    case PROP_TEMPORAL_COVERAGE:
+      g_value_set_variant (value, priv->temporal_coverage);
       break;
 
     case PROP_OUTGOING_LINKS:
@@ -129,6 +135,11 @@ eknc_article_object_model_set_property (GObject *object,
       priv->authors = g_value_dup_variant (value);
       break;
 
+    case PROP_TEMPORAL_COVERAGE:
+      g_clear_pointer (&priv->temporal_coverage, g_variant_unref);
+      priv->temporal_coverage = g_value_dup_variant (value);
+      break;
+
     case PROP_OUTGOING_LINKS:
       g_clear_pointer (&priv->outgoing_links, g_variant_unref);
       priv->outgoing_links = g_value_dup_variant (value);
@@ -154,6 +165,7 @@ eknc_article_object_model_finalize (GObject *object)
   g_clear_pointer (&priv->source_name, g_free);
   g_clear_pointer (&priv->published, g_free);
   g_clear_pointer (&priv->authors, g_variant_unref);
+  g_clear_pointer (&priv->temporal_coverage, g_variant_unref);
   g_clear_pointer (&priv->outgoing_links, g_variant_unref);
   g_clear_pointer (&priv->table_of_contents, g_variant_unref);
 
@@ -230,6 +242,17 @@ eknc_article_object_model_class_init (EkncArticleObjectModelClass *klass)
       G_VARIANT_TYPE ("as"), NULL,
       G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY | G_PARAM_STATIC_STRINGS);
   /**
+   * EkncArticleObjectModel:temporal-coverage:
+   *
+   * A list of dates that the article being read refers to. The
+   * dates are all in ISO8601.
+   */
+  eknc_article_object_model_props[PROP_TEMPORAL_COVERAGE] =
+    g_param_spec_variant ("temporal-coverage", "Temporal Coverage",
+      "A list of dates that the article being read refers to",
+      G_VARIANT_TYPE ("as"), NULL,
+      G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY | G_PARAM_STATIC_STRINGS);
+  /**
    * EkncArticleObjectModel:outgoing-links:
    *
    * A list of the outbound links present in this article.
@@ -294,6 +317,9 @@ eknc_article_object_model_add_json_to_params (JsonNode *node,
   eknc_utils_append_gparam_from_json_node (json_object_get_member (object, "authors"),
                                            g_object_class_find_property (klass, "authors"),
                                            params);
+  eknc_utils_append_gparam_from_json_node (json_object_get_member (object, "temporalCoverage"),
+                                           g_object_class_find_property (klass, "temporal-coverage"),
+                                           params);
   eknc_utils_append_gparam_from_json_node (json_object_get_member (object, "outgoingLinks"),
                                            g_object_class_find_property (klass, "outgoing-links"),
                                            params);
@@ -318,6 +344,24 @@ eknc_article_object_model_get_authors (EkncArticleObjectModel *self)
 
   EkncArticleObjectModelPrivate *priv = eknc_article_object_model_get_instance_private (self);
   return priv->authors;
+}
+
+/**
+ * eknc_article_object_model_get_temporal_coverage:
+ * @self: the model
+ *
+ * Get the temporal coverage over the article.
+ *
+ * Since: 2
+ * Returns: (transfer none): the resources GVariant
+ */
+GVariant *
+eknc_article_object_model_get_temporal_coverage (EkncArticleObjectModel *self)
+{
+  g_return_val_if_fail (EKNC_IS_ARTICLE_OBJECT_MODEL (self), NULL);
+
+  EkncArticleObjectModelPrivate *priv = eknc_article_object_model_get_instance_private (self);
+  return priv->temporal_coverage;
 }
 
 /**

--- a/ekncontent/ekncontent/eknc-article-object-model.h
+++ b/ekncontent/ekncontent/eknc-article-object-model.h
@@ -23,6 +23,9 @@ GVariant *
 eknc_article_object_model_get_authors (EkncArticleObjectModel *self);
 
 GVariant *
+eknc_article_object_model_get_temporal_coverage (EkncArticleObjectModel *self);
+
+GVariant *
 eknc_article_object_model_get_outgoing_links (EkncArticleObjectModel *self);
 
 GVariant *

--- a/ekncontent/overrides/EosKnowledgeContent.js
+++ b/ekncontent/overrides/EosKnowledgeContent.js
@@ -38,6 +38,9 @@ function add_custom_model_constructors (model) {
         marshal_property(props, 'authors', function (v) {
             return new GLib.Variant('as', v);
         });
+        marshal_property(props, 'temporal-coverage', function (v) {
+            return new GLib.Variant('as', v);
+        });
         marshal_property(props, 'outgoing-links', function (v) {
             return new GLib.Variant('as', v);
         });
@@ -93,6 +96,12 @@ function _init() {
         get: function () {
             let authors = this.get_authors();
             return authors ? authors.deep_unpack() : [];
+        },
+    });
+    define_property(Eknc.ArticleObjectModel, 'temporal-coverage', {
+        get: function () {
+            let temporalCoverage = this.get_temporal_coverage();
+            return temporalCoverage ? temporalCoverage.deep_unpack() : [];
         },
     });
     define_property(Eknc.ArticleObjectModel, 'outgoing-links', {

--- a/ekncontent/tests/ekncontent/testArticleObjectModel.js
+++ b/ekncontent/tests/ekncontent/testArticleObjectModel.js
@@ -13,6 +13,7 @@ describe ('Article Object Model', function () {
             'title': 'House Greyjoy',
             'synopsis': 'We Do Not Sow',
             'authors': ['Dalton Greyjoy', 'Dagon Greyjoy'],
+            'temporalCoverage': [new Date(2016, 1, 1).toISOString()],
             'tableOfContents': [
                 {
                     '@id': '_:1',
@@ -39,6 +40,10 @@ describe ('Article Object Model', function () {
 
         it('marshals an authors array', function () {
             expect(articleObject.authors).toEqual(jsonld['authors']);
+        });
+
+        it('marshals an temporalCoverage array', function () {
+            expect(articleObject.temporal_coverage).toEqual(jsonld['temporalCoverage']);
         });
 
         it('makes a deep copy of the authors array', function () {


### PR DESCRIPTION
This property is the dates referred to in the content, which we'll
use for things like WikiArt to add a date to the end of it.

https://phabricator.endlessm.com/T17886