### PR TITLE
modules: Big rename of Views

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -76,23 +76,16 @@ scss_theme_banner_partials = \
 	$(srcdir)/data/css/modules/banner/_set.scss \
 	$(NULL)
 scss_theme_card_partials = \
-	$(srcdir)/data/css/modules/card/_audio.scss \
 	$(srcdir)/data/css/modules/card/_base.scss \
 	$(srcdir)/data/css/modules/card/_deck.scss \
 	$(srcdir)/data/css/modules/card/_default.scss \
-	$(srcdir)/data/css/modules/card/_knowledgeDocument.scss \
 	$(srcdir)/data/css/modules/card/_list.scss \
-	$(srcdir)/data/css/modules/card/_media.scss \
 	$(srcdir)/data/css/modules/card/_sequence.scss \
-	$(srcdir)/data/css/modules/card/_video.scss \
 	$(NULL)
 scss_theme_content_partials = \
 	$(srcdir)/data/css/modules/contentGroup/_contentGroup.scss \
 	$(srcdir)/data/css/modules/contentGroup/_mediaLightbox.scss \
 	$(srcdir)/data/css/modules/contentGroup/_noResultsMessage.scss \
-	$(NULL)
-scss_theme_document_partials = \
-	$(srcdir)/data/css/modules/documentCard/_base.scss \
 	$(NULL)
 scss_theme_layout_partials = \
 	$(srcdir)/data/css/modules/layout/_dynamicBackground.scss \
@@ -114,6 +107,13 @@ scss_theme_pager_partials = \
 	$(srcdir)/data/css/modules/pager/_parallaxBackground.scss \
 	$(srcdir)/data/css/modules/pager/_simple.scss \
 	$(NULL)
+scss_theme_view_partials = \
+	$(srcdir)/data/css/modules/view/_audio.scss \
+	$(srcdir)/data/css/modules/view/_base.scss \
+	$(srcdir)/data/css/modules/view/_document.scss \
+	$(srcdir)/data/css/modules/view/_media.scss \
+	$(srcdir)/data/css/modules/view/_video.scss \
+	$(NULL)
 scss_theme_window_partials = \
 	$(srcdir)/data/css/modules/window/_simple.scss \
 	$(NULL)
@@ -128,10 +128,10 @@ scss_theme_partials = \
 	$(scss_theme_banner_partials) \
 	$(scss_theme_card_partials) \
 	$(scss_theme_content_partials) \
-	$(scss_theme_document_partials) \
 	$(scss_theme_layout_partials) \
 	$(scss_theme_navigation_partials) \
 	$(scss_theme_pager_partials) \
+	$(scss_theme_view_partials) \
 	$(scss_theme_window_partials) \
 	$(scss_theme_widgets_partials) \
 	$(NULL)
@@ -389,9 +389,6 @@ dist_themecard_DATA = $(scss_theme_card_partials)
 themecontentdir = $(thememodulesdir)/contentGroup
 dist_themecontent_DATA = $(scss_theme_content_partials)
 
-themedocumentdir = $(thememodulesdir)/documentCard
-dist_themedocument_DATA = $(scss_theme_document_partials)
-
 themelayoutdir = $(thememodulesdir)/layout
 dist_themelayout_DATA = $(scss_theme_layout_partials)
 
@@ -400,6 +397,9 @@ dist_themenavigation_DATA = $(scss_theme_navigation_partials)
 
 themepagerdir = $(thememodulesdir)/pager
 dist_themepager_DATA = $(scss_theme_pager_partials)
+
+themeviewdir = $(thememodulesdir)/view
+dist_themeview_DATA = $(scss_theme_view_partials)
 
 themewindowdir = $(thememodulesdir)/window
 dist_themewindow_DATA = $(scss_theme_window_partials)
@@ -453,15 +453,11 @@ javascript_tests = \
 	tests/js/app/modules/banner/testDynamic.js \
 	tests/js/app/modules/banner/testSearch.js \
 	tests/js/app/modules/banner/testSet.js \
-	tests/js/app/modules/card/testAudio.js \
 	tests/js/app/modules/card/testDeck.js \
 	tests/js/app/modules/card/testDefault.js \
-	tests/js/app/modules/card/testKnowledgeDocument.js \
 	tests/js/app/modules/card/testList.js \
-	tests/js/app/modules/card/testMedia.js \
 	tests/js/app/modules/card/testSequence.js \
 	tests/js/app/modules/card/testTitle.js \
-	tests/js/app/modules/card/testVideo.js \
 	tests/js/app/modules/contentGroup/testContentGroup.js \
 	tests/js/app/modules/contentGroup/testMediaLightbox.js \
 	tests/js/app/modules/controller/testBuffet.js \
@@ -505,6 +501,10 @@ javascript_tests = \
 	tests/js/app/modules/selection/testSuggested.js \
 	tests/js/app/modules/selection/testSupplementary.js \
 	tests/js/app/modules/selection/testXapian.js \
+	tests/js/app/modules/view/testAudio.js \
+	tests/js/app/modules/view/testDocument.js \
+	tests/js/app/modules/view/testMedia.js \
+	tests/js/app/modules/view/testVideo.js \
 	tests/js/app/modules/window/testSimple.js \
 	tests/js/app/testArticleHTMLRenderer.js \
 	tests/js/app/testBuffetHistoryStore.js \

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ See `js/app/modules/` for the code.
 - **Arrangement** - These modules generally have a `card` slot which a **Card** can go into.
   They arrange a set of dynamically created cards on the screen.
 - **Banner** - These modules represent a piece of data which is presented to the user, such as an app's logo or a search term.
-- **Card** - These modules represent a document in the database of offline content.
+- **Card** - These modules represent a document in the database of offline content, but are not a full **View** of the document.
   They display its metadata (title, keywords) in various ways.
 - **ContentGroup** - This is the heart of displaying offline content.
   Content groups have `selection` and `arrangement` slots.
@@ -111,6 +111,7 @@ See `js/app/modules/` for the code.
   Pager modules contain submodules and display them one at a time, with optional animations between them.
 - **Selection** - These modules retrieve content records from the offline content database.
   A **Selection** serves records through a **ContentGroup** to an **Arrangement**, which turns the records into **Card**s.
+- **View** - These modules display the actual content.
 - **Window** - These modules are the toplevel windows which contain other modules.
 
 Here's a diagram of what contains what, roughly:
@@ -123,6 +124,7 @@ Controller
         Decoration
         Navigation
         (more) Layout
+        View
         ContentGroup
           Arrangement
             Card

--- a/data/css/_base.scss
+++ b/data/css/_base.scss
@@ -17,21 +17,15 @@
 @import 'modules/banner/search';
 @import 'modules/banner/set';
 
-@import 'modules/card/audio';
 @import 'modules/card/base';
 @import 'modules/card/deck';
 @import 'modules/card/default';
-@import 'modules/card/knowledgeDocument';
 @import 'modules/card/list';
-@import 'modules/card/media';
 @import 'modules/card/sequence';
-@import 'modules/card/video';
 
 @import 'modules/contentGroup/contentGroup';
 @import 'modules/contentGroup/mediaLightbox';
 @import 'modules/contentGroup/noResultsMessage';
-
-@import 'modules/documentCard/base';
 
 @import 'modules/layout/dynamicBackground';
 @import 'modules/layout/hamburgerBasement';
@@ -49,6 +43,12 @@
 
 @import 'modules/pager/parallaxBackground';
 @import 'modules/pager/simple';
+
+@import 'modules/view/audio';
+@import 'modules/view/base';
+@import 'modules/view/document';
+@import 'modules/view/media';
+@import 'modules/view/video';
 
 @import 'modules/window/simple';
 

--- a/data/css/modules/view/_audio.scss
+++ b/data/css/modules/view/_audio.scss
@@ -1,4 +1,4 @@
-.CardAudio {
+.ViewAudio {
     padding: 25px;
     &__title {
         font-weight: bold;

--- a/data/css/modules/view/_base.scss
+++ b/data/css/modules/view/_base.scss
@@ -1,4 +1,4 @@
-.DocumentCard {
+.View {
     &__title {
         color: white;
         font-family: $title-font;

--- a/data/css/modules/view/_document.scss
+++ b/data/css/modules/view/_document.scss
@@ -3,7 +3,7 @@ $toc-selected-color: transparentize(white, 1 - 0.10);
 /* This aligns the document title to the TOC entryTitle */
 $toc-align-padding: 15px;
 
-.CardKnowledgeDocument {
+.ViewDocument {
     &__contentFrame {
         padding: 0;
         margin: 0;
@@ -175,7 +175,7 @@ $toc-align-padding: 15px;
         }
     }
 
-    .CardKnowledgeDocument {
+    .ViewDocument {
         &__title {
             font-size: 30px;
             padding: 1.0em 0.5em 0.5em 0.5em;

--- a/data/css/modules/view/_media.scss
+++ b/data/css/modules/view/_media.scss
@@ -1,4 +1,4 @@
-.CardMedia {
+.ViewMedia {
     background-color: white;
 
     &__caption {
@@ -26,8 +26,8 @@
 
 // When both the caption & attribution are present in the lightbox,
 // edit padding to accommodate both
-.CardMedia--withCaption.CardMedia--withAttribution {
-    .CardMedia {
+.ViewMedia--withCaption.ViewMedia--withAttribution {
+    .ViewMedia {
         &__caption {
             padding-bottom: 7px;
         }
@@ -39,7 +39,7 @@
 }
 
 .composite {
-    .CardMedia {
+    .ViewMedia {
         &__caption {
             font-size: 20px;
         }

--- a/data/css/modules/view/_video.scss
+++ b/data/css/modules/view/_video.scss
@@ -1,4 +1,4 @@
-.CardVideo {
+.ViewVideo {
     padding: 20px;
     &__title {
         font-weight: bold;

--- a/data/preset/A.yaml
+++ b/data/preset/A.yaml
@@ -125,9 +125,9 @@ defines:
 - &article-page
   type: Layout.ArticleStack
   slots:
-    card: 'Card.KnowledgeDocument(show-toc: true)'
-    video: 'Card.Video'
-    audio: 'Card.Audio(show-title: false, show-synopsis: false)'
+    article: 'View.Document(show-toc: true)'
+    video: View.Video
+    audio: 'View.Audio(show-title: false, show-synopsis: false)'
 
 root:
   shortdef: 'Controller.Mesh(theme: preset_a)'
@@ -139,7 +139,7 @@ root:
         content:
           type: ContentGroup.MediaLightbox
           slots:
-            card: Card.Media
+            view: View.Media
             content:
               type: Layout.Navigation
               slots:

--- a/data/preset/B.yaml
+++ b/data/preset/B.yaml
@@ -97,12 +97,12 @@ defines:
     content:
       type: Layout.ArticleStack
       slots:
-        card:
-          type: Card.KnowledgeDocument
+        article:
+          type: View.Document
           properties:
             show-titles: false
-        video: 'Card.Video'
-        audio: 'Card.Audio(show-title: false, show-synopsis: false)'
+        video: View.Video
+        audio: 'View.Audio(show-title: false, show-synopsis: false)'
     sidebar:
       type: Layout.InfiniteScrolling
       references:
@@ -126,7 +126,7 @@ root:
         content:
           type: ContentGroup.MediaLightbox
           slots:
-            card: Card.Media
+            view: View.Media
             content:
               type: Layout.Navigation
               slots:

--- a/data/preset/blog.yaml
+++ b/data/preset/blog.yaml
@@ -79,9 +79,9 @@ defines:
   properties:
     do-sliding-animation: false
   slots:
-    card: 'Card.KnowledgeDocument(show-titles: false, show-toc: false)'
-    video: 'Card.Video(show-title: false, show-synopsis: false)'
-    audio: 'Card.Audio(show-title: false, show-synopsis: false)'
+    article: 'View.Document(show-titles: false, show-toc: false)'
+    video: 'View.Video(show-title: false, show-synopsis: false)'
+    audio: 'View.Audio(show-title: false, show-synopsis: false)'
     nav-content:
       type: ContentGroup.ContentGroup
       styles:
@@ -210,7 +210,7 @@ root:
         content:
           type: ContentGroup.MediaLightbox
           slots:
-            card: Card.Media
+            view: View.Media
             content:
               type: Layout.Sidebar
               slots:

--- a/data/preset/buffet.yaml
+++ b/data/preset/buffet.yaml
@@ -301,8 +301,8 @@ defines:
       properties:
         do-sliding-animation: false
       slots:
-        card:
-          type: Card.KnowledgeDocument
+        article:
+          type: View.Document
           properties:
             show-titles: false
             show-toc: false
@@ -344,7 +344,7 @@ root:
             content:
               type: ContentGroup.MediaLightbox
               slots:
-                card: Card.Media
+                view: View.Media
                 content:
                   type: Pager.Simple
                   slots:

--- a/data/preset/encyclopedia.yaml
+++ b/data/preset/encyclopedia.yaml
@@ -77,7 +77,7 @@ defines:
             styles:
               - paper-template
             slots:
-              card: 'Card.KnowledgeDocument(show-titles: false)'
+              article: 'View.Document(show-titles: false)'
 
 root:
   shortdef: 'Controller.Mesh(theme: encyclopedia)'
@@ -88,7 +88,7 @@ root:
         content:
           type: ContentGroup.MediaLightbox
           slots:
-            card: Card.Media
+            view: View.Media
             content:
               type: Pager.Simple
               slots:

--- a/data/preset/gallery.yaml
+++ b/data/preset/gallery.yaml
@@ -508,8 +508,8 @@ defines:
       properties:
         do-sliding-animation: false
       slots:
-        card: 'Card.KnowledgeDocument(show-titles: false, show-toc: false)'
-        video: 'Card.Video(show-title: false, show-synopsis: false)'
+        article: 'View.Document(show-titles: false, show-toc: false)'
+        video: 'View.Video(show-title: false, show-synopsis: false)'
         nav-content:
           type: ContentGroup.ContentGroup
           styles:
@@ -546,7 +546,7 @@ root:
         content:
           type: ContentGroup.MediaLightbox
           slots:
-            card: Card.Media
+            view: View.Media
             content:
               type: Pager.Simple
               slots:

--- a/data/preset/library-list.yaml
+++ b/data/preset/library-list.yaml
@@ -180,9 +180,9 @@ defines:
 - &article-page
   type: Layout.ArticleStack
   slots:
-    card: 'Card.KnowledgeDocument(show-toc: false, show-titles: false)'
-    video: 'Card.Video'
-    audio: 'Card.Audio(show-title: false, show-synopsis: false)'
+    article: 'View.Document(show-toc: false, show-titles: false)'
+    video: View.Video
+    audio: 'View.Audio(show-title: false, show-synopsis: false)'
 
 root:
   shortdef: 'Controller.Mesh(theme: library_list)'
@@ -194,7 +194,7 @@ root:
         content:
           type: ContentGroup.MediaLightbox
           slots:
-            card: Card.Media
+            view: View.Media
             content:
               type: Layout.Navigation
               slots:

--- a/data/preset/news.yaml
+++ b/data/preset/news.yaml
@@ -294,9 +294,9 @@ defines:
       properties:
         do-sliding-animation: false
       slots:
-        card: 'Card.KnowledgeDocument(show-titles: false, show-toc: false)'
-        video: 'Card.Video(show-title: false, show-synopsis: false)'
-        audio: 'Card.Audio(show-title: false, show-synopsis: false)'
+        article: 'View.Document(show-titles: false, show-toc: false)'
+        video: 'View.Video(show-title: false, show-synopsis: false)'
+        audio: 'View.Audio(show-title: false, show-synopsis: false)'
         nav-content:
           type: ContentGroup.ContentGroup
           styles:
@@ -332,7 +332,7 @@ root:
         content:
           type: ContentGroup.MediaLightbox
           slots:
-            card: Card.Media
+            view: View.Media
             content:
               type: Pager.Simple
               slots:

--- a/data/widgets/view/audio.ui
+++ b/data/widgets/view/audio.ui
@@ -2,7 +2,7 @@
 <!-- Generated with glade 3.18.3 -->
 <interface>
   <requires lib="gtk+" version="3.12"/>
-  <template class="EknCard_Audio" parent="GtkGrid">
+  <template class="EknView_Audio" parent="GtkGrid">
     <property name="visible">True</property>
     <property name="can_focus">False</property>
     <child>
@@ -16,8 +16,8 @@
         <property name="max_width_chars">25</property>
         <property name="lines">1</property>
         <style>
-          <class name="CardAudio__title"/>
-          <class name="Card__title"/>
+          <class name="ViewAudio__title"/>
+          <class name="View__title"/>
         </style>
       </object>
       <packing>
@@ -41,8 +41,8 @@
         <property name="lines">8</property>
         <property name="xalign">0</property>
         <style>
-          <class name="CardAudio__synopsis"/>
-          <class name="Card__synopsis"/>
+          <class name="ViewAudio__synopsis"/>
+          <class name="View__synopsis"/>
         </style>
       </object>
       <packing>

--- a/data/widgets/view/document.ui
+++ b/data/widgets/view/document.ui
@@ -2,7 +2,7 @@
 <!-- Generated with glade 3.18.3 -->
 <interface>
   <requires lib="gtk+" version="3.12"/>
-  <template class="EknCard_KnowledgeDocument" parent="EosCustomContainer">
+  <template class="EknView_Document" parent="EosCustomContainer">
     <property name="can_focus">False</property>
     <child>
       <object class="GtkFrame" id="toolbar-frame">
@@ -28,9 +28,8 @@
                 <property name="lines">5</property>
                 <property name="xalign">0</property>
                 <style>
-                  <class name="CardKnowledgeDocument__title"/>
-                  <class name="DocumentCard__title"/>
-                  <class name="Card__title"/>
+                  <class name="ViewDocument__title"/>
+                  <class name="View__title"/>
                 </style>
               </object>
               <packing>
@@ -54,7 +53,7 @@
           </object>
         </child>
         <style>
-          <class name="CardKnowledgeDocument__toolbarFrame"/>
+          <class name="ViewDocument__toolbarFrame"/>
         </style>
       </object>
     </child>
@@ -87,9 +86,8 @@
                     <property name="ellipsize">end</property>
                     <property name="max_width_chars">1</property>
                     <style>
-                      <class name="CardKnowledgeDocument__title"/>
-                      <class name="DocumentCard__title"/>
-                      <class name="Card__title"/>
+                      <class name="ViewDocument__title"/>
+                      <class name="View__title"/>
                       <class name="collapsed"/>
                     </style>
                   </object>
@@ -127,8 +125,8 @@
           </object>
         </child>
         <style>
-          <class name="CardKnowledgeDocument__contentFrame"/>
-          <class name="Card__contentFrame"/>
+          <class name="ViewDocument__contentFrame"/>
+          <class name="View__contentFrame"/>
         </style>
       </object>
     </child>

--- a/data/widgets/view/media.ui
+++ b/data/widgets/view/media.ui
@@ -2,7 +2,7 @@
 <!-- Generated with glade 3.18.3 -->
 <interface>
   <requires lib="gtk+" version="3.12"/>
-  <template class="EknCard_Media" parent="GtkFrame">
+  <template class="EknView_Media" parent="GtkFrame">
     <property name="visible">True</property>
     <property name="can_focus">False</property>
     <property name="label_xalign">0</property>
@@ -24,7 +24,7 @@
             <property name="lines">5</property>
             <property name="xalign">0</property>
             <style>
-              <class name="CardMedia__caption"/>
+              <class name="ViewMedia__caption"/>
             </style>
           </object>
           <packing>
@@ -49,7 +49,7 @@
               </object>
             </child>
             <style>
-              <class name="CardMedia__attributionText"/>
+              <class name="ViewMedia__attributionText"/>
             </style>
           </object>
           <packing>

--- a/data/widgets/view/video.ui
+++ b/data/widgets/view/video.ui
@@ -2,7 +2,7 @@
 <!-- Generated with glade 3.18.3 -->
 <interface>
   <requires lib="gtk+" version="3.12"/>
-  <template class="EknCard_Video" parent="GtkGrid">
+  <template class="EknView_Video" parent="GtkGrid">
     <property name="visible">True</property>
     <property name="can_focus">False</property>
     <child>
@@ -16,8 +16,8 @@
         <property name="max_width_chars">25</property>
         <property name="lines">1</property>
         <style>
-          <class name="CardVideo__title"/>
-          <class name="Card__title"/>
+          <class name="ViewVideo__title"/>
+          <class name="View__title"/>
         </style>
       </object>
       <packing>
@@ -41,7 +41,7 @@
         <property name="lines">8</property>
         <property name="xalign">0</property>
         <style>
-          <class name="Card__synopsis"/>
+          <class name="View__synopsis"/>
         </style>
       </object>
       <packing>

--- a/eos-knowledge.gresource.xml
+++ b/eos-knowledge.gresource.xml
@@ -52,15 +52,11 @@
     <file compressed="true" preprocess="xml-stripblanks">data/widgets/banner/app.ui</file>
     <file compressed="true" preprocess="xml-stripblanks">data/widgets/banner/dynamic.ui</file>
     <file compressed="true" preprocess="xml-stripblanks">data/widgets/banner/search.ui</file>
-    <file compressed="true" preprocess="xml-stripblanks">data/widgets/card/audio.ui</file>
     <file compressed="true" preprocess="xml-stripblanks">data/widgets/card/deck.ui</file>
     <file compressed="true" preprocess="xml-stripblanks">data/widgets/card/default.ui</file>
-    <file compressed="true" preprocess="xml-stripblanks">data/widgets/card/knowledgeDocument.ui</file>
     <file compressed="true" preprocess="xml-stripblanks">data/widgets/card/list.ui</file>
-    <file compressed="true" preprocess="xml-stripblanks">data/widgets/card/media.ui</file>
     <file compressed="true" preprocess="xml-stripblanks">data/widgets/card/sequence.ui</file>
     <file compressed="true" preprocess="xml-stripblanks">data/widgets/card/title.ui</file>
-    <file compressed="true" preprocess="xml-stripblanks">data/widgets/card/video.ui</file>
     <file compressed="true" preprocess="xml-stripblanks">data/widgets/contentGroup/noResultsMessage.ui</file>
     <file compressed="true" preprocess="xml-stripblanks">data/widgets/contentGroup/contentGroup.ui</file>
     <file compressed="true" preprocess="xml-stripblanks">data/widgets/layout/hamburgerBasement.ui</file>
@@ -68,6 +64,10 @@
     <file compressed="true" preprocess="xml-stripblanks">data/widgets/layout/sideMenu.ui</file>
     <file compressed="true" preprocess="xml-stripblanks">data/widgets/layout/topMenu.ui</file>
     <file compressed="true" preprocess="xml-stripblanks">data/widgets/tooltips.ui</file>
+    <file compressed="true" preprocess="xml-stripblanks">data/widgets/view/audio.ui</file>
+    <file compressed="true" preprocess="xml-stripblanks">data/widgets/view/document.ui</file>
+    <file compressed="true" preprocess="xml-stripblanks">data/widgets/view/media.ui</file>
+    <file compressed="true" preprocess="xml-stripblanks">data/widgets/view/video.ui</file>
     <file>js/app/actions.js</file>
     <file>js/app/application.js</file>
     <file>js/app/articleHTMLRenderer.js</file>
@@ -86,6 +86,7 @@
     <file>js/app/interfaces/module.js</file>
     <file>js/app/interfaces/navigationCard.js</file>
     <file>js/app/interfaces/order.js</file>
+    <file>js/app/interfaces/view.js</file>
     <file>js/app/introspect.js</file>
     <file>js/app/knowledge.js</file>
     <file>js/app/libs/mustache.js</file>
@@ -112,16 +113,12 @@
     <file>js/app/modules/banner/dynamic.js</file>
     <file>js/app/modules/banner/search.js</file>
     <file>js/app/modules/banner/set.js</file>
-    <file>js/app/modules/card/audio.js</file>
     <file>js/app/modules/card/contentGroup.js</file>
     <file>js/app/modules/card/deck.js</file>
     <file>js/app/modules/card/default.js</file>
-    <file>js/app/modules/card/knowledgeDocument.js</file>
     <file>js/app/modules/card/list.js</file>
-    <file>js/app/modules/card/media.js</file>
     <file>js/app/modules/card/sequence.js</file>
     <file>js/app/modules/card/title.js</file>
-    <file>js/app/modules/card/video.js</file>
     <file>js/app/modules/contentGroup/contentGroup.js</file>
     <file>js/app/modules/contentGroup/dynamicTitle.js</file>
     <file>js/app/modules/contentGroup/mediaLightbox.js</file>
@@ -173,6 +170,10 @@
     <file>js/app/modules/selection/suggested.js</file>
     <file>js/app/modules/selection/supplementary.js</file>
     <file>js/app/modules/selection/xapian.js</file>
+    <file>js/app/modules/view/audio.js</file>
+    <file>js/app/modules/view/document.js</file>
+    <file>js/app/modules/view/media.js</file>
+    <file>js/app/modules/view/video.js</file>
     <file>js/app/modules/window/simple.js</file>
     <file>js/app/moltresEngine.js</file>
     <file>js/app/pages.js</file>

--- a/js/app/interfaces/arrangement.js
+++ b/js/app/interfaces/arrangement.js
@@ -127,7 +127,7 @@ var Arrangement = new Lang.Interface({
         card.make_ready();
 
         // It's either this or have Card require Gtk.Button, but that would be
-        // very bad for DocumentCards.
+        // very bad for Card.ContentGroup.
         if (GObject.signal_lookup('clicked', card.constructor.$gtype) !== 0) {
             card.connect('clicked', card => {
                 this.emit('card-clicked', card.model);

--- a/js/app/interfaces/articleContent.js
+++ b/js/app/interfaces/articleContent.js
@@ -2,19 +2,19 @@ const GObject = imports.gi.GObject;
 const Gtk = imports.gi.Gtk;
 const Lang = imports.lang;
 
-const Card = imports.app.interfaces.card;
+const {View} = imports.app.interfaces.view;
 
 /**
  * Interface: ArticleContent
  * Interface for article content modules
  *
  * Requires:
- *   <Card>
+ *   <View>
  */
 var ArticleContent = new Lang.Interface({
     Name: 'ArticleContent',
     GTypeName: 'EknArticleContent',
-    Requires: [ Card.Card ],
+    Requires: [View],
 
     Properties: {
         /**

--- a/js/app/interfaces/card.js
+++ b/js/app/interfaces/card.js
@@ -21,6 +21,7 @@ const Module = imports.app.interfaces.module;
 const SetMap = imports.app.setMap;
 const SpaceContainer = imports.app.widgets.spaceContainer;
 const Utils = imports.app.utils;
+const {View} = imports.app.interfaces.view;
 
 String.prototype.format = Format.format;
 let ngettext = Gettext.dngettext.bind(null, Config.GETTEXT_PACKAGE);
@@ -122,7 +123,7 @@ var MaxSize = {
  * Interface for card modules
  *
  * Requires:
- *   Gtk.Widget
+ *   Gtk.Widget, View
  *
  * CSS classes:
  *   Card--pdf, <class>--pdf - Added when the card is displaying a PDF record
@@ -130,27 +131,9 @@ var MaxSize = {
 var Card = new Lang.Interface({
     Name: 'Card',
     GTypeName: 'EknCard',
-    Requires: [ Gtk.Widget, Module.Module ],
+    Requires: [Gtk.Widget, Module.Module, View],
 
     Properties: {
-        /**
-         * Property: model
-         * Record backing this card
-         *
-         * Every card is backed by a record in the database.
-         * A card's record is represented by a <ContentObjectModel> or one of
-         * its subclasses.
-         *
-         * Type:
-         *   <ContentObjectModel>
-         *
-         * Flags:
-         *   Construct only
-         */
-        'model': GObject.ParamSpec.object('model', 'Model',
-            'Card model with which to create this card',
-            GObject.ParamFlags.READWRITE | GObject.ParamFlags.CONSTRUCT_ONLY,
-            Eknc.ContentObjectModel),
         /**
          * Property: highlight-string
          * A substring within a card's title or synopsis to get highlighted
@@ -259,16 +242,6 @@ var Card = new Lang.Interface({
     // Overridable in tests; otherwise keep synchronized with the CSS
     FADE_IN_TIME_MS: 1000,
     NUM_STYLE_VARIANTS: 3,
-
-    /**
-     * Method: set_label_or_hide
-     *
-     * Sets a label contents and hides if contents is empty.
-     */
-    set_label_or_hide: function (label, text) {
-        label.label = GLib.markup_escape_text(text, -1);
-        label.visible = !!text;
-    },
 
     set_duration_label: function (label, duration) {
         if (typeof duration !== 'undefined') {
@@ -485,18 +458,6 @@ var Card = new Lang.Interface({
         let span = Utils.style_context_to_markup_span(label.get_style_context(), Gtk.StateFlags.NORMAL);
         context.restore();
         label.label = title.replace(regex, span + '$1</span>');
-    },
-
-    /**
-     * Method: set_title_label_from_model
-     *
-     * Sets up a label to show the model's title.
-     */
-    set_title_label_from_model: function (label) {
-        this.set_label_or_hide(label, this.model.title);
-        let context = label.get_style_context();
-        context.add_class(Utils.get_element_style_class('Card', 'title'));
-        context.add_class(Utils.get_element_style_class(this.constructor, 'title'));
     },
 
     /**

--- a/js/app/interfaces/view.js
+++ b/js/app/interfaces/view.js
@@ -1,0 +1,64 @@
+const Eknc = imports.gi.EosKnowledgeContent;
+const GLib = imports.gi.GLib;
+const GObject = imports.gi.GObject;
+const Gtk = imports.gi.Gtk;
+const Lang = imports.lang;
+
+const {Module} = imports.app.interfaces.module;
+const Utils = imports.app.utils;
+
+/**
+ * Interface: View
+ * Interface for modules that show a database record
+ *
+ * Requires:
+ *   Gtk.Widget
+ */
+var View = new Lang.Interface({
+    Name: 'View',
+    GTypeName: 'EknView',
+    Requires: [Gtk.Widget, Module],
+
+    Properties: {
+        /**
+         * Property: model
+         * Record backing this view
+         *
+         * Every view is backed by a record in the database.
+         * A view's record is represented by a <ContentObjectModel> or one of
+         * its subclasses.
+         *
+         * Type:
+         *   <ContentObjectModel>
+         *
+         * Flags:
+         *   Construct only
+         */
+        'model': GObject.ParamSpec.object('model', 'Model',
+            'Model with which to create this view',
+            GObject.ParamFlags.READWRITE | GObject.ParamFlags.CONSTRUCT_ONLY,
+            Eknc.ContentObjectModel),
+    },
+
+    /**
+     * Method: set_label_or_hide
+     *
+     * Sets a label contents and hides if contents is empty.
+     */
+    set_label_or_hide: function (label, text) {
+        label.label = GLib.markup_escape_text(text, -1);
+        label.visible = !!text;
+    },
+
+    /**
+     * Method: set_title_label_from_model
+     *
+     * Sets up a label to show the model's title.
+     */
+    set_title_label_from_model: function (label) {
+        this.set_label_or_hide(label, this.model.title);
+        let context = label.get_style_context();
+        context.add_class(Utils.get_element_style_class('View', 'title'));
+        context.add_class(Utils.get_element_style_class(this.constructor, 'title'));
+    },
+});

--- a/js/app/modules/card/contentGroup.js
+++ b/js/app/modules/card/contentGroup.js
@@ -3,6 +3,7 @@
 const Card = imports.app.interfaces.card;
 const Module = imports.app.interfaces.module;
 const ContentGroupSuper = imports.app.modules.contentGroup.contentGroup;
+const {View} = imports.app.interfaces.view;
 
 /**
  * Class: ContentGroup
@@ -18,7 +19,7 @@ const ContentGroupSuper = imports.app.modules.contentGroup.contentGroup;
 var ContentGroup = new Module.Class({
     Name: 'Card.ContentGroup',
     Extends: ContentGroupSuper.ContentGroup,
-    Implements: [Card.Card],
+    Implements: [View, Card.Card],
 
     _init: function (props={}) {
         this.parent(props);

--- a/js/app/modules/card/deck.js
+++ b/js/app/modules/card/deck.js
@@ -8,6 +8,7 @@ const Gtk = imports.gi.Gtk;
 const Card = imports.app.interfaces.card;
 const Module = imports.app.interfaces.module;
 const Utils = imports.app.utils;
+const {View} = imports.app.interfaces.view;
 
 /**
  * Class: Deck
@@ -25,7 +26,7 @@ const Utils = imports.app.utils;
 var Deck = new Module.Class({
     Name: 'Card.Deck',
     Extends: Gtk.Button,
-    Implements: [Card.Card],
+    Implements: [View, Card.Card],
 
     Template: 'resource:///com/endlessm/knowledge/data/widgets/card/deck.ui',
     InternalChildren: ['overlay', 'shadow-frame', 'thumbnail-frame',

--- a/js/app/modules/card/default.js
+++ b/js/app/modules/card/default.js
@@ -15,6 +15,7 @@ const Card = imports.app.interfaces.card;
 const Knowledge = imports.app.knowledge;
 const Module = imports.app.interfaces.module;
 const Utils = imports.app.utils;
+const {View} = imports.app.interfaces.view;
 
 const CardType = {
     LOW_RES_IMAGE: 0,
@@ -53,7 +54,7 @@ const CARD_POLAROID_VERTICAL_HEIGHTS = {
 var Default = new Module.Class({
     Name: 'Card.Default',
     Extends: Gtk.Button,
-    Implements: [Card.Card],
+    Implements: [View, Card.Card],
 
     Template: 'resource:///com/endlessm/knowledge/data/widgets/card/default.ui',
     InternalChildren: [ 'layout', 'inner-content-grid', 'thumbnail-frame',

--- a/js/app/modules/card/list.js
+++ b/js/app/modules/card/list.js
@@ -10,6 +10,7 @@ const Module = imports.app.interfaces.module;
 const ReadingHistoryModel = imports.app.readingHistoryModel;
 const ThemeableImage = imports.app.widgets.themeableImage;
 const Utils = imports.app.utils;
+const {View} = imports.app.interfaces.view;
 
 /**
  * Class: List
@@ -19,7 +20,7 @@ const Utils = imports.app.utils;
 var List = new Module.Class({
     Name: 'Card.List',
     Extends: Gtk.Button,
-    Implements: [Card.Card, NavigationCard.NavigationCard],
+    Implements: [View, Card.Card, NavigationCard.NavigationCard],
 
     Properties: {
         /**

--- a/js/app/modules/card/sequence.js
+++ b/js/app/modules/card/sequence.js
@@ -6,6 +6,7 @@ const Card = imports.app.interfaces.card;
 const Module = imports.app.interfaces.module;
 const NavigationCard = imports.app.interfaces.navigationCard;
 const Utils = imports.app.utils;
+const {View} = imports.app.interfaces.view;
 
 /**
  * Class: Sequence
@@ -23,7 +24,7 @@ const Utils = imports.app.utils;
 var Sequence = new Module.Class({
     Name: 'Card.Sequence',
     Extends: Gtk.Button,
-    Implements: [Card.Card, NavigationCard.NavigationCard],
+    Implements: [View, Card.Card, NavigationCard.NavigationCard],
 
     Template: 'resource:///com/endlessm/knowledge/data/widgets/card/sequence.ui',
     InternalChildren: [ 'title-label', 'next-label', 'previous-label' ],

--- a/js/app/modules/card/title.js
+++ b/js/app/modules/card/title.js
@@ -11,6 +11,7 @@ const NavigationCard = imports.app.interfaces.navigationCard;
 // Make sure included for glade template
 const ThemeableImage = imports.app.widgets.themeableImage;
 const Utils = imports.app.utils;
+const {View} = imports.app.interfaces.view;
 
 /**
  * Class: Title
@@ -28,7 +29,7 @@ const Utils = imports.app.utils;
 var Title = new Module.Class({
     Name: 'Card.Title',
     Extends: Gtk.Button,
-    Implements: [Card.Card, NavigationCard.NavigationCard],
+    Implements: [View, Card.Card, NavigationCard.NavigationCard],
 
     Properties: {
         /**

--- a/js/app/modules/contentGroup/mediaLightbox.js
+++ b/js/app/modules/contentGroup/mediaLightbox.js
@@ -19,7 +19,7 @@ var MediaLightbox = new Module.Class({
     Extends: Lightbox.Lightbox,
 
     Slots: {
-        'card': {
+        'view': {
             multi: true,
         },
         'content': {},
@@ -121,7 +121,7 @@ var MediaLightbox = new Module.Class({
             this.lightbox_widget = null;
         }
 
-        let widget = this.create_submodule('card', {
+        let widget = this.create_submodule('view', {
             model: media_object
         });
 

--- a/js/app/modules/layout/articleStack.js
+++ b/js/app/modules/layout/articleStack.js
@@ -11,7 +11,6 @@ const Gtk = imports.gi.Gtk;
 const WebKit2 = imports.gi.WebKit2;
 
 const Actions = imports.app.actions;
-const Card = imports.app.interfaces.card;
 const Config = imports.app.config;
 const Dispatcher = imports.app.dispatcher;
 const HistoryStore = imports.app.historyStore;
@@ -55,7 +54,7 @@ var ArticleStack = new Module.Class({
     },
 
     Slots: {
-        'card': {
+        'article': {
             multi: true,
         },
         'nav-content': {
@@ -162,7 +161,7 @@ var ArticleStack = new Module.Class({
         if (nav_content)
             article_content_props.nav_content = nav_content;
 
-        let slot = 'card';
+        let slot = 'article';
         if (model instanceof Eknc.VideoObjectModel) {
             slot = 'video';
         } else if (model instanceof Eknc.AudioObjectModel) {

--- a/js/app/modules/view/audio.js
+++ b/js/app/modules/view/audio.js
@@ -1,29 +1,39 @@
-// Copyright 2016 Endless Mobile, Inc.
+// Copyright 2017 Endless Mobile, Inc.
 
 const GObject = imports.gi.GObject;
 const Gtk = imports.gi.Gtk;
 
 const ArticleContent = imports.app.interfaces.articleContent;
-const Card = imports.app.interfaces.card;
 const EosKnowledgePrivate = imports.gi.EosKnowledgePrivate;
 const Module = imports.app.interfaces.module;
+const {View} = imports.app.interfaces.view;
 
 // Make sure included for glade template
+const FormattableLabel = imports.app.widgets.formattableLabel;
 const Utils = imports.app.utils;
 
 /**
- * Class: Video
+ * Class: Audio
  *
- * A card for displaying video content.
+ * A card for displaying audio content
+ *
+ * This widget displays the title if enabled via properties, the synopsis if
+ * included in the object model, and the player for reproducing the audio.
+ *
+ * Style classes:
+ * - ViewAudio - on the widget itself
+ * - ViewAudio__title - on the title label
+ * - ViewAudio__synopsis - on the synopsis label
+ * - ViewAudio__player - on the audio player
  */
-var Video = new Module.Class({
-    Name: 'Card.Video',
+var Audio = new Module.Class({
+    Name: 'View.Audio',
     Extends: Gtk.Grid,
-    Implements: [Card.Card, ArticleContent.ArticleContent],
+    Implements: [View, ArticleContent.ArticleContent],
 
     Properties: {
         /**
-         * Property: show-titles
+         * Property: show-title
          *
          * Set true if the title label should be visible.
          */
@@ -40,7 +50,7 @@ var Video = new Module.Class({
             GObject.ParamFlags.READWRITE | GObject.ParamFlags.CONSTRUCT_ONLY, true),
     },
 
-    Template: 'resource:///com/endlessm/knowledge/data/widgets/card/video.ui',
+    Template: 'resource:///com/endlessm/knowledge/data/widgets/view/audio.ui',
     InternalChildren: [ 'title-label', 'synopsis-label' ],
 
     _init: function (props={}) {
@@ -51,16 +61,12 @@ var Video = new Module.Class({
 
         this._title_label.visible = this.show_title;
         this._synopsis_label.visible = this.show_synopsis;
-        let video_player = new EosKnowledgePrivate.MediaBin( {
-            visible: true,
-            uri: this.model.ekn_id,
-            title: this.model.title,
-            description: this.model.synopsis,
-        });
-        video_player.get_style_context().add_class(Utils.get_element_style_class(Video, 'player'));
-        video_player.show_all();
-        this.attach(video_player, 1, 1, 1, 1);
-        this.content_view = video_player;
+        let player = new EosKnowledgePrivate.MediaBin({ audio_mode: true });
+        player.get_style_context().add_class(Utils.get_element_style_class(Audio, 'player'));
+        player.set_uri(this.model.ekn_id)
+        player.show_all();
+        this.attach(player, 0, 3, 1, 1);
+        this.content_view = player;
     },
 
     load_content_promise: function () {

--- a/js/app/modules/view/document.js
+++ b/js/app/modules/view/document.js
@@ -9,7 +9,6 @@ const Gtk = imports.gi.Gtk;
 const WebKit2 = imports.gi.WebKit2;
 
 const ArticleContent = imports.app.interfaces.articleContent;
-const Card = imports.app.interfaces.card;
 const EknWebview = imports.app.widgets.eknWebview;
 const HistoryStore = imports.app.historyStore;
 const InArticleSearch = imports.app.widgets.inArticleSearch;
@@ -19,28 +18,27 @@ const PDFView = imports.app.widgets.PDFView;
 const SlidingPanelOverlay = imports.app.widgets.slidingPanelOverlay;
 const TableOfContents = imports.app.widgets.tableOfContents;
 const Utils = imports.app.utils;
+const {View} = imports.app.interfaces.view;
 
 const SPINNER_PAGE_NAME = 'spinner';
 const CONTENT_PAGE_NAME = 'content';
 const SCROLLED_PAST_PREFIX = 'scrolled-past-';
 
 /**
- * Class: KnowledgeDocument
- *
- * A card implementation for showing entire documents of content.
+ * Class: Document
+ * A view of an HTML or PDF document, with scrolling
  *
  * This widget will handle toggling the <TableOfContents.collapsed> parameter
  * of the table of contents depending on available space. It provides two
- * internal frames with style classes
- * 'CardKnowledgeDocument__toolbarFrame' and
- * 'CardKnowledgeDocument__contentFrame' for theming purposes.
+ * internal frames with style classes `ViewDocument__toolbarFrame` and
+ * `ViewDocument__contentFrame` for theming purposes.
  * The toolbar frame surrounds the <title> and <toc> on the right. The
  * content frame surrounds the <webview> on the left.
  */
-var KnowledgeDocument = new Module.Class({
-    Name: 'Card.KnowledgeDocument',
+var Document = new Module.Class({
+    Name: 'View.Document',
     Extends: Endless.CustomContainer,
-    Implements: [Card.Card, ArticleContent.ArticleContent],
+    Implements: [View, ArticleContent.ArticleContent],
 
     Properties: {
         /**
@@ -71,7 +69,7 @@ var KnowledgeDocument = new Module.Class({
             TableOfContents.TableOfContents.$gtype),
     },
 
-    Template: 'resource:///com/endlessm/knowledge/data/widgets/card/knowledgeDocument.ui',
+    Template: 'resource:///com/endlessm/knowledge/data/widgets/view/document.ui',
     InternalChildren: [ 'title-label', 'top-title-label', 'toolbar-frame',
         'content-frame', 'content-grid', 'panel-overlay', 'spinner', 'stack' ],
     Children: [ 'toc' ],
@@ -335,7 +333,7 @@ var KnowledgeDocument = new Module.Class({
         }
         this._toolbar_frame.set_child_visible(true);
 
-        let collapsed_class = Utils.get_modifier_style_class('CardKnowledgeDocument__toolbarFrame', 'collapsed');
+        let collapsed_class = Utils.get_modifier_style_class('ViewDocument__toolbarFrame', 'collapsed');
         // Decide if toolbar should be collapsed
         if (this._should_collapse(alloc.width)) {
             if (!this.toc.collapsed) {

--- a/js/app/modules/view/media.js
+++ b/js/app/modules/view/media.js
@@ -3,10 +3,10 @@ const Gdk = imports.gi.Gdk;
 const Gio = imports.gi.Gio;
 const Gtk = imports.gi.Gtk;
 
-const Card = imports.app.interfaces.card;
 const Module = imports.app.interfaces.module;
 const Previewer = imports.app.widgets.previewer;
 const Utils = imports.app.utils;
+const {View} = imports.app.interfaces.view;
 
 /**
  * Class: Media
@@ -15,11 +15,11 @@ const Utils = imports.app.utils;
  * used with a MediaObject Model.
  */
 var Media = new Module.Class({
-    Name: 'Card.Media',
+    Name: 'View.Media',
     Extends: Gtk.Frame,
-    Implements: [Card.Card],
+    Implements: [View],
 
-    Template: 'resource:///com/endlessm/knowledge/data/widgets/card/media.ui',
+    Template: 'resource:///com/endlessm/knowledge/data/widgets/view/media.ui',
     InternalChildren: [ 'caption-label', 'attribution-label', 'grid',
         'attribution-button'],
 

--- a/js/app/modules/view/video.js
+++ b/js/app/modules/view/video.js
@@ -1,38 +1,29 @@
-// Copyright 2017 Endless Mobile, Inc.
+// Copyright 2016 Endless Mobile, Inc.
 
 const GObject = imports.gi.GObject;
 const Gtk = imports.gi.Gtk;
 
 const ArticleContent = imports.app.interfaces.articleContent;
-const Card = imports.app.interfaces.card;
 const EosKnowledgePrivate = imports.gi.EosKnowledgePrivate;
 const Module = imports.app.interfaces.module;
+const {View} = imports.app.interfaces.view;
 
 // Make sure included for glade template
 const Utils = imports.app.utils;
 
 /**
- * Class: Audio
+ * Class: Video
  *
- * A card for displaying audio content
- *
- * This widget displays the title if enabled via properties, the synopsis if
- * included in the object model, and the player for reproducing the audio.
- *
- * Style classes:
- *   CardAudio - on the widget itself
- *   CardAudio__title - on the title label
- *   CardAudio__synopsis - on the synopsis label
- *   CardAudio__player - on the audio player
+ * A card for displaying video content.
  */
-var Audio = new Module.Class({
-    Name: 'Card.Audio',
+var Video = new Module.Class({
+    Name: 'View.Video',
     Extends: Gtk.Grid,
-    Implements: [Card.Card, ArticleContent.ArticleContent],
+    Implements: [View, ArticleContent.ArticleContent],
 
     Properties: {
         /**
-         * Property: show-title
+         * Property: show-titles
          *
          * Set true if the title label should be visible.
          */
@@ -49,7 +40,7 @@ var Audio = new Module.Class({
             GObject.ParamFlags.READWRITE | GObject.ParamFlags.CONSTRUCT_ONLY, true),
     },
 
-    Template: 'resource:///com/endlessm/knowledge/data/widgets/card/audio.ui',
+    Template: 'resource:///com/endlessm/knowledge/data/widgets/view/video.ui',
     InternalChildren: [ 'title-label', 'synopsis-label' ],
 
     _init: function (props={}) {
@@ -60,12 +51,16 @@ var Audio = new Module.Class({
 
         this._title_label.visible = this.show_title;
         this._synopsis_label.visible = this.show_synopsis;
-        let player = new EosKnowledgePrivate.MediaBin({ audio_mode: true });
-        player.get_style_context().add_class(Utils.get_element_style_class(Audio, 'player'));
-        player.set_uri(this.model.ekn_id)
-        player.show_all();
-        this.attach(player, 0, 3, 1, 1);
-        this.content_view = player;
+        let video_player = new EosKnowledgePrivate.MediaBin( {
+            visible: true,
+            uri: this.model.ekn_id,
+            title: this.model.title,
+            description: this.model.synopsis,
+        });
+        video_player.get_style_context().add_class(Utils.get_element_style_class(Video, 'player'));
+        video_player.show_all();
+        this.attach(video_player, 1, 1, 1, 1);
+        this.content_view = video_player;
     },
 
     load_content_promise: function () {

--- a/js/app/warehouse.js
+++ b/js/app/warehouse.js
@@ -27,7 +27,7 @@ var Warehouse = new Knowledge.Class({
                 let file_name = module_path.charAt(0).toLowerCase() + module_path.slice(1);
                 // If it's the last member of the path, then we need to add the module name to
                 // reference the actual class we want to retrieve.
-                // e.g. Card.Media --> card.media.Media
+                // e.g. View.Media --> view.media.Media
                 if (idx === arr.length - 1) {
                     return current_dir[file_name][module_path];
                 }

--- a/tests/js/app/modules/contentGroup/testMediaLightbox.js
+++ b/tests/js/app/modules/contentGroup/testMediaLightbox.js
@@ -27,7 +27,7 @@ describe('ContentGroup.MediaLightbox', function () {
         [module, factory] = MockFactory.setup_tree({
             type: MediaLightbox.MediaLightbox,
             slots: {
-                'card': { type: Minimal.MinimalCard },
+                'view': { type: Minimal.MinimalCard },
                 'content': { type: null },
             },
         });
@@ -61,7 +61,7 @@ describe('ContentGroup.MediaLightbox', function () {
             context: article_model.resources,
             media_model: media_model,
         });
-        expect(factory.get_created('card').length).toBe(1);
+        expect(factory.get_created('view').length).toBe(1);
 
         let nonexistent_media_object = Eknc.MediaObjectModel.new_from_props({
             ekn_id: 'ekn://no/media',
@@ -71,7 +71,7 @@ describe('ContentGroup.MediaLightbox', function () {
             context: article_model.resources,
             media_model: nonexistent_media_object,
         });
-        expect(factory.get_created('card').length).toBe(1);
+        expect(factory.get_created('view').length).toBe(1);
     });
 
     it('closes the lightbox on history item without media model', function () {

--- a/tests/js/app/modules/layout/testArticleStack.js
+++ b/tests/js/app/modules/layout/testArticleStack.js
@@ -20,7 +20,7 @@ const WidgetDescendantMatcher = imports.tests.WidgetDescendantMatcher;
 Gtk.init(null);
 
 describe('Layout.ArticleStack', function () {
-    let module, card, selection, root, factory, dispatcher, article_model;
+    let module, view, selection, root, factory, dispatcher, article_model;
     let store;
 
     beforeEach(function () {
@@ -40,7 +40,7 @@ describe('Layout.ArticleStack', function () {
                         'selection': 'selection',
                     },
                     slots: {
-                        'card': { type: Minimal.MinimalDocumentCard },
+                        'article': { type: Minimal.MinimalView },
                     },
                 },
                 {
@@ -72,11 +72,11 @@ describe('Layout.ArticleStack', function () {
         });
 
         selection = factory.get_last_created('contents.selection');
-        card = factory.get_last_created('contents.card.0');
+        view = factory.get_last_created('contents.article.0');
     });
 
     it('transitions in new content when state changes to article page', function () {
-        expect(module).toHaveDescendant(card);
+        expect(module).toHaveDescendant(view);
     });
 
     it('shows the article without animation when first loading the article page', function () {
@@ -85,7 +85,7 @@ describe('Layout.ArticleStack', function () {
 
     it('dispatches article link clicked', function () {
         let id = 'ekn://foo/bar';
-        card.emit('ekn-link-clicked', id);
+        view.emit('ekn-link-clicked', id);
         let payload = dispatcher.last_payload_with_type(Actions.ARTICLE_LINK_CLICKED);
         expect(payload.ekn_id).toBe(id);
     });
@@ -96,16 +96,16 @@ describe('Layout.ArticleStack', function () {
         selection.get_models.and.returnValue([different_article_model]);
         selection.emit('models-changed');
         Utils.update_gui();
-        let new_card = factory.get_created('contents.card.1')[0];
-        expect(new_card).toBeDefined();
-        expect(module).toHaveDescendant(new_card);
+        let new_view = factory.get_created('contents.article.1')[0];
+        expect(new_view).toBeDefined();
+        expect(module).toHaveDescendant(new_view);
     });
 
     it('still works without a selection reference', function () {
         [module, factory] = new MockFactory.setup_tree({
             type: ArticleStack.ArticleStack,
             slots: {
-                'card': { type: Minimal.MinimalDocumentCard },
+                'article': { type: Minimal.MinimalView },
             },
         });
         expect(module).toBeDefined();

--- a/tests/js/app/modules/view/testAudio.js
+++ b/tests/js/app/modules/view/testAudio.js
@@ -4,49 +4,41 @@ const Gtk = imports.gi.Gtk;
 const Utils = imports.tests.utils;
 Utils.register_gresource();
 
-const Compliance = imports.tests.compliance;
+const {Audio} = imports.app.modules.view.audio;
 const CssClassMatcher = imports.tests.CssClassMatcher;
 const EosKnowledgePrivate = imports.gi.EosKnowledgePrivate;
-const Video = imports.app.modules.card.video;
 const WidgetDescendantMatcher = imports.tests.WidgetDescendantMatcher;
 
 Gtk.init(null);
 
-describe('Card.Video', function () {
-    let card;
+describe('View.Audio', function () {
+    let view;
 
     beforeEach(function () {
         jasmine.addMatchers(CssClassMatcher.customMatchers);
         jasmine.addMatchers(WidgetDescendantMatcher.customMatchers);
-        card = new Video.Video({
+        view = new Audio({
             model: Eknc.ContentObjectModel.new_from_props({
                 title: '!!!',
             }),
         });
-        card.content_view.title = '';
-        card.content_view.description = '';
     });
 
     it('has the correct style classes', function () {
-        expect(card).toHaveDescendantWithCssClass('Card__synopsis');
-        expect(card).toHaveDescendantWithCssClass('CardVideo__title');
+        expect(view).toHaveDescendantWithCssClass('View__synopsis');
+        expect(view).toHaveDescendantWithCssClass('ViewAudio__title');
     });
 
     it('has labels that understand Pango markup', function () {
-        expect(Gtk.test_find_label(card, '*!!!*').use_markup).toBeTruthy();
+        expect(Gtk.test_find_label(view, '*!!!*').use_markup).toBeTruthy();
     });
 
-    it('has a video player', function () {
-        expect(card).toHaveDescendantWithClass(EosKnowledgePrivate.MediaBin);
+    it('has a audio player', function () {
+        expect(view).toHaveDescendantWithClass(EosKnowledgePrivate.MediaBin);
     });
 
     it('implements the ArticleContent interface', function (done) {
-        expect(() => card.set_active(false)).not.toThrow();
-        card.load_content_promise().then(done);
+        expect(() => view.set_active(false)).not.toThrow();
+        view.load_content_promise().then(done);
     });
-});
-
-Compliance.test_card_compliance(Video.Video, function (card) {
-    card.content_view.title = '';
-    card.content_view.description = '';
 });

--- a/tests/js/app/modules/view/testMedia.js
+++ b/tests/js/app/modules/view/testMedia.js
@@ -6,12 +6,11 @@ const CssClassMatcher = imports.tests.CssClassMatcher;
 const Utils = imports.tests.utils;
 Utils.register_gresource();
 
-const Media = imports.app.modules.card.media;
+const {Media} = imports.app.modules.view.media;
 
 Gtk.init(null);
 
-describe ('Card.Media', function () {
-
+describe('View.Media', function () {
     Object.defineProperty(Eknc.ImageObjectModel.prototype, 'ekn_id', {
         get: function() { return null; }
     });
@@ -22,15 +21,15 @@ describe ('Card.Media', function () {
             caption: '@@@',
         });
 
-        let card = new Media.Media({
+        let view = new Media({
             model: model,
         });
-        expect(Gtk.test_find_label(card, '*!!!*').use_markup).toBeTruthy();
-        expect(Gtk.test_find_label(card, '*@@@*').use_markup).toBeTruthy();
+        expect(Gtk.test_find_label(view, '*!!!*').use_markup).toBeTruthy();
+        expect(Gtk.test_find_label(view, '*@@@*').use_markup).toBeTruthy();
     });
 
     describe ('Attribution button', function () {
-        let card;
+        let view;
         let copyright_holder = '!!!';
         let attribution_button;
 
@@ -40,11 +39,11 @@ describe ('Card.Media', function () {
                 copyright_holder: copyright_holder,
             });
 
-            card = new Media.Media({
+            view = new Media({
                 model: model,
             });
 
-            attribution_button = Gtk.test_find_label(card, '*!!!*').get_parent();
+            attribution_button = Gtk.test_find_label(view, '*!!!*').get_parent();
             expect(attribution_button.sensitive).toBe(true);
         });
 
@@ -54,11 +53,11 @@ describe ('Card.Media', function () {
                 copyright_holder: copyright_holder,
             });
 
-            card = new Media.Media({
+            view = new Media({
                 model: model,
             });
 
-            attribution_button = Gtk.test_find_label(card, '*!!!*').get_parent();
+            attribution_button = Gtk.test_find_label(view, '*!!!*').get_parent();
             expect(attribution_button.sensitive).toBe(false);
         });
     });

--- a/tests/js/app/modules/view/testVideo.js
+++ b/tests/js/app/modules/view/testVideo.js
@@ -7,41 +7,41 @@ Utils.register_gresource();
 const Compliance = imports.tests.compliance;
 const CssClassMatcher = imports.tests.CssClassMatcher;
 const EosKnowledgePrivate = imports.gi.EosKnowledgePrivate;
-const Audio = imports.app.modules.card.audio;
+const {Video} = imports.app.modules.view.video;
 const WidgetDescendantMatcher = imports.tests.WidgetDescendantMatcher;
 
 Gtk.init(null);
 
-describe('Card.Audio', function () {
-    let card;
+describe('View.Video', function () {
+    let view;
 
     beforeEach(function () {
         jasmine.addMatchers(CssClassMatcher.customMatchers);
         jasmine.addMatchers(WidgetDescendantMatcher.customMatchers);
-        card = new Audio.Audio({
+        view = new Video({
             model: Eknc.ContentObjectModel.new_from_props({
                 title: '!!!',
             }),
         });
+        view.content_view.title = '';
+        view.content_view.description = '';
     });
 
     it('has the correct style classes', function () {
-        expect(card).toHaveDescendantWithCssClass('Card__synopsis');
-        expect(card).toHaveDescendantWithCssClass('CardAudio__title');
+        expect(view).toHaveDescendantWithCssClass('View__synopsis');
+        expect(view).toHaveDescendantWithCssClass('ViewVideo__title');
     });
 
     it('has labels that understand Pango markup', function () {
-        expect(Gtk.test_find_label(card, '*!!!*').use_markup).toBeTruthy();
+        expect(Gtk.test_find_label(view, '*!!!*').use_markup).toBeTruthy();
     });
 
-    it('has a audio player', function () {
-        expect(card).toHaveDescendantWithClass(EosKnowledgePrivate.MediaBin);
+    it('has a video player', function () {
+        expect(view).toHaveDescendantWithClass(EosKnowledgePrivate.MediaBin);
     });
 
     it('implements the ArticleContent interface', function (done) {
-        expect(() => card.set_active(false)).not.toThrow();
-        card.load_content_promise().then(done);
+        expect(() => view.set_active(false)).not.toThrow();
+        view.load_content_promise().then(done);
     });
 });
-
-Compliance.test_card_compliance(Audio.Audio);

--- a/tests/minimal.js
+++ b/tests/minimal.js
@@ -1,8 +1,8 @@
 // Copyright 2015 Endless Mobile, Inc.
 
 /* exported add_cards, MinimalArrangement, MinimalBinModule, MinimalCard,
-MinimalDocumentCard, MinimalHomePage, MinimalModule, MinimalNavigationCard,
-MinimalOrder, MinimalXapianFilter, MinimalXapianOrder, TitleFilter */
+MinimalHomePage, MinimalModule, MinimalNavigationCard, MinimalOrder,
+MinimalView, MinimalXapianFilter, MinimalXapianOrder, TitleFilter */
 
 const Eknc = imports.gi.EosKnowledgeContent;
 const GLib = imports.gi.GLib;
@@ -17,6 +17,7 @@ const Module = imports.app.interfaces.module;
 const NavigationCard = imports.app.interfaces.navigationCard;
 const Order = imports.app.interfaces.order;
 const Selection = imports.app.modules.selection.selection;
+const {View} = imports.app.interfaces.view;
 
 var MinimalArrangement = new Module.Class({
     Name: 'MinimalArrangement',
@@ -61,7 +62,7 @@ var MinimalArrangement = new Module.Class({
 var MinimalCard = new Module.Class({
     Name: 'MinimalCard',
     Extends: Gtk.Button,
-    Implements: [Card.Card],
+    Implements: [View, Card.Card],
 
     _init: function (props={}) {
         this.parent(props);
@@ -81,7 +82,7 @@ var MinimalCard = new Module.Class({
 var MinimalNavigationCard = new Module.Class({
     Name: 'MinimalNavigationCard',
     Extends: Gtk.Button,
-    Implements: [Card.Card, NavigationCard.NavigationCard],
+    Implements: [View, Card.Card, NavigationCard.NavigationCard],
 });
 
 var MinimalModule = new Module.Class({
@@ -89,10 +90,10 @@ var MinimalModule = new Module.Class({
     Extends: GObject.Object,
 });
 
-var MinimalDocumentCard = new Module.Class({
-    Name: 'MinimalDocumentCard',
+var MinimalView = new Module.Class({
+    Name: 'MinimalView',
     Extends: Gtk.Widget,
-    Implements: [Card.Card, ArticleContent.ArticleContent],
+    Implements: [View, ArticleContent.ArticleContent],
 
     Properties: {
         'info-notice': GObject.ParamSpec.object('info-notice', '', '',

--- a/tools/picard.js
+++ b/tools/picard.js
@@ -14,6 +14,7 @@ const ReadingHistoryModel = imports.app.readingHistoryModel;
 const Selection = imports.app.modules.selection.selection;
 const SetMap = imports.app.setMap;
 const Utils = imports.app.utils;
+const {View} = imports.app.interfaces.view;
 
 // Patch in a reading history model that works without a GApplication.
 const DummyReadingHistoryModel = new Knowledge.Class({
@@ -163,12 +164,6 @@ function get_available_modules_for_type (type) {
     return arr;
 }
 
-const UNUSED_CARDS = [
-    'Card.ContentGroup',
-    'Card.KnowledgeDocument',
-    'Card.Media',
-];
-
 function get_dimensions_menu () {
     widgets.dimension_menu = new Gtk.Popover({
         border_width: SPACING_UNIT,
@@ -238,7 +233,8 @@ function get_module_menu () {
 
     widgets.card_combo_box = new Gtk.ComboBoxText();
 
-    let card_types = get_available_modules_for_type('Card').sort().filter((name) => UNUSED_CARDS.indexOf(name) < 0);
+    let card_types = get_available_modules_for_type('Card').sort()
+        .filter(name => name !== 'Card.ContentGroup');
     card_types.unshift('ColorBoxCard');
     card_types.forEach((name) => widgets.card_combo_box.append_text(name));
 
@@ -469,7 +465,7 @@ function format_card_class (size, use_height=false) {
 const ColorBox = new Module.Class({
     Name: 'ColorBox',
     Extends: Gtk.Frame,
-    Implements: [Card.Card],
+    Implements: [View, Card.Card],
 
     _init: function (props={}) {
         props.width_request = Card.MinSize.A;


### PR DESCRIPTION
Renames Card.Audio to View.Audio, Card.KnowledgeDocument to
View.Document, Card.Video to View.Video, Card.Media to View.Media,
ContentGroup.MediaLightbox's 'card' slot to 'view', and
Layout.ArticleStack's 'card' slot to 'article'.

https://phabricator.endlessm.com/T16467