### PR TITLE
constrained: fix forEach() callback warning

### DIFF
--- a/js/app/modules/arrangement/constrained.js
+++ b/js/app/modules/arrangement/constrained.js
@@ -109,7 +109,7 @@ var Constrained = new Module.Class({
             0, 0,
             widgets,
             {});
-        constraints.forEach(this.add_constraint, this);
+        constraints.forEach(c => this.add_constraint(c));
     },
 
     // XXX workaround for minimum size issues in Emeus


### PR DESCRIPTION
Emeus.ConstraintLayout.add_constraint can not be used as a forEach()
callback because it only expect one argument

https://phabricator.endlessm.com/T18829