### PR TITLE
T18872 - Gallery Template: logo vertical center, search page side padding

### DIFF
--- a/data/css/gallery.scss
+++ b/data/css/gallery.scss
@@ -41,6 +41,11 @@
     padding: 50px 100px;
 }
 
+.search-page .LayoutBox {
+    padding-left: 50px;
+    padding-right: 50px;
+}
+
 // FIXME: These 2 selector styles should be integrated into the framework.
 .PagerSimple {
     margin-top: 0;

--- a/data/preset/gallery.yaml
+++ b/data/preset/gallery.yaml
@@ -20,7 +20,7 @@ defines:
     content:
       type: Navigation.TopMenu
       slots:
-        banner: 'Banner.Dynamic(mode: full, show-subtitle: false)'
+        banner: 'Banner.Dynamic(mode: full, show-subtitle: false, valign: center)'
         menu:
           shortdef: ContentGroup.ContentGroup
           slots:


### PR DESCRIPTION
Gallery template:

- vertically center the logo (Banner.Dynamic) inside the top menu
- Add padding to the sides of the search-page Layout so that the cards don't have so much space between them on a 1080p display

https://phabricator.endlessm.com/T18872