### PR TITLE
tests: Ignore trailing space in polib output

### DIFF
--- a/tests/autobahn/test-autobahn-catalog
+++ b/tests/autobahn/test-autobahn-catalog
@@ -4,4 +4,4 @@ input="$G_TEST_SRCDIR/autobahn/basic.yaml"
 expected=${input/.yaml/.pot}
 cd "$G_TEST_SRCDIR/.."
 # Ignore change in '# ' comment in header, polib 1.0.7 and later
-./tools/autobahn "$input" --catalog | diff -u "$expected" -I "POT-Creation-Date" -I "^# ?$" -
+./tools/autobahn "$input" --catalog | diff -u "$expected" -I "POT-Creation-Date" --ignore-trailing-space -


### PR DESCRIPTION
I thought the regex '^# ?$' would cover both cases of the output for
polib < 1.0.7 and >= 1.0.7. However, it doesn't. For simplicity, just
ignore all trailing spaces.

https://phabricator.endlessm.com/T18981