### PR TITLE
Layout.ArticleStack: Stop video before switching

### DIFF
--- a/js/app/modules/layout/articleStack.js
+++ b/js/app/modules/layout/articleStack.js
@@ -179,6 +179,7 @@ var ArticleStack = new Module.Class({
         this.add(article_content);
         article_content.show_all();
 
+        this.visible_child.set_active(false);
         article_content.load_content_promise()
         .then(() => {
             if (article_content.get_parent() === null)


### PR DESCRIPTION
Apparently if the video player is running it will starve out the main
loop so that the load_content_promise() in the next line will resolve
only after a few seconds. I'm not sure why this happens, but we can work
around it by stopping the video before loading a new one.

https://phabricator.endlessm.com/T19384