### PR TITLE
ekn-app-runner: Remove 'exec'

### DIFF
--- a/ekn-app-runner.in
+++ b/ekn-app-runner.in
@@ -40,4 +40,4 @@ let application = new Application.Application({
 });
 application.run(['$0'].concat(ARGV));"
 
-exec $DEBUG_COMMAND gjs -c "$SCRIPT" "$@"
+$DEBUG_COMMAND gjs -c "$SCRIPT" "$@"


### PR DESCRIPTION
For some reason, this makes debugging tools stop working inside Flatpak.
Probably something to do with tracing child processes.

https://phabricator.endlessm.com/T19535