### PR TITLE
HistoryStore: determine if Facebook sharing was canceled.

### DIFF
--- a/js/app/utils.js
+++ b/js/app/utils.js
@@ -25,6 +25,7 @@ const Gettext = imports.gettext;
 const Gio = imports.gi.Gio;
 const GLib = imports.gi.GLib;
 const Gtk = imports.gi.Gtk;
+const Soup = imports.gi.Soup;
 
 const Dispatcher = imports.app.dispatcher;
 const Knowledge = imports.app.knowledge;
@@ -559,4 +560,27 @@ function intersection(a, b) {
     b.filter(item => a_set.has(item))
         .forEach(item => intersection.add(item));
     return [...intersection];
+}
+
+function parse_uri (uri_str, parse_query) {
+    if (!uri_str || !uri_str.length)
+        return null;
+
+    let uri = new Soup.URI (uri_str);
+    if (!uri)
+        return null;
+
+    let {scheme, user, password, host, port, path, query, fragment} = uri;
+
+    if (parse_query && query) {
+        let params = query.split('&');
+        query = {};
+
+        params.forEach((param) => {
+            let tokens = param.split('=');
+            query[decodeURIComponent(tokens[0])] = decodeURIComponent(tokens[1]);
+        });
+    }
+
+    return {scheme, user, password, host, port, path, query, fragment};
 }

--- a/tests/js/app/testUtils.js
+++ b/tests/js/app/testUtils.js
@@ -134,4 +134,53 @@ describe('Utilities:', function () {
             expect(Utils.intersection(null, a)).toEqual([]);
         });
     });
+
+    describe('parse_uri', function () {
+        /* scheme:[//[user[:password]@]host[:port]][/path][?query][#fragment] */
+        it('can handle an empty URI', function () {
+            let uri = Utils.parse_uri('');
+            expect(uri).toEqual(null);
+        });
+
+        it('can handle a null URI', function () {
+            let uri = Utils.parse_uri(null);
+            expect(uri).toEqual(null);
+        });
+
+        it('can handle an undefined URI', function () {
+            let uri = Utils.parse_uri();
+            expect(uri).toEqual(null);
+        });
+
+        it('can handle malformed URI', function () {
+            let uri = Utils.parse_uri("hostnameWithNoScheme");
+            expect(uri).toEqual(null);
+        });
+
+        it('can parse a full URI', function () {
+            let uri = Utils.parse_uri('https://username:qwerty@endlessm.com:8080/a/random/path.html?param1=value1&param2=value2#_=_');
+            expect(uri.scheme).toEqual('https');
+            expect(uri.user).toEqual('username');
+            expect(uri.password).toEqual('qwerty');
+            expect(uri.host).toEqual('endlessm.com');
+            expect(uri.path).toEqual('/a/random/path.html');
+            expect(uri.port).toEqual(8080);
+            expect(uri.query).toEqual('param1=value1&param2=value2');
+            expect(uri.fragment).toEqual('_=_');
+        });
+
+        it('can parse URI with empty query', function () {
+            let uri = Utils.parse_uri('https://endlessm.com/random/path.html#_=_', true);
+            expect(uri.scheme).toEqual('https');
+            expect(uri.host).toEqual('endlessm.com');
+            expect(uri.path).toEqual('/random/path.html');
+            expect(uri.query).toEqual(null);
+        });
+
+        it('can parse URI query parameters', function () {
+            let uri = Utils.parse_uri('https://endlessm.com/random/path.html?param1=value1&param2=value2#_=_', true);
+            expect(uri.query.param1).toEqual('value1');
+            expect(uri.query.param2).toEqual('value2');
+        });
+    });
 });


### PR DESCRIPTION
Use WebShareDialog::transaction-done to determine if sharing was canceled
or not to properly report to the metrics system.

https://phabricator.endlessm.com/T18524