### PR TITLE
webShareDialog: Allow dependency-injecting the DBus manager

### DIFF
--- a/js/app/widgets/webShareDialog.js
+++ b/js/app/widgets/webShareDialog.js
@@ -47,6 +47,11 @@ var WebShareDialog = new Lang.Class({
             'Use a mobile user agent for the webview',
             GObject.ParamFlags.READWRITE | GObject.ParamFlags.CONSTRUCT_ONLY,
             false),
+
+        'manager': GObject.ParamSpec.object('manager', 'Manager',
+            'DBus manager for dependency injection in tests',
+            GObject.ParamFlags.READWRITE | GObject.ParamFlags.CONSTRUCT_ONLY,
+            GObject.Object.$gtype),
     },
 
     Signals: {
@@ -74,14 +79,18 @@ var WebShareDialog = new Lang.Class({
         this._cookies_path_init();
 
         /* Get GOA object manager */
-        this._dbus_manager = Gio.DBusObjectManagerClient.new_for_bus_sync(
-            Gio.BusType.SESSION,
-            Gio.DBusObjectManagerClientFlags.NONE,
-            'org.gnome.OnlineAccounts',
-            '/org/gnome/OnlineAccounts',
-            null,
-            null
-        );
+        if (props.manager) {
+            this._dbus_manager = props.manager;
+        } else {
+            this._dbus_manager = Gio.DBusObjectManagerClient.new_for_bus_sync(
+                Gio.BusType.SESSION,
+                Gio.DBusObjectManagerClientFlags.NONE,
+                'org.gnome.OnlineAccounts',
+                '/org/gnome/OnlineAccounts',
+                null,
+                null
+            );
+        }
 
         /* Assume GetSessionCookies is present.
          * It will be updated the first time we try to call it.

--- a/tests/js/app/testHistoryStore.js
+++ b/tests/js/app/testHistoryStore.js
@@ -1,5 +1,5 @@
 const Eknc = imports.gi.EosKnowledgeContent;
-const Gtk = imports.gi.Gtk;
+const {GObject, Gtk} = imports.gi;
 
 const Utils = imports.tests.utils;
 Utils.register_gresource();
@@ -183,6 +183,8 @@ describe('History Store', function () {
             let WebShareDialogConstructor = WebShareDialog.WebShareDialog;
 
             spyOn(WebShareDialog, 'WebShareDialog').and.callFake(function(props) {
+                props.manager = new GObject.Object();
+                props.manager.get_objects = jasmine.createSpy().and.returnValue([]);
                 share_dialog = new WebShareDialogConstructor(props);
                 return share_dialog;
             });


### PR DESCRIPTION
This is in order to prevent the tests from trying to access the real
org.gnome.OnlineAccounts object, which (1) doesn't exist in the CI
environment and (2) could do unwanted actions on a real system.

https://phabricator.endlessm.com/T19798