### PR TITLE
Remove unused eknc_database_manager_get_instance_private() calls

### DIFF
--- a/ekncontent/ekncontent/eknc-database-manager.c
+++ b/ekncontent/ekncontent/eknc-database-manager.c
@@ -755,8 +755,6 @@ eknc_database_manager_fix_query (EkncDatabaseManager *self,
                                  char **spell_fixed_query,
                                  GError **error_out)
 {
-  EkncDatabaseManagerPrivate *priv = eknc_database_manager_get_instance_private (self);
-
   g_return_val_if_fail (EKNC_IS_DATABASE_MANAGER (self), FALSE);
 
   if (!ensure_db (self, error_out))
@@ -965,8 +963,6 @@ eknc_database_manager_query (EkncDatabaseManager *self,
                              GHashTable *params,
                              GError **error_out)
 {
-  EkncDatabaseManagerPrivate *priv = eknc_database_manager_get_instance_private (self);
-
   g_return_val_if_fail (EKNC_IS_DATABASE_MANAGER (self), NULL);
 
   if (!ensure_db (self, error_out))


### PR DESCRIPTION
I was freeing up disk space and found this unpushed patch in my EKL tree - `priv` isn't actually used in either case.

I seem to not have all the currently required ekl dependencies installed, so haven't tested this change as updated to current master, but it seems obvious and useful to push.

