### PR TITLE
Replace all "as" GVariant properties

### DIFF
--- a/ekncontent/ekncontent/eknc-article-object-model.h
+++ b/ekncontent/ekncontent/eknc-article-object-model.h
@@ -19,13 +19,13 @@ struct _EkncArticleObjectModelClass
   gpointer padding[8];
 };
 
-GVariant *
+char * const *
 eknc_article_object_model_get_authors (EkncArticleObjectModel *self);
 
-GVariant *
+char * const *
 eknc_article_object_model_get_temporal_coverage (EkncArticleObjectModel *self);
 
-GVariant *
+char * const *
 eknc_article_object_model_get_outgoing_links (EkncArticleObjectModel *self);
 
 GVariant *

--- a/ekncontent/ekncontent/eknc-content-object-model.c
+++ b/ekncontent/ekncontent/eknc-content-object-model.c
@@ -28,8 +28,8 @@ typedef struct {
   gchar *last_modified_date;
   gchar *license;
   gboolean featured;
-  GVariant *tags;
-  GVariant *resources;
+  char **tags;
+  char **resources;
   GVariant *discovery_feed_content;
 } EkncContentObjectModelPrivate;
 
@@ -124,11 +124,11 @@ eknc_content_object_model_get_property (GObject    *object,
       break;
 
     case PROP_TAGS:
-      g_value_set_variant (value, priv->tags);
+      g_value_set_boxed (value, priv->tags);
       break;
 
     case PROP_RESOURCES:
-      g_value_set_variant (value, priv->resources);
+      g_value_set_boxed (value, priv->resources);
       break;
 
     case PROP_DISCOVERY_FEED_CONTENT:
@@ -216,13 +216,13 @@ eknc_content_object_model_set_property (GObject *object,
       break;
 
     case PROP_TAGS:
-      g_clear_pointer (&priv->tags, g_variant_unref);
-      priv->tags = g_value_dup_variant (value);
+      g_clear_pointer (&priv->tags, g_strfreev);
+      priv->tags = g_value_dup_boxed (value);
       break;
 
     case PROP_RESOURCES:
-      g_clear_pointer (&priv->resources, g_variant_unref);
-      priv->resources = g_value_dup_variant (value);
+      g_clear_pointer (&priv->resources, g_strfreev);
+      priv->resources = g_value_dup_boxed (value);
       break;
 
     case PROP_DISCOVERY_FEED_CONTENT:
@@ -275,8 +275,8 @@ eknc_content_object_model_finalize (GObject *object)
   g_clear_pointer (&priv->synopsis, g_free);
   g_clear_pointer (&priv->last_modified_date, g_free);
   g_clear_pointer (&priv->license, g_free);
-  g_clear_pointer (&priv->tags, g_variant_unref);
-  g_clear_pointer (&priv->resources, g_variant_unref);
+  g_clear_pointer (&priv->tags, g_strfreev);
+  g_clear_pointer (&priv->resources, g_strfreev);
   g_clear_pointer (&priv->discovery_feed_content, g_variant_unref);
 
   G_OBJECT_CLASS (eknc_content_object_model_parent_class)->finalize (object);
@@ -433,9 +433,9 @@ eknc_content_object_model_class_init (EkncContentObjectModelClass *klass)
    * A list of tag strings associated with the model.
    */
   eknc_content_object_model_props[PROP_TAGS] =
-    g_param_spec_variant ("tags", "Tags",
+    g_param_spec_boxed ("tags", "Tags",
       "A list of tag strings associated with the model.",
-      G_VARIANT_TYPE ("as"), NULL,
+      G_TYPE_STRV,
       G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY | G_PARAM_STATIC_STRINGS);
   /**
    * EkncContentObjectModel:resources:
@@ -443,9 +443,9 @@ eknc_content_object_model_class_init (EkncContentObjectModelClass *klass)
    * A list of ekn ids of resources belonging to the model.
    */
   eknc_content_object_model_props[PROP_RESOURCES] =
-    g_param_spec_variant ("resources", "Resources",
+    g_param_spec_boxed ("resources", "Resources",
       "A list of ekn ids of resources belonging to the model.",
-      G_VARIANT_TYPE ("as"), NULL,
+      G_TYPE_STRV,
       G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY | G_PARAM_STATIC_STRINGS);
 
   /**
@@ -551,9 +551,9 @@ eknc_content_object_model_add_json_to_params (JsonNode *node,
  *
  * Get the model's tags.
  *
- * Returns: (transfer none): the resources GVariant
+ * Returns: (transfer none) (array zero-terminated=1): an array of strings
  */
-GVariant *
+char * const *
 eknc_content_object_model_get_tags (EkncContentObjectModel *self)
 {
   g_return_val_if_fail (EKNC_IS_CONTENT_OBJECT_MODEL (self), NULL);
@@ -568,9 +568,9 @@ eknc_content_object_model_get_tags (EkncContentObjectModel *self)
  *
  * Get the model's resources.
  *
- * Returns: (transfer none): the resources GVariant
+ * Returns: (transfer none) (array zero-terminated=1): an array of strings
  */
-GVariant *
+char * const *
 eknc_content_object_model_get_resources (EkncContentObjectModel *self)
 {
   g_return_val_if_fail (EKNC_IS_CONTENT_OBJECT_MODEL (self), NULL);

--- a/ekncontent/ekncontent/eknc-content-object-model.h
+++ b/ekncontent/ekncontent/eknc-content-object-model.h
@@ -17,14 +17,14 @@ struct _EkncContentObjectModelClass
   gpointer padding[8];
 };
 
-EkncContentObjectModel *
-eknc_content_object_model_new_from_json_node (JsonNode *node);
-
-GVariant *
+char * const *
 eknc_content_object_model_get_tags (EkncContentObjectModel *self);
 
-GVariant *
+char * const *
 eknc_content_object_model_get_resources (EkncContentObjectModel *self);
+
+EkncContentObjectModel *
+eknc_content_object_model_new_from_json_node (JsonNode *node);
 
 GFileInputStream *
 eknc_content_object_model_get_content_stream (EkncContentObjectModel *self,

--- a/ekncontent/ekncontent/eknc-query-object.h
+++ b/ekncontent/ekncontent/eknc-query-object.h
@@ -64,19 +64,19 @@ typedef enum {
   EKNC_QUERY_OBJECT_ORDER_DESCENDING,
 } EkncQueryObjectOrder;
 
-GVariant *
+char * const *
 eknc_query_object_get_tags_match_all (EkncQueryObject *self);
 
-GVariant *
+char * const *
 eknc_query_object_get_tags_match_any (EkncQueryObject *self);
 
-GVariant *
+char * const *
 eknc_query_object_get_ids (EkncQueryObject *self);
 
-GVariant *
+char * const *
 eknc_query_object_get_excluded_ids (EkncQueryObject *self);
 
-GVariant *
+char * const *
 eknc_query_object_get_excluded_tags (EkncQueryObject *self);
 
 const char *

--- a/ekncontent/ekncontent/eknc-query-results.c
+++ b/ekncontent/ekncontent/eknc-query-results.c
@@ -94,6 +94,8 @@ eknc_query_results_finalize (GObject *object)
   EkncQueryResults *self = EKNC_QUERY_RESULTS (object);
 
   g_slist_free_full (self->models, g_object_unref);
+
+  G_OBJECT_CLASS (eknc_query_results_parent_class)->finalize (object);
 }
 
 

--- a/ekncontent/ekncontent/eknc-set-object-model.c
+++ b/ekncontent/ekncontent/eknc-set-object-model.c
@@ -13,7 +13,7 @@
  * The model class for set objects.
  */
 typedef struct {
-  GVariant *child_tags;
+  char **child_tags;
 } EkncSetObjectModelPrivate;
 
 G_DEFINE_TYPE_WITH_PRIVATE (EkncSetObjectModel,
@@ -40,7 +40,7 @@ eknc_set_object_model_get_property (GObject    *object,
   switch (prop_id)
     {
     case PROP_CHILD_TAGS:
-      g_value_set_variant (value, priv->child_tags);
+      g_value_set_boxed (value, priv->child_tags);
       break;
 
     default:
@@ -60,8 +60,8 @@ eknc_set_object_model_set_property (GObject *object,
   switch (prop_id)
     {
     case PROP_CHILD_TAGS:
-      g_clear_pointer (&priv->child_tags, g_variant_unref);
-      priv->child_tags = g_value_dup_variant (value);
+      g_clear_pointer (&priv->child_tags, g_strfreev);
+      priv->child_tags = g_value_dup_boxed (value);
       break;
 
     default:
@@ -75,7 +75,7 @@ eknc_set_object_model_finalize (GObject *object)
   EkncSetObjectModel *self = EKNC_SET_OBJECT_MODEL (object);
   EkncSetObjectModelPrivate *priv = eknc_set_object_model_get_instance_private (self);
 
-  g_clear_pointer (&priv->child_tags, g_variant_unref);
+  g_clear_pointer (&priv->child_tags, g_strfreev);
 
   G_OBJECT_CLASS (eknc_set_object_model_parent_class)->finalize (object);
 }
@@ -103,9 +103,9 @@ eknc_set_object_model_class_init (EkncSetObjectModelClass *klass)
    * to the tags with which a set itself has been tagged.
    */
   eknc_set_object_model_props[PROP_CHILD_TAGS] =
-    g_param_spec_variant ("child-tags", "Child Tags",
+    g_param_spec_boxed ("child-tags", "Child Tags",
       "A list of tags that articles in this set are tagged with",
-      G_VARIANT_TYPE ("as"), NULL,
+      G_TYPE_STRV,
       G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY | G_PARAM_STATIC_STRINGS);
 
   g_object_class_install_properties (object_class,
@@ -145,9 +145,9 @@ eknc_set_object_model_add_json_to_params (JsonNode *node,
  *
  * Get the models child_tags.
  *
- * Returns: (transfer none): the resources GVariant
+ * Returns: (transfer none) (array zero-terminated=1): an array of strings
  */
-GVariant *
+char * const *
 eknc_set_object_model_get_child_tags (EkncSetObjectModel *self)
 {
   g_return_val_if_fail (EKNC_IS_SET_OBJECT_MODEL (self), NULL);

--- a/ekncontent/ekncontent/eknc-set-object-model.h
+++ b/ekncontent/ekncontent/eknc-set-object-model.h
@@ -19,7 +19,7 @@ struct _EkncSetObjectModelClass
   gpointer padding[8];
 };
 
-GVariant *
+char * const *
 eknc_set_object_model_get_child_tags (EkncSetObjectModel *self);
 
 EkncContentObjectModel *

--- a/ekncontent/overrides/EosKnowledgeContent.js
+++ b/ekncontent/overrides/EosKnowledgeContent.js
@@ -29,24 +29,6 @@ function add_custom_model_constructors (model) {
     // FIXME: would be way nicer to put this on the actual gobject init, or
     // better yet support introspection on list properties
     model.new_from_props = function (props={}) {
-        marshal_property(props, 'tags', function (v) {
-            return new GLib.Variant('as', v);
-        });
-        marshal_property(props, 'resources', function (v) {
-            return new GLib.Variant('as', v);
-        });
-        marshal_property(props, 'authors', function (v) {
-            return new GLib.Variant('as', v);
-        });
-        marshal_property(props, 'temporal-coverage', function (v) {
-            return new GLib.Variant('as', v);
-        });
-        marshal_property(props, 'outgoing-links', function (v) {
-            return new GLib.Variant('as', v);
-        });
-        marshal_property(props, 'child-tags', function (v) {
-            return new GLib.Variant('as', v);
-        });
         marshal_property(props, 'discovery-feed-content', function (v) {
             return new GLib.Variant('a{sv}', v);
         });
@@ -73,18 +55,6 @@ function add_custom_model_constructors (model) {
 function _init() {
     let Eknc = this;
 
-    define_property(Eknc.ContentObjectModel, 'tags', {
-        get: function () {
-            let tags = this.get_tags();
-            return tags ? tags.deep_unpack() : [];
-        },
-    });
-    define_property(Eknc.ContentObjectModel, 'resources', {
-        get: function () {
-            let resources = this.get_resources();
-            return resources ? resources.deep_unpack() : [];
-        },
-    });
     define_property(Eknc.ContentObjectModel, 'discovery-feed-content', {
         get: function () {
             let content = this.get_discovery_feed_content();
@@ -92,24 +62,6 @@ function _init() {
         }
     });
 
-    define_property(Eknc.ArticleObjectModel, 'authors', {
-        get: function () {
-            let authors = this.get_authors();
-            return authors ? authors.deep_unpack() : [];
-        },
-    });
-    define_property(Eknc.ArticleObjectModel, 'temporal-coverage', {
-        get: function () {
-            let temporalCoverage = this.get_temporal_coverage();
-            return temporalCoverage ? temporalCoverage.deep_unpack() : [];
-        },
-    });
-    define_property(Eknc.ArticleObjectModel, 'outgoing-links', {
-        get: function () {
-            let outgoing_links = this.get_outgoing_links();
-            return outgoing_links ? outgoing_links.deep_unpack() : [];
-        },
-    });
     define_property(Eknc.ArticleObjectModel, 'table-of-contents', {
         get: function () {
             let toc = this.get_table_of_contents();
@@ -124,13 +76,6 @@ function _init() {
         },
     });
 
-    define_property(Eknc.SetObjectModel, 'child-tags', {
-        get: function () {
-            let child_tags = this.get_child_tags();
-            return child_tags ? child_tags.deep_unpack() : [];
-        },
-    });
-
     add_custom_model_constructors(Eknc.AudioObjectModel);
     add_custom_model_constructors(Eknc.ContentObjectModel);
     add_custom_model_constructors(Eknc.DictionaryObjectModel);
@@ -139,56 +84,6 @@ function _init() {
     add_custom_model_constructors(Eknc.MediaObjectModel);
     add_custom_model_constructors(Eknc.ImageObjectModel);
     add_custom_model_constructors(Eknc.VideoObjectModel);
-
-    define_property(Eknc.QueryObject, 'tags-match-any', {
-        get: function () {
-            let tags = this.get_tags_match_any();
-            return tags ? tags.deep_unpack() : [];
-        },
-    });
-    define_property(Eknc.QueryObject, 'tags-match-all', {
-        get: function () {
-            let tags = this.get_tags_match_all();
-            return tags ? tags.deep_unpack() : [];
-        },
-    });
-    define_property(Eknc.QueryObject, 'ids', {
-        get: function () {
-            let ids = this.get_ids();
-            return ids ? ids.deep_unpack() : [];
-        },
-    });
-    define_property(Eknc.QueryObject, 'excluded-ids', {
-        get: function () {
-            let ids = this.get_excluded_ids();
-            return ids ? ids.deep_unpack() : [];
-        },
-    });
-    define_property(Eknc.QueryObject, 'excluded-tags', {
-        get: function () {
-            let tags = this.get_excluded_tags();
-            return tags ? tags.deep_unpack() : [];
-        },
-    });
-
-    Eknc.QueryObject.new_from_props = function (props={}) {
-        marshal_property(props, 'tags-match-any', function (v) {
-            return new GLib.Variant('as', v);
-        });
-        marshal_property(props, 'tags-match-all', function (v) {
-            return new GLib.Variant('as', v);
-        });
-        marshal_property(props, 'ids', function (v) {
-            return new GLib.Variant('as', v);
-        });
-        marshal_property(props, 'excluded-ids', function (v) {
-            return new GLib.Variant('as', v);
-        });
-        marshal_property(props, 'excluded-tags', function (v) {
-            return new GLib.Variant('as', v);
-        });
-        return new Eknc.QueryObject(props);
-    };
 
     Eknc.QueryObject.new_from_object = function (source, props={}) {
         for (let param_spec of GObject.Object.list_properties.call(Eknc.QueryObject)) {
@@ -199,7 +94,7 @@ function _init() {
                 continue;
             props[name] = source[name];
         }
-        return Eknc.QueryObject.new_from_props(props);
+        return new Eknc.QueryObject(props);
     };
 
     // FIXME: Can be removed when GJS supports pointer-valued properties.

--- a/ekncontent/tests/ekncontent/testQueryObject.js
+++ b/ekncontent/tests/ekncontent/testQueryObject.js
@@ -10,7 +10,7 @@ describe('QueryObject', function () {
     const EXCLUDED_TAGS = ['Zuul'];
 
     it('sets tags and ids objects properly', function () {
-        let query_obj = Eknc.QueryObject.new_from_props({
+        let query_obj = new Eknc.QueryObject({
             ids: IDS,
             excluded_ids: EXCLUDED_IDS,
             tags_match_any: TAGS_MATCH_ANY,
@@ -28,7 +28,7 @@ describe('QueryObject', function () {
         let mutable_ids = ['ekn://busters-es/0123456789012345',
                            'ekn://busters-es/fabaffacabacbafa'];
         let mutable_tags = ['Venkman', 'Stantz'];
-        let query_obj = Eknc.QueryObject.new_from_props({
+        let query_obj = new Eknc.QueryObject({
             ids: mutable_ids,
             tags_match_any: mutable_tags,
         });
@@ -40,7 +40,7 @@ describe('QueryObject', function () {
 
     describe('new_from_object constructor', function () {
         const QUERY = 'keymaster';
-        const QUERY_OBJ = Eknc.QueryObject.new_from_props({
+        const QUERY_OBJ = new Eknc.QueryObject({
             tags_match_any: TAGS_MATCH_ANY,
             query: QUERY,
         });
@@ -77,14 +77,14 @@ describe('QueryObject', function () {
     });
 
     it('should map sort property to xapian sort value', function () {
-        let query_obj = Eknc.QueryObject.new_from_props({
+        let query_obj = new Eknc.QueryObject({
             query: 'tyrion wins',
             sort: Eknc.QueryObjectSort.SEQUENCE_NUMBER,
         });
         let result = query_obj.get_sort_value();
         expect(result).toBe(0);
 
-        query_obj = Eknc.QueryObject.new_from_props({
+        query_obj = new Eknc.QueryObject({
             query: 'tyrion wins',
         });
         let undefined_result = query_obj.get_sort_value();
@@ -92,14 +92,14 @@ describe('QueryObject', function () {
     });
 
     it('should map match type to xapian cutoff value', () => {
-        let query_obj = Eknc.QueryObject.new_from_props({
+        let query_obj = new Eknc.QueryObject({
             query: 'tyrion wins',
             match: Eknc.QueryObjectMatch.TITLE_SYNOPSIS,
         });
         let result = query_obj.get_cutoff();
         expect(result).toBe(20);
 
-        query_obj = Eknc.QueryObject.new_from_props({
+        query_obj = new Eknc.QueryObject({
             query: 'tyrion wins',
             match: Eknc.QueryObjectMatch.ONLY_TITLE,
         });

--- a/js/app/application.js
+++ b/js/app/application.js
@@ -254,7 +254,7 @@ var Application = new Knowledge.Class({
     },
 
     _initialize_set_map: function () {
-        Eknc.Engine.get_default().query_promise(Eknc.QueryObject.new_from_props({
+        Eknc.Engine.get_default().query_promise(new Eknc.QueryObject({
             limit: GLib.MAXUINT32,
             tags_match_all: ['EknSetObject'],
         }))

--- a/js/app/courseHistoryStore.js
+++ b/js/app/courseHistoryStore.js
@@ -82,7 +82,7 @@ var CourseHistoryStore = new GObject.Class({
     },
 
     _load_first_subset: function (model) {
-        let query = Eknc.QueryObject.new_from_props({
+        let query = new Eknc.QueryObject({
             limit: 1,
             tags_match_any: model.child_tags,
             tags_match_all: ['EknSetObject'],

--- a/js/app/interfaces/card.js
+++ b/js/app/interfaces/card.js
@@ -284,7 +284,7 @@ var Card = new Lang.Interface({
 
     // O promises, where art thou?
     _count_set: function (set_obj, callback) {
-        let query = Eknc.QueryObject.new_from_props({
+        let query = new Eknc.QueryObject({
             tags_match_any: set_obj.child_tags,
             limit: GLib.MAXUINT32,
         });

--- a/js/app/modules/navigation/searchBox.js
+++ b/js/app/modules/navigation/searchBox.js
@@ -103,7 +103,7 @@ var SearchBox = new Module.Class({
         if (query.length === 0)
             return;
 
-        let query_obj = Eknc.QueryObject.new_from_props({
+        let query_obj = new Eknc.QueryObject({
             query: query,
             limit: RESULTS_SIZE,
             tags_match_any: ['EknArticleObject'],

--- a/js/app/modules/selection/all.js
+++ b/js/app/modules/selection/all.js
@@ -26,7 +26,7 @@ var All = new Module.Class({
     construct_query_object: function (limit, query_index) {
         if (query_index > 0)
             return null;
-        return Eknc.QueryObject.new_from_props({
+        return new Eknc.QueryObject({
             limit: limit,
         });
     },

--- a/js/app/modules/selection/allSets.js
+++ b/js/app/modules/selection/allSets.js
@@ -21,7 +21,7 @@ var AllSets = new Module.Class({
     construct_query_object: function (limit, query_index) {
         if (query_index > 0)
             return null;
-        return Eknc.QueryObject.new_from_props({
+        return new Eknc.QueryObject({
             limit: limit,
             tags_match_all: ['EknSetObject'],
             sort: Eknc.QueryObjectSort.SEQUENCE_NUMBER,

--- a/js/app/modules/selection/articleContext.js
+++ b/js/app/modules/selection/articleContext.js
@@ -39,14 +39,14 @@ var ArticleContext = new Module.Class({
             return null;
 
         if (this._item.query.length > 0) {
-            return Eknc.QueryObject.new_from_props({
+            return new Eknc.QueryObject({
                 limit: limit,
                 query: this._item.query,
                 tags_match_any: ['EknArticleObject'],
             });
         }
 
-        return Eknc.QueryObject.new_from_props({
+        return new Eknc.QueryObject({
             limit: limit,
             tags_match_any: this._item.model.child_tags,
             sort: Eknc.QueryObjectSort.SEQUENCE_NUMBER,

--- a/js/app/modules/selection/contentForSet.js
+++ b/js/app/modules/selection/contentForSet.js
@@ -77,7 +77,7 @@ var ContentForSet = new Module.Class({
         if (!this.model)
             return null;
 
-        return Eknc.QueryObject.new_from_props({
+        return new Eknc.QueryObject({
             limit: limit,
             tags_match_any: this.model.child_tags,
             sort: Eknc.QueryObjectSort.SEQUENCE_NUMBER,

--- a/js/app/modules/selection/featuredFirst.js
+++ b/js/app/modules/selection/featuredFirst.js
@@ -29,12 +29,12 @@ var FeaturedFirst = new Module.Class({
 
     construct_query_object: function (limit, query_index) {
         if (query_index == 0) {
-            return Eknc.QueryObject.new_from_props({
+            return new Eknc.QueryObject({
                 limit: limit,
                 tags_match_all: ['EknFeaturedTag'],
             });
         } else if (query_index == 1) {
-            return Eknc.QueryObject.new_from_props({
+            return new Eknc.QueryObject({
                 limit: limit,
                 excluded_tags: ['EknFeaturedTag'],
             });

--- a/js/app/modules/selection/next.js
+++ b/js/app/modules/selection/next.js
@@ -44,11 +44,9 @@ var Next = new Module.Class({
         if (!next_model)
             return null;
 
-        let query_object_params = {
+        return new Eknc.QueryObject({
             limit: 1,
             ids: [next_model.ekn_id],
-        };
-
-        return Eknc.QueryObject.new_from_props(query_object_params);
+        });
     },
 });

--- a/js/app/modules/selection/related.js
+++ b/js/app/modules/selection/related.js
@@ -35,11 +35,10 @@ var Related = new Module.Class({
             return null;
 
         let tags = item.model.tags.filter(tag => !tag.startsWith('Ekn'));
-        let query_object_params = {
+
+        return new Eknc.QueryObject({
             limit: limit,
             tags_match_any: tags,
-        };
-
-        return Eknc.QueryObject.new_from_props(query_object_params);
+        });
     },
 });

--- a/js/app/modules/selection/search.js
+++ b/js/app/modules/selection/search.js
@@ -23,7 +23,7 @@ var Search = new Module.Class({
         let query = HistoryStore.get_default().current_query;
         if (query_index > 0 || query.length === 0)
             return null;
-        return Eknc.QueryObject.new_from_props({
+        return new Eknc.QueryObject({
             query: query,
             limit: limit,
         });

--- a/js/app/modules/selection/setCrossSection.js
+++ b/js/app/modules/selection/setCrossSection.js
@@ -29,7 +29,7 @@ var SetCrossSection = new Module.Class({
         let current_set = HistoryStore.get_default().current_set;
         if (current_set)
             tags = tags.concat(current_set.child_tags);
-        return Eknc.QueryObject.new_from_props({
+        return new Eknc.QueryObject({
             limit: limit,
             tags_match_all: tags,
             sort: Eknc.QueryObjectSort.SEQUENCE_NUMBER,

--- a/js/app/modules/selection/suggested.js
+++ b/js/app/modules/selection/suggested.js
@@ -31,12 +31,10 @@ var Suggested = new Module.Class({
         // FIXME: We still need a better way to issue a query for
         // 'random' articles. This just gets a random offset and then
         // requests articles (in order) starting from that point.
-        let random_query = Eknc.QueryObject.new_from_props({
+        return new Eknc.QueryObject({
             offset: this._hash % this._TOTAL_ARTICLES,
             limit: limit,
         });
-
-        return random_query;
     },
 
     get_models: function () {

--- a/js/app/modules/selection/supplementary.js
+++ b/js/app/modules/selection/supplementary.js
@@ -37,6 +37,6 @@ var Supplementary = new Module.Class({
             default:
                 return null;
         }
-        return Eknc.QueryObject.new_from_props(query_object_params);
+        return new Eknc.QueryObject(query_object_params);
     },
 });

--- a/tests/js/app/modules/selection/testXapian.js
+++ b/tests/js/app/modules/selection/testXapian.js
@@ -18,12 +18,12 @@ var SampleXapianSelection = new Module.Class({
 
     construct_query_object: function (limit, query_index) {
         if (query_index == 0) {
-            return Eknc.QueryObject.new_from_props({
+            return new Eknc.QueryObject({
                 limit: limit,
                 tags_match_all: ['foobar'],
             });
         } else if (query_index == 1) {
-            return Eknc.QueryObject.new_from_props({
+            return new Eknc.QueryObject({
                 limit: limit,
                 tags_match_all: ['baz'],
             });

--- a/tools/kermit.js
+++ b/tools/kermit.js
@@ -459,7 +459,7 @@ function _pretty_print_table (elements) {
 
 function query (app_id, query_string) {
     let engine = Eknc.Engine.get_default();
-    let query_obj = Eknc.QueryObject.new_from_props({
+    let query_obj = new Eknc.QueryObject({
         query: query_string,
         limit: BATCH_SIZE,
         app_id: app_id,


### PR DESCRIPTION
Replaces most of the GVariant properties with `G_TYPE_STRV` boxed properties.

https://phabricator.endlessm.com/T19625