### PR TITLE
ekncontent: Change discovery-feed-content property to JsonObject*

### DIFF
--- a/ekncontent/docs/reference/ekncontent/eos-knowledge-content-sections.txt
+++ b/ekncontent/docs/reference/ekncontent/eos-knowledge-content-sections.txt
@@ -49,6 +49,7 @@ eknc_domain_error_quark
 <SECTION>
 <FILE>content-object-model</FILE>
 eknc_content_object_model_get_content_stream
+eknc_content_object_model_get_discovery_feed_content
 eknc_content_object_model_get_resources
 eknc_content_object_model_get_tags
 eknc_content_object_model_new_from_json_node

--- a/ekncontent/ekncontent/eknc-content-object-model.c
+++ b/ekncontent/ekncontent/eknc-content-object-model.c
@@ -580,6 +580,24 @@ eknc_content_object_model_get_resources (EkncContentObjectModel *self)
 }
 
 /**
+ * eknc_content_object_model_get_discovery_feed_content:
+ * @self: the model
+ *
+ * Get the discovery feed content for the model, which is a collection of
+ * properties with no defined schema yet.
+ *
+ * Returns: (transfer none): a #GVariant
+ */
+GVariant *
+eknc_content_object_model_get_discovery_feed_content (EkncContentObjectModel *self)
+{
+  g_return_val_if_fail (EKNC_IS_CONTENT_OBJECT_MODEL (self), NULL);
+
+  EkncContentObjectModelPrivate *priv = eknc_content_object_model_get_instance_private (self);
+  return priv->discovery_feed_content;
+}
+
+/**
  * eknc_content_object_model_get_content_stream:
  * @self: the model
  * @error: set if an error occurred while loading the content

--- a/ekncontent/ekncontent/eknc-content-object-model.c
+++ b/ekncontent/ekncontent/eknc-content-object-model.c
@@ -30,7 +30,7 @@ typedef struct {
   gboolean featured;
   char **tags;
   char **resources;
-  GVariant *discovery_feed_content;
+  JsonObject *discovery_feed_content;
 } EkncContentObjectModelPrivate;
 
 G_DEFINE_TYPE_WITH_PRIVATE (EkncContentObjectModel,
@@ -132,7 +132,7 @@ eknc_content_object_model_get_property (GObject    *object,
       break;
 
     case PROP_DISCOVERY_FEED_CONTENT:
-      g_value_set_variant (value, priv->discovery_feed_content);
+      g_value_set_boxed (value, priv->discovery_feed_content);
       break;
 
     default:
@@ -226,8 +226,8 @@ eknc_content_object_model_set_property (GObject *object,
       break;
 
     case PROP_DISCOVERY_FEED_CONTENT:
-      g_clear_pointer (&priv->discovery_feed_content, g_variant_unref);
-      priv->discovery_feed_content = g_value_dup_variant (value);
+      g_clear_pointer (&priv->discovery_feed_content, json_object_unref);
+      priv->discovery_feed_content = g_value_dup_boxed (value);
       break;
 
     default:
@@ -277,7 +277,7 @@ eknc_content_object_model_finalize (GObject *object)
   g_clear_pointer (&priv->license, g_free);
   g_clear_pointer (&priv->tags, g_strfreev);
   g_clear_pointer (&priv->resources, g_strfreev);
-  g_clear_pointer (&priv->discovery_feed_content, g_variant_unref);
+  g_clear_pointer (&priv->discovery_feed_content, json_object_unref);
 
   G_OBJECT_CLASS (eknc_content_object_model_parent_class)->finalize (object);
 }
@@ -458,9 +458,9 @@ eknc_content_object_model_class_init (EkncContentObjectModelClass *klass)
    * discovery feed.
    */
   eknc_content_object_model_props[PROP_DISCOVERY_FEED_CONTENT] =
-    g_param_spec_variant ("discovery-feed-content", "Discovery Feed Content",
+    g_param_spec_boxed ("discovery-feed-content", "Discovery Feed Content",
       "Content to be used by the Discovery Feed",
-      G_VARIANT_TYPE ("a{sv}"), NULL,
+      JSON_TYPE_OBJECT,
       G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY | G_PARAM_STATIC_STRINGS);
 
   g_object_class_install_properties (object_class,
@@ -586,9 +586,9 @@ eknc_content_object_model_get_resources (EkncContentObjectModel *self)
  * Get the discovery feed content for the model, which is a collection of
  * properties with no defined schema yet.
  *
- * Returns: (transfer none): a #GVariant
+ * Returns: (transfer none): a #JsonObject
  */
-GVariant *
+JsonObject *
 eknc_content_object_model_get_discovery_feed_content (EkncContentObjectModel *self)
 {
   g_return_val_if_fail (EKNC_IS_CONTENT_OBJECT_MODEL (self), NULL);

--- a/ekncontent/ekncontent/eknc-content-object-model.h
+++ b/ekncontent/ekncontent/eknc-content-object-model.h
@@ -23,6 +23,9 @@ eknc_content_object_model_get_tags (EkncContentObjectModel *self);
 char * const *
 eknc_content_object_model_get_resources (EkncContentObjectModel *self);
 
+GVariant *
+eknc_content_object_model_get_discovery_feed_content (EkncContentObjectModel *self);
+
 EkncContentObjectModel *
 eknc_content_object_model_new_from_json_node (JsonNode *node);
 

--- a/ekncontent/ekncontent/eknc-content-object-model.h
+++ b/ekncontent/ekncontent/eknc-content-object-model.h
@@ -23,7 +23,7 @@ eknc_content_object_model_get_tags (EkncContentObjectModel *self);
 char * const *
 eknc_content_object_model_get_resources (EkncContentObjectModel *self);
 
-GVariant *
+JsonObject *
 eknc_content_object_model_get_discovery_feed_content (EkncContentObjectModel *self);
 
 EkncContentObjectModel *

--- a/ekncontent/ekncontent/eknc-utils.c
+++ b/ekncontent/ekncontent/eknc-utils.c
@@ -173,8 +173,6 @@ eknc_utils_append_gparam_from_json_node (JsonNode *node,
 
       if (g_variant_type_equal (type, G_VARIANT_TYPE ("aa{sv}")))
         variant = dict_array_from_json (node, &error);
-      else if (g_variant_type_equal (type, G_VARIANT_TYPE ("a{sv}")))
-        variant = dict_from_json (node, &error);
       else
         variant = json_gvariant_deserialize (node, g_variant_type_peek_string (type), &error);
 
@@ -193,6 +191,10 @@ eknc_utils_append_gparam_from_json_node (JsonNode *node,
     {
       char **array = string_array_from_json (node);
       g_value_take_boxed (&param.value, array);
+    }
+  else if (JSON_NODE_HOLDS_OBJECT (node) && pspec->value_type == JSON_TYPE_OBJECT)
+    {
+      g_value_set_boxed (&param.value, json_node_get_object (node));
     }
   else if (JSON_NODE_HOLDS_VALUE (node))
     {

--- a/ekncontent/overrides/EosKnowledgeContent.js
+++ b/ekncontent/overrides/EosKnowledgeContent.js
@@ -30,7 +30,7 @@ function add_custom_model_constructors (model) {
     // better yet support introspection on list properties
     model.new_from_props = function (props={}) {
         marshal_property(props, 'discovery-feed-content', function (v) {
-            return new GLib.Variant('a{sv}', v);
+            return Json.from_string(JSON.stringify(v)).get_object();
         });
         marshal_property(props, 'table-of-contents', function (v) {
             // Mimic json_gvariant_deserialize
@@ -57,8 +57,9 @@ function _init() {
 
     define_property(Eknc.ContentObjectModel, 'discovery-feed-content', {
         get: function () {
-            let content = this.get_discovery_feed_content();
-            return content ? content.deep_unpack() : [];
+            let node = new Json.Node();
+            node.init_object(this.get_discovery_feed_content());
+            return JSON.parse(Json.to_string(node, false));
         }
     });
 

--- a/ekncontent/tests/ekncontent/testContentObjectModel.js
+++ b/ekncontent/tests/ekncontent/testContentObjectModel.js
@@ -12,6 +12,9 @@ const MOCK_CONTENT_DATA = {
     'thumbnail': 'ekn://text_editors/Stallman.jpg',
     'resources': ['ekn://text_editors/stallman_the_bard', 'ekn://text_editors/emacs_screenshot'],
     'featured': true,
+    'discoveryFeedContent': {'blurbs':
+        ['10 Facts About Emacs That Will Blow Your Mind. #7 Knocked My Socks Off!'],
+    },
 };
 
 describe('Content Object Model', function () {
@@ -92,6 +95,12 @@ describe('Content Object Model', function () {
 
         it('has a featured flag', function () {
             expect(contentObject.featured).toBeTruthy();
+        });
+
+        // SKIP: Doesn't work because of deep-unpacking
+        xit('has discovery feed content', function () {
+            expect(contentObject.discovery_feed_content)
+                .toEqual(MOCK_CONTENT_DATA['discoveryFeedContent']);
         });
     });
 });

--- a/ekncontent/tests/ekncontent/testContentObjectModel.js
+++ b/ekncontent/tests/ekncontent/testContentObjectModel.js
@@ -97,8 +97,7 @@ describe('Content Object Model', function () {
             expect(contentObject.featured).toBeTruthy();
         });
 
-        // SKIP: Doesn't work because of deep-unpacking
-        xit('has discovery feed content', function () {
+        it('has discovery feed content', function () {
             expect(contentObject.discovery_feed_content)
                 .toEqual(MOCK_CONTENT_DATA['discoveryFeedContent']);
         });


### PR DESCRIPTION
Instead of string-to-JSON-to-GVariant, we now go string-to-JSON. We can
now drop another problematic JSON-to-GVariant conversion.

https://phabricator.endlessm.com/T20702