### PR TITLE
T20761: Add "content-type" filter and "wrapper-uri" prop

### DIFF
--- a/ekncontent/ekncontent/eknc-query-object.c
+++ b/ekncontent/ekncontent/eknc-query-object.c
@@ -16,6 +16,7 @@
 #define MAX_TERM_LENGTH 245
 
 #define XAPIAN_PREFIX_EXACT_TITLE "XEXACTS"
+#define XAPIAN_PREFIX_CONTENT_TYPE "T"
 #define XAPIAN_PREFIX_ID "Q"
 #define XAPIAN_PREFIX_TAG "K"
 
@@ -51,6 +52,7 @@ struct _EkncQueryObject
   gchar *corrected_terms;
   gchar *stopword_free_terms;
   gchar *literal_query;
+  gchar *content_type;
   EkncQueryObjectMode mode;
   EkncQueryObjectMatch match;
   EkncQueryObjectSort sort;
@@ -86,6 +88,7 @@ enum {
   PROP_EXCLUDED_IDS,
   PROP_EXCLUDED_TAGS,
   PROP_CORRECTED_TERMS,
+  PROP_CONTENT_TYPE,
   NPROPS
 };
 
@@ -163,6 +166,10 @@ eknc_query_object_get_property (GObject    *object,
 
     case PROP_EXCLUDED_TAGS:
       g_value_set_boxed (value, self->excluded_tags);
+      break;
+
+    case PROP_CONTENT_TYPE:
+      g_value_set_string (value, self->content_type);
       break;
 
     default:
@@ -254,6 +261,11 @@ eknc_query_object_set_property (GObject *object,
       self->excluded_tags = g_value_dup_boxed (value);
       break;
 
+    case PROP_CONTENT_TYPE:
+      g_clear_pointer (&self->content_type, g_free);
+      self->content_type = g_value_dup_string (value);
+      break;
+
     default:
       G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
     }
@@ -269,6 +281,7 @@ eknc_query_object_finalize (GObject *object)
   g_clear_pointer (&self->corrected_terms, g_free);
   g_clear_pointer (&self->stopword_free_terms, g_free);
   g_clear_pointer (&self->literal_query, g_free);
+  g_clear_pointer (&self->content_type, g_free);
   g_clear_pointer (&self->tags_match_all, g_strfreev);
   g_clear_pointer (&self->tags_match_any, g_strfreev);
   g_clear_pointer (&self->ids, g_strfreev);
@@ -454,6 +467,17 @@ eknc_query_object_class_init (EkncQueryObjectClass *klass)
     g_param_spec_boxed ("excluded-tags", "Excluded tags",
       "A list of specific ekn tags to exclude from the search",
       G_TYPE_STRV,
+      G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY | G_PARAM_STATIC_STRINGS);
+
+  /**
+   * EkncQueryObject:content-type:
+   *
+   * Content Type to restrict the search to.
+   */
+  eknc_query_object_props[PROP_CONTENT_TYPE] =
+    g_param_spec_string ("content-type", "Content Type",
+      "Content Type to restrict the search to",
+      NULL,
       G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY | G_PARAM_STATIC_STRINGS);
 
   g_object_class_install_properties (object_class,
@@ -726,6 +750,21 @@ eknc_query_object_get_search_terms (EkncQueryObject *self)
   return self->search_terms;
 }
 
+/**
+ * eknc_query_object_get_content_type:
+ * @self: the model
+ *
+ * Get the content type that this query is restricted to
+ *
+ * Returns: (transfer none): the content type as a string
+ */
+const char *
+eknc_query_object_get_content_type (EkncQueryObject *self)
+{
+  g_return_val_if_fail (EKNC_IS_QUERY_OBJECT (self), NULL);
+  return self->content_type;
+}
+
 /*
  * get_corrected_query:
  * @self: a #EkncQueryObject
@@ -828,6 +867,27 @@ get_corrected_query (EkncQueryObject *self,
 }
 
 /*
+ * get_content_type_clause:
+ * @content_type: a string containing the content type
+ *
+ * Retreives a content-type query clause from the content type string
+ *
+ * Returns: (transfer full) (nullable): a #XapianQuery object
+ *
+ */
+static XapianQuery *
+get_content_type_clause (const gchar *content_type)
+{
+  g_autofree gchar *prefixed = NULL;
+
+  if (content_type == NULL)
+    return NULL;
+
+  prefixed = g_strconcat (XAPIAN_PREFIX_CONTENT_TYPE, content_type, NULL);
+  return xapian_query_new_for_term (prefixed);
+}
+
+/*
  * get_filter_clause:
  * @self: a #EkncQueryObject
  *
@@ -838,7 +898,10 @@ get_corrected_query (EkncQueryObject *self,
 static XapianQuery *
 get_filter_clause (EkncQueryObject *self)
 {
-  if (self->tags_match_any == NULL && self->tags_match_all == NULL && self->ids == NULL)
+  if (self->tags_match_any == NULL &&
+      self->tags_match_all == NULL &&
+      self->ids == NULL &&
+      self->content_type == NULL)
     return NULL;
 
   GSList *clauses = NULL;
@@ -853,6 +916,10 @@ get_filter_clause (EkncQueryObject *self)
   XapianQuery *ids = get_ids_clause (self->ids, XAPIAN_QUERY_OP_OR);
   if (ids != NULL)
     clauses = g_slist_prepend (clauses, ids);
+
+  XapianQuery *content_type = get_content_type_clause (self->content_type);
+  if (content_type != NULL)
+    clauses = g_slist_prepend (clauses, content_type);
 
   if (clauses == NULL)
     return NULL;

--- a/ekncontent/ekncontent/eknc-query-object.h
+++ b/ekncontent/ekncontent/eknc-query-object.h
@@ -98,6 +98,9 @@ eknc_query_object_get_offset (EkncQueryObject *self);
 guint
 eknc_query_object_get_limit (EkncQueryObject *self);
 
+const char *
+eknc_query_object_get_content_type (EkncQueryObject *self);
+
 XapianQuery *
 eknc_query_object_get_query (EkncQueryObject *self,
                              XapianQueryParser *qp,

--- a/ekncontent/ekncontent/eknc-video-object-model.c
+++ b/ekncontent/ekncontent/eknc-video-object-model.c
@@ -18,6 +18,7 @@ typedef struct {
   guint duration;
   gchar *transcript;
   gchar *poster_uri;
+  gchar *wrapper_uri;
 } EkncVideoObjectModelPrivate;
 
 G_DEFINE_TYPE_WITH_PRIVATE (EkncVideoObjectModel,
@@ -29,6 +30,7 @@ enum {
   PROP_DURATION,
   PROP_TRANSCRIPT,
   PROP_POSTER_URI,
+  PROP_WRAPPER_URI,
   NPROPS
 };
 
@@ -55,6 +57,10 @@ eknc_video_object_model_get_property (GObject    *object,
 
     case PROP_POSTER_URI:
       g_value_set_string (value, priv->poster_uri);
+      break;
+
+    case PROP_WRAPPER_URI:
+      g_value_set_string (value, priv->wrapper_uri);
       break;
 
     default:
@@ -87,6 +93,11 @@ eknc_video_object_model_set_property (GObject *object,
       priv->poster_uri = g_value_dup_string (value);
       break;
 
+    case PROP_WRAPPER_URI:
+      g_clear_pointer (&priv->wrapper_uri, g_free);
+      priv->wrapper_uri = g_value_dup_string (value);
+      break;
+
     default:
       G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
     }
@@ -100,6 +111,7 @@ eknc_video_object_model_finalize (GObject *object)
 
   g_clear_pointer (&priv->transcript, g_free);
   g_clear_pointer (&priv->poster_uri, g_free);
+  g_clear_pointer (&priv->wrapper_uri, g_free);
 
   G_OBJECT_CLASS (eknc_video_object_model_parent_class)->finalize (object);
 }
@@ -142,6 +154,18 @@ eknc_video_object_model_class_init (EkncVideoObjectModelClass *klass)
     g_param_spec_string ("poster-uri", "Poster URI",
       "URI of the poster image",
       "", G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY | G_PARAM_STATIC_STRINGS);
+  /**
+   * EkncVideoObjectModel:wrapper-uri:
+   *
+   * URI of an article that wraps this video if the video is thinly
+   * wrapped by some other article.
+   *
+   * The EKN ID of an #ArticleObjectModel.
+   */
+  eknc_video_object_model_props[PROP_WRAPPER_URI] =
+    g_param_spec_string ("wrapper-uri", "Wrapper",
+      "URI of the wrapper article",
+      "", G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY | G_PARAM_STATIC_STRINGS);
 
   g_object_class_install_properties (object_class,
                                      NPROPS,
@@ -176,6 +200,9 @@ eknc_video_object_model_add_json_to_params (JsonNode *node,
                                            params);
   eknc_utils_append_gparam_from_json_node (json_object_get_member (object, "poster"),
                                            g_object_class_find_property (klass, "poster-uri"),
+                                           params);
+  eknc_utils_append_gparam_from_json_node (json_object_get_member (object, "wrapper"),
+                                           g_object_class_find_property (klass, "wrapper-uri"),
                                            params);
   g_type_class_unref (klass);
 }


### PR DESCRIPTION
This PR adds a "content-type" filter to `EkncQueryObject` and a "wrapper-uri" property to `EkncVideoObjectModel`.

The "wrapper-uri" property indicates on an `EkncVideoObjectModel` which article ID is "thinly wrapping" it if it was tagged with `EknWrappedContent`. Capturing this relationship might be useful if a client needs to go back from some `EkncVideoObjectModel` to its wrapper.

The "content-type" filter on `EkncQueryObject` makes use of the `XCONTENTTYPE` term prefix added to the shard packer as a means to filter results by content type.

It should be noted that both of these changes aren't strictly speaking necessary in order to enable the feature referred to on the ticket, though they were both requested there, so this PR was created for completeness sake.

https://phabricator.endlessm.com/T20761