### PR TITLE
ekncontent: Support "content-type" property on EknQueryObject

### DIFF
--- a/ekncontent/docs/reference/ekncontent/eos-knowledge-content-sections.txt
+++ b/ekncontent/docs/reference/ekncontent/eos-knowledge-content-sections.txt
@@ -138,6 +138,7 @@ EkncQueryObjectMode
 EkncQueryObjectMatch
 EkncQueryObjectSort
 EkncQueryObjectOrder
+eknc_query_object_get_content_type
 eknc_query_object_get_cutoff
 eknc_query_object_get_excluded_ids
 eknc_query_object_get_excluded_tags

--- a/ekncontent/ekncontent/eknc-query-object.h
+++ b/ekncontent/ekncontent/eknc-query-object.h
@@ -98,6 +98,9 @@ eknc_query_object_get_offset (EkncQueryObject *self);
 guint
 eknc_query_object_get_limit (EkncQueryObject *self);
 
+const char *
+eknc_query_object_get_content_type (EkncQueryObject *self);
+
 XapianQuery *
 eknc_query_object_get_query (EkncQueryObject *self,
                              XapianQueryParser *qp,

--- a/ekncontent/tests/ekncontent/testQueryObject.js
+++ b/ekncontent/tests/ekncontent/testQueryObject.js
@@ -188,6 +188,14 @@ describe('QueryObject', function () {
                 .toEqual('Query((<alldocuments> AND_NOT ((Kjazz OR Kblues) AND (Q0123456789abcdef01230123456789abcdef0123 OR Qc0ffeec0ffeec0ffeec0c0ffeec0ffeec0ffeec0))))');
         });
 
+        it('can filter by content type', function () {
+            let query_obj = new Eknc.QueryObject({
+                content_type: 'text/html'
+            });
+            expect(query_obj.get_query(qp).get_description())
+                .toEqual('Query(Ttext/html)');
+        });
+
         it('combines filter and filter-out clauses', function () {
             let query_obj = new Eknc.QueryObject({
                 tags_match_any: ['rock'],


### PR DESCRIPTION
This property can be used to filter a query by content type, for
instance, if you only want to get images or HTML articles.

https://phabricator.endlessm.com/T21112