### PR TITLE
Remove all remaining GtkSpinners

### DIFF
--- a/data/widgets/view/document.ui
+++ b/data/widgets/view/document.ui
@@ -113,7 +113,7 @@
               </packing>
             </child>
             <child>
-              <object class="GtkSpinner" id="spinner">
+              <object class="EknSpinnerReplacement" id="spinner">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
               </object>

--- a/data/widgets/websharedialog.ui
+++ b/data/widgets/websharedialog.ui
@@ -53,7 +53,7 @@
                   </packing>
                 </child>
                 <child type="overlay">
-                  <object class="GtkSpinner" id="spinner">
+                  <object class="EknSpinnerReplacement" id="spinner">
                     <property name="can_focus">False</property>
                   </object>
                   <packing>

--- a/eos-knowledge.gresource.xml
+++ b/eos-knowledge.gresource.xml
@@ -212,6 +212,7 @@
     <file>js/app/widgets/slidingPanel.js</file>
     <file>js/app/widgets/slidingPanelOverlay.js</file>
     <file>js/app/widgets/spaceContainer.js</file>
+    <file>js/app/widgets/spinnerReplacement.js</file>
     <file>js/app/widgets/tabButton.js</file>
     <file>js/app/widgets/tableOfContents.js</file>
     <file>js/app/widgets/themeableImage.js</file>

--- a/js/app/modules/contentGroup/contentGroup.js
+++ b/js/app/modules/contentGroup/contentGroup.js
@@ -17,6 +17,7 @@ const Dispatcher = imports.app.dispatcher;
 const HistoryStore = imports.app.historyStore;
 const Module = imports.app.interfaces.module;
 const Overflow = imports.app.modules.arrangement.overflow;
+const {SpinnerReplacement} = imports.app.widgets.spinnerReplacement;
 const Utils = imports.app.utils;
 
 let _ = Gettext.dgettext.bind(null, Config.GETTEXT_PACKAGE);
@@ -351,29 +352,5 @@ var ContentGroup = new Module.Class({
         if (max_cards > -1)
             cards_to_load = max_cards;
         this._selection.queue_load_more(cards_to_load);
-    },
-});
-
-const SpinnerReplacement = new Lang.Class({
-    Name: 'SpinnerReplacement',
-    Extends: Gtk.Revealer,
-
-    _init(props={}) {
-        props.transition_duration = 200;
-        props.transition_type = Gtk.RevealerTransitionType.CROSSFADE;
-        this.parent(props);
-
-        let fake_spinner = Gtk.Image.new_from_icon_name('content-loading-symbolic',
-            Gtk.IconSize.DIALOG);
-        fake_spinner.show();
-        this.add(fake_spinner);
-    },
-
-    get active() {
-        return this.reveal_child;
-    },
-
-    set active(v) {
-        this.reveal_child = v;
     },
 });

--- a/js/app/modules/view/document.js
+++ b/js/app/modules/view/document.js
@@ -16,11 +16,14 @@ const HistoryStore = imports.app.historyStore;
 const InArticleSearch = imports.app.widgets.inArticleSearch;
 const Module = imports.app.interfaces.module;
 const PDFView = imports.app.widgets.PDFView;
-// Make sure included for glade template
-const SlidingPanelOverlay = imports.app.widgets.slidingPanelOverlay;
+const {slidingPanelOverlay, spinnerReplacement} = imports.app.widgets;
 const TableOfContents = imports.app.widgets.tableOfContents;
 const Utils = imports.app.utils;
 const {View} = imports.app.interfaces.view;
+
+// Make sure included for glade template
+void slidingPanelOverlay;
+void spinnerReplacement;
 
 const SPINNER_PAGE_NAME = 'spinner';
 const CONTENT_PAGE_NAME = 'content';

--- a/js/app/widgets/spinnerReplacement.js
+++ b/js/app/widgets/spinnerReplacement.js
@@ -1,0 +1,26 @@
+/* exported SpinnerReplacement */
+
+const {GObject, Gtk} = imports.gi;
+
+var SpinnerReplacement = GObject.registerClass({
+    GTypeName: 'EknSpinnerReplacement',
+}, class SpinnerReplacement extends Gtk.Revealer {
+    _init(props={}) {
+        props.transition_duration = 200;
+        props.transition_type = Gtk.RevealerTransitionType.CROSSFADE;
+        super._init(props);
+
+        const fake_spinner = Gtk.Image.new_from_icon_name('content-loading-symbolic',
+            Gtk.IconSize.DIALOG);
+        fake_spinner.show();
+        this.add(fake_spinner);
+    }
+
+    get active() {
+        return this.reveal_child;
+    }
+
+    set active(v) {
+        this.reveal_child = v;
+    }
+});

--- a/js/app/widgets/webShareDialog.js
+++ b/js/app/widgets/webShareDialog.js
@@ -12,11 +12,13 @@ const Gettext = imports.gettext;
 const WebKit2 = imports.gi.WebKit2;
 
 const Lang = imports.lang;
+const {spinnerReplacement} = imports.app.widgets;
 
 let _ = Gettext.dgettext.bind(null, Config.GETTEXT_PACKAGE);
 
-/* Template needs WebView type */
+/* Template needs WebView and SpinnerReplacement types */
 GObject.type_ensure( WebKit2.WebView.$gtype);
+void spinnerReplacement;
 
 const MsgResponse = {
     NONE: 0,


### PR DESCRIPTION
GtkSpinner animations still don't interact well with the video player.
It is causing async operations not to resolve. Replace existing
GtkSpinners with the EknSpinnerReplacement that we already used in
ContentGroup.

https://phabricator.endlessm.com/T21362