### PR TITLE
docs, ingester tutorial: Highlight code

### DIFF
--- a/docs/framework/tutorial/ingester-full-code.md
+++ b/docs/framework/tutorial/ingester-full-code.md
@@ -3,7 +3,9 @@ title: Full code
 short-description: The full ingester code
 ...
 ## index.js ##
+{% highlight javascript %}
 {{ tutorial/code/cc-ingester/index.js }}
+{% endhighlight %}
 
 ## package.json ##
 {{ tutorial/code/cc-ingester/package.json }}


### PR DESCRIPTION
For some reason the index.js is not highlighted by default, unlike the
two json files in this same page which are properly highlighted.