### PR TITLE
ThemeableImage: ignore PixbufLoader exceptions

### DIFF
--- a/js/app/widgets/themeableImage.js
+++ b/js/app/widgets/themeableImage.js
@@ -74,9 +74,13 @@ var ThemeableImage = new Knowledge.Class({
                 loader.write_bytes(chunk);
             } while (this._pixbuf_width === undefined);
 
-            /* Close stream and loader */
-            stream.close(null);
-            loader.close();
+            try {
+                /* Close stream and loader */
+                stream.close(null);
+
+                /* Ignore errors, we are only interested in the image size */
+                loader.close();
+            } catch (e) { }
 
             let provider = new Gtk.CssProvider();
             provider.load_from_data(


### PR DESCRIPTION
On close pixbuf loaders try to finish parsing the image and can throw
exceptions if there is any error. But since we are not trying to
actually load the image, we just wanted to ge the image size,
we need to ignore them.

https://phabricator.endlessm.com/T21534