### PR TITLE
Depend on xapian-glib-2.0

### DIFF
--- a/ekncontent/Makefile.am
+++ b/ekncontent/Makefile.am
@@ -233,7 +233,7 @@ EosKnowledgeContent_@EKN_CONTENT_API_VERSION@_gir_INCLUDES = \
 	GObject-2.0 \
 	Json-1.0 \
 	Soup-2.4 \
-	Xapian-1.0 \
+	Xapian-2.0 \
 	$(NULL)
 EosKnowledgeContent_@EKN_CONTENT_API_VERSION@_gir_SCANNERFLAGS = \
 	--warn-all --warn-error \

--- a/ekncontent/configure.ac
+++ b/ekncontent/configure.ac
@@ -120,7 +120,7 @@ AC_SUBST([JASMINE_REPORT_ARGUMENT])
 # Package dependencies
 # Update these whenever you use a function that requires a certain API version
 AX_PKG_CHECK_MODULES([EKN_CONTENT], [glib-2.0 gio-2.0 gobject-2.0 json-glib-1.0 libsoup-2.4],
-    [eos-shard-0 >= 0.1.2 xapian-glib-1.0 >= 1.7 endless-0 >= 0.5])
+    [eos-shard-0 >= 0.1.2 xapian-glib-2.0 endless-0 >= 0.5])
 AX_PKG_CHECK_MODULES([EKN_VFS], [], [eos-shard-0 gio-2.0 gmodule-2.0])
 
 # Code Coverage

--- a/ekncontent/tests/ekncontent/testQueryObject.js
+++ b/ekncontent/tests/ekncontent/testQueryObject.js
@@ -1,4 +1,6 @@
 const Eknc = imports.gi.EosKnowledgeContent;
+
+imports.gi.Xapian.version = '2.0';
 const Xapian = imports.gi.Xapian;
 
 describe('QueryObject', function () {


### PR DESCRIPTION
We're switching to a new version of Xapian, which means we're going to
be using a new version of the Xapian-GLib bindings.

https://phabricator.endlessm.com/T21284