### PR TITLE
ThemeableImage: fix infinite loop bug

### DIFF
--- a/js/app/widgets/themeableImage.js
+++ b/js/app/widgets/themeableImage.js
@@ -69,7 +69,7 @@ var ThemeableImage = new Knowledge.Class({
             /* Read 4k chunks until we get the image size */
             do {
                 let chunk = stream.read_bytes(4096, null);
-                if (chunk === null)
+                if (chunk === null || chunk.get_size() === 0)
                     break;
                 loader.write_bytes(chunk);
             } while (this._pixbuf_width === undefined);


### PR DESCRIPTION
Fix pixbuf loader loop.

g_input_stream_read_bytes() started to return a zero-length GBytes
instead of null when there is no more data causing an infinite loop.

https://phabricator.endlessm.com/T21788