### PR TITLE
Fix tutorial node tar extraction step

### DIFF
--- a/docs/framework/tutorial/install.md
+++ b/docs/framework/tutorial/install.md
@@ -49,7 +49,7 @@ Create a `.local` folder in your home directory and unzip the downloaded package
 
 ```bash
 mkdir -p ~/.local
-tar -C ~/.local -xJf --strip-components=1 node-v8.9.4-linux-x64.tar.xz
+tar -C ~/.local -xJf node-v8.9.4-linux-x64.tar.xz --strip-components=1
 ```
 
 Check if `~/.local/bin` is in your path (`echo $PATH`) and if not, add the following line to your `~/.bashrc` file, then close and reopen the terminal:


### PR DESCRIPTION
Error gives:
```tar (child): --strip-components=1: Cannot open: No such file or directory```