### PR TITLE
thematic: Remove search box right margin

### DIFF
--- a/data/css/thematic.scss
+++ b/data/css/thematic.scss
@@ -43,7 +43,6 @@ $legacy-post-card-border-color-hover: white !default;
 
     .NavigationSearchBox {
         min-width: 400px;
-        margin-right: 30px;
     }
 }
 


### PR DESCRIPTION
It's not clear why this margin was there, since there was already other
padding separating the search box from the edge of the window. It only
served to create an odd gap between the width of the search box and the
width of the popup.

https://phabricator.endlessm.com/T20352