### PR TITLE
application: Fix caching of web overrides SCSS compilation

### DIFF
--- a/data/css/modules/card/_default.scss
+++ b/data/css/modules/card/_default.scss
@@ -25,10 +25,6 @@
         font-size: 16px;
     }
 
-    &__synopsis {
-        font-size: 16px;
-    }
-
     &__context {
         font-weight: bold;
         font-size: 14px;

--- a/js/framework/application.js
+++ b/js/framework/application.js
@@ -141,8 +141,10 @@ var Application = new Knowledge.Class({
 
         if (has_option('web-overrides-path')) {
             this._web_overrides_path = get_option_string('web-overrides-path');
-            if (!this._web_overrides_path.endsWith('.scss'))
-                this._compiled_web_overrides_path = this._web_overrides_path;
+            if (!this._web_overrides_path.endsWith('.scss')) {
+                const uri = Gio.File.new_for_path(this._web_overrides_path).get_uri();
+                this._compiled_web_overrides_uri = uri;
+            }
         }
 
         return -1;


### PR DESCRIPTION
Previously the result of the SCSS compilation was not saved, so the
compilation would be performed every time a webpage was loaded when
using the -w debug option.

https://phabricator.endlessm.com/T23562