### PR TITLE
Fix source code that's incompatible with mozjs60

### DIFF
--- a/js/framework/application.js
+++ b/js/framework/application.js
@@ -225,7 +225,9 @@ var Application = new Knowledge.Class({
 
         try {
             this._initialize_vfs();
-        } catch (e if e.matches(DModel.DomainError, DModel.DomainError.EMPTY)) {
+        } catch (e) {
+            if (!e.matches(DModel.DomainError, DModel.DomainError.EMPTY))
+                throw e;
             let dialog = new NoContentDialog.NoContentDialog();
             dialog.run();
         }
@@ -307,7 +309,9 @@ var Application = new Knowledge.Class({
         try {
             [, contents] = theme_file.load_contents(null);
             contents = contents.toString();
-        } catch (error if !this._overrides_path && error.matches(Gio.IOErrorEnum, Gio.IOErrorEnum.NOT_FOUND)) {
+        } catch (e) {
+            if (this._overrides_path || !e.matches(Gio.IOErrorEnum, Gio.IOErrorEnum.NOT_FOUND))
+                throw e;
             // No overrides, fallback to stock theme
             return '';
         }

--- a/js/framework/knowledge.js
+++ b/js/framework/knowledge.js
@@ -92,7 +92,7 @@ var Class = new Lang.Class({
                     // gjs, which will have proptotype.__name__ set
                     let iface_name = iface.prototype.__name__;
                     if (is_widget && iface_name)
-                        this.get_style_context().add_class(iface_name.replace('.', '', 'g'));
+                        this.get_style_context().add_class(iface_name.replace(/\./g, ''));
                 });
             }
             this._interfaces_inited = true;

--- a/js/framework/modules/selection/contentForSet.js
+++ b/js/framework/modules/selection/contentForSet.js
@@ -63,7 +63,7 @@ var ContentForSet = new Module.Class({
     },
 
     _get_model: function (property_name) {
-        let model = HistoryStore.get_default()[property_name.replace('-', '_', 'g')];
+        let model = HistoryStore.get_default()[property_name.replace(/-/g, '_')];
         if (model && this.track_parent)
             model = SetMap.get_parent_set(model);
         return model;

--- a/js/framework/utils.js
+++ b/js/framework/utils.js
@@ -533,7 +533,9 @@ function components_from_id(id) {
 function ensure_directory (dir) {
     try {
         dir.make_directory_with_parents(null);
-    } catch (e if e.matches(Gio.IOErrorEnum, Gio.IOErrorEnum.EXISTS)) {
+    } catch (e) {
+        if (!e.matches(Gio.IOErrorEnum, Gio.IOErrorEnum.EXISTS))
+            throw e;
         // Directory already exists, we're good.
     }
 }

--- a/tests/compliance.js
+++ b/tests/compliance.js
@@ -32,7 +32,7 @@ function test_card_compliance(CardClass, setup=function () {}) {
                 }),
             });
             let pretty_name = CardClass.$gtype.name.slice('Ekn'.length)
-                .replace(/_/, '', 'g');
+                .replace(/_/g, '');
             expect(card).toHaveCssClass('Card--pdf');
             expect(card).toHaveCssClass(pretty_name + '--pdf');
             card = new CardClass({

--- a/tests/js/framework/modules/layout/testArticleStack.js
+++ b/tests/js/framework/modules/layout/testArticleStack.js
@@ -71,7 +71,7 @@ describe('Layout.ArticleStack', function () {
         });
 
         selection = factory.get_last_created('contents.selection');
-        view = factory.get_last_created('contents.article.0');
+        view = factory.get_last_created('contents.article');
     });
 
     it('transitions in new content when state changes to article page', function () {
@@ -95,7 +95,7 @@ describe('Layout.ArticleStack', function () {
         selection.get_models.and.returnValue([different_article_model]);
         selection.emit('models-changed');
         Utils.update_gui();
-        let new_view = factory.get_created('contents.article.1')[0];
+        let new_view = factory.get_created('contents.article')[1];
         expect(new_view).toBeDefined();
         expect(module).toHaveDescendant(new_view);
     });

--- a/tests/mockFactory.js
+++ b/tests/mockFactory.js
@@ -52,7 +52,7 @@ const MockFactory = new Knowledge.Class({
     _create_module: function (path, description, extra_props={}) {
         let module = this.parent(path, description, extra_props);
 
-        let key = path.replace(/\.[0-9]+/, '', 'g').replace(/^root\./, '');
+        let key = path.replace(/\.[0-9]+/g, '').replace(/^root\./, '');
         if (!this._created_modules.has(key))
             this._created_modules.set(key, []);
 


### PR DESCRIPTION
This is the result of scanning all the sources in js/ and tests/ with
moz60tool (https://gitlab.gnome.org/ptomato/moz60tool) and fixing the
issues.

Especially the str.replace('foo', 'bar', 'g') which was actually already
invalid since GNOME 3.26, was actually causing some minor bugs.