### PR TITLE
Include better promisify function from upstream GJS

### DIFF
--- a/js/framework/courseHistoryStore.js
+++ b/js/framework/courseHistoryStore.js
@@ -86,7 +86,7 @@ var CourseHistoryStore = new GObject.Class({
 
     // HistoryStore override
     load_dbus_item: function (id, search_terms, timestamp) {
-        DModel.Engine.get_default().get_object_promise(id)
+        DModel.Engine.get_default().get_object(id, null)
         .then((model) => {
             if (model instanceof DModel.Media) {
                 this.set_current_item_from_props({
@@ -123,7 +123,7 @@ var CourseHistoryStore = new GObject.Class({
             tags_match_all: ['EknSetObject'],
             sort: DModel.QuerySort.SEQUENCE_NUMBER,
         });
-        DModel.Engine.get_default().query_promise(query)
+        DModel.Engine.get_default().query(query, null)
         .then((results) => {
             if (results.models.length > 0) {
                 this.set_current_subset(results.models[0]);

--- a/js/framework/historyStore.js
+++ b/js/framework/historyStore.js
@@ -306,7 +306,7 @@ var HistoryStore = new Lang.Class({
     // the same after a link click, factoring out this common function. When we
     // diverge in future interactions we should revisit this decomposition.
     show_id: function (id) {
-        DModel.Engine.get_default().get_object_promise(id)
+        DModel.Engine.get_default().get_object(id, null)
         .then((model) => {
             if (model instanceof DModel.Article) {
                 this.set_current_item_from_props({
@@ -335,7 +335,7 @@ var HistoryStore = new Lang.Class({
     },
 
     load_dbus_item: function (id, search_terms, timestamp) {
-        DModel.Engine.get_default().get_object_promise(id)
+        DModel.Engine.get_default().get_object(id, null)
         .then((model) => {
             if (model instanceof DModel.Article ||
                 model instanceof DModel.Video ||

--- a/js/framework/interfaces/card.js
+++ b/js/framework/interfaces/card.js
@@ -281,7 +281,7 @@ var Card = new Lang.Interface({
         let query = new DModel.Query({
             tags_match_any: set_obj.child_tags,
         });
-        DModel.Engine.get_default().query_promise(query)
+        DModel.Engine.get_default().query(query, null)
         .then((results) => {
             let reached_bottom = true;
             results.models.forEach((obj) => {

--- a/js/framework/modules/contentGroup/mediaLightbox.js
+++ b/js/framework/modules/contentGroup/mediaLightbox.js
@@ -96,7 +96,7 @@ var MediaLightbox = new Module.Class({
             this._preview_media_object(resource);
             this._loading_new_lightbox = false;
         } else {
-            DModel.Engine.get_default().get_object_promise(resource)
+            DModel.Engine.get_default().get_object(resource, null)
             .then((media_object) => {
                 this._loading_new_lightbox = false;
 

--- a/js/framework/modules/layout/articleStack.js
+++ b/js/framework/modules/layout/articleStack.js
@@ -217,7 +217,7 @@ var ArticleStack = new Module.Class({
 
     _on_show_tooltip: function (tooltip_presenter, tooltip, uri) {
         if (GLib.uri_parse_scheme(uri) === 'ekn') {
-            DModel.Engine.get_default().get_object_promise(uri)
+            DModel.Engine.get_default().get_object(uri, null)
             .then((article_model) => {
                 this._webview_tooltip_presenter.show_default_tooltip(tooltip, article_model.title);
             })

--- a/js/framework/modules/navigation/searchBox.js
+++ b/js/framework/modules/navigation/searchBox.js
@@ -99,7 +99,7 @@ var SearchBox = new Module.Class({
             tags_match_any: ['EknArticleObject'],
         });
         let engine = DModel.Engine.get_default();
-        this._query_promise = engine.query_promise(query_obj, this._cancellable)
+        engine.query(query_obj, this._cancellable)
         .then((results) => {
             if (search_terms !== Utils.sanitize_search_terms(this.text))
                 return;

--- a/js/framework/modules/selection/xapian.js
+++ b/js/framework/modules/selection/xapian.js
@@ -97,7 +97,7 @@ var Xapian = new Module.Class({
 
         this._loading = true;
         this.notify('loading');
-        engine.query_promise(query)
+        engine.query(query, null)
         .then(({ models, upper_bound }) => {
             this._loading = false;
             this._set_needs_refresh(false);

--- a/js/framework/moltresEngine.js
+++ b/js/framework/moltresEngine.js
@@ -63,7 +63,7 @@ var MoltresEngine = new Lang.Class({
 
     get_id: function () {},
 
-    get_object_promise: function (id) {
+    get_object(id) {
         return Promise.resolve(this._set_models
         .concat(this._article_models)
         .concat(this._video_models)
@@ -136,7 +136,7 @@ var MoltresEngine = new Lang.Class({
         return to_return;
     },
 
-    query_promise: function (query) {
+    query(query) {
         if (query.tags_match_all.indexOf('EknSetObject') >= 0) {
             return Promise.resolve(this._get_sets(query));
         } else if (query.tags_match_all.indexOf('EknArticleObject') >= 0) {

--- a/js/framework/widgets/eknWebview.js
+++ b/js/framework/widgets/eknWebview.js
@@ -109,7 +109,7 @@ var EknWebview = new Knowledge.Class({
     },
 
     _load_object: function (id) {
-        return DModel.Engine.get_default().get_object_promise(id)
+        return DModel.Engine.get_default().get_object(id, null)
         .then((model) => {
             if (model instanceof DModel.Article) {
                 let html = this.renderer.render(model);

--- a/tests/compliance.js
+++ b/tests/compliance.js
@@ -249,7 +249,7 @@ function test_selection_compliance (SelectionClass, setup=function () {}, extra_
             // Not all Selections might use the Xapian engine, but I can't think
             // of a better place to put this
             let engine = MockEngine.mock_default();
-            engine.query_promise.and.returnValue(Promise.resolve({ models: [] }));
+            engine.query.and.returnValue(Promise.resolve({models: []}));
         });
 
         function add_models (c, num) {
@@ -362,7 +362,7 @@ function test_xapian_selection_compliance(SelectionClass, setup=function () {}, 
             jasmine.addMatchers(WidgetDescendantMatcher.customMatchers);
 
             engine = MockEngine.mock_default();
-            engine.query_promise.and.returnValue(Promise.resolve({ models: [] }));
+            engine.query.and.returnValue(Promise.resolve({models: []}));
         });
 
         it('continues the query based on how many results were added', function () {
@@ -372,24 +372,24 @@ function test_xapian_selection_compliance(SelectionClass, setup=function () {}, 
                 let model = new DModel.Content();
                 models.push(model);
             }
-            engine.query_promise.and.returnValue(Promise.resolve({ models: models, upper_bound: 10 }));
+            engine.query.and.returnValue(Promise.resolve({models, upper_bound: 10}));
             selection.queue_load_more(3);
             Utils.update_gui();
-            let first_query = engine.query_promise.calls.mostRecent().args[0];
+            const [first_query] = engine.query.calls.mostRecent().args;
             // Since we requested 3, we should only add three models to the
             // selection, regardless of how many actually came back.
             expect(selection.add_model.calls.count()).toBe(3);
             selection.queue_load_more(10);
             // When we request more models, we should start the offset from
             // where we left off
-            let second_query = engine.query_promise.calls.mostRecent().args[0];
+            const [second_query] = engine.query.calls.mostRecent().args;
             expect(second_query.offset).toEqual(first_query.offset + 3);
         });
 
         it('by going into an error state when the engine throws an exception', function () {
             spyOn(window, 'logError');  // silence console message
             expect(selection.in_error_state).toBeFalsy();
-            engine.query_promise.and.returnValue(Promise.reject(new Error('asplode')));
+            engine.query.and.returnValue(Promise.reject(new Error('asplode')));
             selection.queue_load_more(1);
             Utils.update_gui();
             expect(selection.in_error_state).toBeTruthy();
@@ -397,7 +397,7 @@ function test_xapian_selection_compliance(SelectionClass, setup=function () {}, 
 
         it('saves the exception that was thrown', function () {
             spyOn(window, 'logError');  // silence console message
-            engine.query_promise.and.returnValue(Promise.reject(new Error('asplode')));
+            engine.query.and.returnValue(Promise.reject(new Error('asplode')));
             selection.queue_load_more(1);
             Utils.update_gui();
             expect(selection.get_error().message).toEqual('asplode');

--- a/tests/js/framework/modules/controller/testCourse.js
+++ b/tests/js/framework/modules/controller/testCourse.js
@@ -38,7 +38,7 @@ describe('Controller.Course', function () {
         set_models.push(parent);
 
         engine = MockEngine.mock_default();
-        engine.query_promise.and.returnValue(Promise.resolve({ models: set_models }));
+        engine.query.and.returnValue(Promise.resolve({models: set_models}));
 
         [course, factory] = MockFactory.setup_tree({
             type: Course.Course,

--- a/tests/js/framework/modules/controller/testMesh.js
+++ b/tests/js/framework/modules/controller/testMesh.js
@@ -43,7 +43,7 @@ describe('Controller.Mesh', function () {
         application.application_id = 'foobar';
 
         engine = MockEngine.mock_default();
-        engine.query_promise.and.returnValue(Promise.resolve({ models: [] }));
+        engine.query.and.returnValue(Promise.resolve({models: []}));
 
         [mesh, factory] = MockFactory.setup_tree({
             type: Mesh.Mesh,

--- a/tests/js/framework/modules/navigation/testSearchBox.js
+++ b/tests/js/framework/modules/navigation/testSearchBox.js
@@ -66,9 +66,9 @@ describe('Navigation.SearchBox', function () {
     });
 
     it('calls into engine for auto complete results', function () {
-        engine.query_promise.and.returnValue(Promise.resolve({ models: [] }));
+        engine.query.and.returnValue(Promise.resolve({models: []}));
         box.text = 'foo';
-        expect(engine.query_promise).toHaveBeenCalled();
+        expect(engine.query).toHaveBeenCalled();
     });
 
     it('dispatches autocomplete-selected when a item is selected', function () {
@@ -76,7 +76,7 @@ describe('Navigation.SearchBox', function () {
             id: 'ekn://aaaabbbbccccdddd',
             title: 'foo',
         });
-        engine.query_promise.and.returnValue(Promise.resolve({ models: [model] }));
+        engine.query.and.returnValue(Promise.resolve({models: [model]}));
         box.text = 'foo';
         Utils.update_gui();
         box.emit('menu-item-selected', 'ekn://aaaabbbbccccdddd');

--- a/tests/js/framework/modules/selection/testNext.js
+++ b/tests/js/framework/modules/selection/testNext.js
@@ -40,7 +40,7 @@ describe('Selection.Next', function () {
 
     it('queries for the next model id', function () {
         selection.queue_load_more(1);
-        let query = engine.query_promise.calls.mostRecent().args[0];
+        const [query] = engine.query.calls.mostRecent().args;
         expect(query.ids[0]).toBe(ID);
     });
 });

--- a/tests/js/framework/modules/selection/testXapian.js
+++ b/tests/js/framework/modules/selection/testXapian.js
@@ -49,7 +49,7 @@ describe('Selection.Xapian superclass', function () {
 
     it('modifies the Xapian query when retrieving subsequent query indices', function (done) {
         let returnedEmpty = false;
-        engine.query_promise.and.callFake(query => {
+        engine.query.and.callFake(() => {
             if (!returnedEmpty) {
                 returnedEmpty = true;
                 return Promise.resolve({
@@ -65,8 +65,8 @@ describe('Selection.Xapian superclass', function () {
 
         selection.queue_load_more(1);
         let connectionId = selection.connect('models-changed', () => {
-            let query1 = engine.query_promise.calls.argsFor(0)[0];
-            let query2 = engine.query_promise.calls.argsFor(1)[0];
+            const [query1] = engine.query.calls.argsFor(0);
+            const [query2] = engine.query.calls.argsFor(1);
             expect(query1.search_terms).toEqual('null title');
             expect(query1.tags_match_all).toEqual(['foobar', 'EknIncludeMe']);
             expect(query2.search_terms).toEqual('null title');

--- a/tests/js/framework/testCourseHistoryStore.js
+++ b/tests/js/framework/testCourseHistoryStore.js
@@ -33,7 +33,7 @@ describe('CourseHistoryStore', function () {
             },
         ];
         let sets = data.map(props => new DModel.Set(props));
-        engine.query_promise.and.returnValue(Promise.resolve({ models: sets }));
+        engine.query.and.returnValue(Promise.resolve({models: sets}));
         SetMap.init_map_with_models(sets);
     });
 
@@ -134,7 +134,7 @@ describe('CourseHistoryStore', function () {
             model = new DModel.Article({
                 id: 'ekn:///foo',
             });
-            engine.get_object_promise.and.returnValue(Promise.resolve(model));
+            engine.get_object.and.returnValue(Promise.resolve(model));
             dispatcher.dispatch({
                 action_type: Actions.DBUS_LOAD_ITEM_CALLED,
                 search_terms: 'foo',
@@ -144,8 +144,8 @@ describe('CourseHistoryStore', function () {
         });
 
         it('loads an item', function () {
-            expect(engine.get_object_promise).toHaveBeenCalled();
-            expect(engine.get_object_promise.calls.mostRecent().args[0])
+            expect(engine.get_object).toHaveBeenCalled();
+            expect(engine.get_object.calls.mostRecent().args[0])
                 .toBe('ekn:///foo');
         });
 
@@ -159,7 +159,7 @@ describe('CourseHistoryStore', function () {
 
         beforeEach(function () {
             model = new DModel.Media();
-            engine.get_object_promise.and.returnValue(Promise.resolve(model));
+            engine.get_object.and.returnValue(Promise.resolve(model));
             dispatcher.dispatch({
                 action_type: Actions.DBUS_LOAD_ITEM_CALLED,
                 search_terms: 'foo',

--- a/tests/js/framework/testMeshHistoryStore.js
+++ b/tests/js/framework/testMeshHistoryStore.js
@@ -182,7 +182,7 @@ describe('MeshHistoryStore', function () {
             let model = new DModel.Article({
                 id: 'ekn://foo/bar',
             });
-            engine.get_object_promise.and.returnValue(Promise.resolve(model));
+            engine.get_object.and.returnValue(Promise.resolve(model));
             dispatcher.dispatch({
                 action_type: Actions.ARTICLE_LINK_CLICKED,
                 id: 'ekn://foo/bar',
@@ -206,7 +206,7 @@ describe('MeshHistoryStore', function () {
             let model = new DModel.Media({
                 id: 'ekn://foo/pix',
             });
-            engine.get_object_promise.and.returnValue(Promise.resolve(model));
+            engine.get_object.and.returnValue(Promise.resolve(model));
             dispatcher.dispatch({
                 action_type: Actions.ARTICLE_LINK_CLICKED,
                 id: 'ekn://foo/pix',
@@ -223,15 +223,15 @@ describe('MeshHistoryStore', function () {
             model = new DModel.Article({
                 id: 'ekn:///foo',
             });
-            engine.get_object_promise.and.returnValue(Promise.resolve(model));
+            engine.get_object.and.returnValue(Promise.resolve(model));
             dispatcher.dispatch({
                 action_type: Actions.DBUS_LOAD_ITEM_CALLED,
                 search_terms: 'foo',
                 id: 'ekn:///foo',
             });
 
-            expect(engine.get_object_promise).toHaveBeenCalled();
-            expect(engine.get_object_promise.calls.mostRecent().args[0])
+            expect(engine.get_object).toHaveBeenCalled();
+            expect(engine.get_object.calls.mostRecent().args[0])
                 .toBe('ekn:///foo');
         });
 
@@ -239,7 +239,7 @@ describe('MeshHistoryStore', function () {
             model = new DModel.Article({
                 id: 'ekn:///foo',
             });
-            engine.get_object_promise.and.returnValue(Promise.resolve(model));
+            engine.get_object.and.returnValue(Promise.resolve(model));
             dispatcher.dispatch({
                 action_type: Actions.DBUS_LOAD_ITEM_CALLED,
                 search_terms: 'foo',
@@ -254,7 +254,7 @@ describe('MeshHistoryStore', function () {
             model = new DModel.Article({
                 id: 'ekn:///foo',
             });
-            engine.get_object_promise.and.returnValue(Promise.resolve(model));
+            engine.get_object.and.returnValue(Promise.resolve(model));
             dispatcher.dispatch({
                 action_type: Actions.DBUS_LOAD_ITEM_CALLED,
                 search_terms: 'foo',
@@ -271,7 +271,7 @@ describe('MeshHistoryStore', function () {
             model = new DModel.Set({
                 id: 'ekn:///foo',
             });
-            engine.get_object_promise.and.returnValue(Promise.resolve(model));
+            engine.get_object.and.returnValue(Promise.resolve(model));
             dispatcher.dispatch({
                 action_type: Actions.DBUS_LOAD_ITEM_CALLED,
                 search_terms: 'foo',
@@ -288,7 +288,7 @@ describe('MeshHistoryStore', function () {
                     model = new DModel[kind]({
                         id: 'ekn:///99bac9189b30bb0877f60e1bc16ded7ad94af37f',
                     });
-                    engine.get_object_promise.and.returnValue(Promise.resolve(model));
+                    engine.get_object.and.returnValue(Promise.resolve(model));
                     dispatcher.dispatch({
                         action_type: Actions.DBUS_LOAD_ITEM_CALLED,
                         search_terms: 'foo',

--- a/tests/mockEngine.js
+++ b/tests/mockEngine.js
@@ -11,27 +11,23 @@ var MockEngine = new Lang.Class({
         this.port = 3003;
         this.language = '';
 
-        // get_object_promise() and query_promise() are spies to begin
+        // get_object() and query() are spies to begin
         // with, since that is how they will usually be used.
         // Use like so, for example:
-        // engine.get_object_promise.and.returnValue(Promise.resolve(my_object));
-        // engine.query_promise.and.returnValue(Promise.resolve([[object1,
+        // engine.get_object.and.returnValue(Promise.resolve(my_object));
+        // engine.query.and.returnValue(Promise.resolve([[object1,
         //    object2], {}]))
-        spyOn(this, 'get_object_promise').and.callThrough();
-        spyOn(this, 'query_promise').and.callThrough();
+        spyOn(this, 'get_object').and.callThrough();
+        spyOn(this, 'query').and.callThrough();
     },
 
     get_id: function () {},
 
-    // FIXME: we launch into the callbacks synchronously because all the tests
-    // in testAisleController expect it currently. Would be good to rewrite
-    // those tests to tolerate a mock object that was actually async.
-
-    get_object_promise: function () {
+    get_object() {
         return Promise.resolve();
     },
 
-    query_promise: function () {
+    query() {
         return Promise.resolve({ models: [], upper_bound: 0 });
     },
 });


### PR DESCRIPTION
The promisify function in upstream GJS (available from GNOME 3.30
onward) has more features, such as better stack traces, the ability to
work on local Gio.File instances, and conforms better to the original
callback-based API.

Once eos-knowledge-lib switches to the GNOME 3.30 runtime, the
_promisify and _LocalFilePrototype code can be removed, since it will be
built in to GJS.