### PR TITLE
Add support for enable_scroll_manager and show_title in non legacy do…

### DIFF
--- a/data/templates/article-wrapper.mst
+++ b/data/templates/article-wrapper.mst
@@ -25,6 +25,9 @@
             window.chunk_init({{{chunk-data}}});
             window.share_actions_init();
             window.nav_content_init();
+            if (window.title_hider_init) {
+                window.title_hider_init();
+            }
         </script>
     </body>
 </html>

--- a/data/templates/js/title-hider.js
+++ b/data/templates/js/title-hider.js
@@ -1,0 +1,3 @@
+function title_hider_init () {
+    $('.eos-article-title').hide();
+}

--- a/eos-knowledge.gresource.xml
+++ b/eos-knowledge.gresource.xml
@@ -33,6 +33,7 @@
     <file preprocess="xml-stripblanks">data/images/deckbg.svg</file>
     <file>data/images/separator.png</file>
     <file>data/templates/js/nav-content.js</file>
+    <file>data/templates/js/title-hider.js</file>
     <file compressed="true">data/templates/article-wrapper.mst</file>
     <file compressed="true" preprocess="xml-stripblanks">data/widgets/banner/app.ui</file>
     <file compressed="true" preprocess="xml-stripblanks">data/widgets/banner/dynamic.ui</file>

--- a/js/framework/articleHTMLRenderer.js
+++ b/js/framework/articleHTMLRenderer.js
@@ -85,7 +85,7 @@ var ArticleHTMLRenderer = new Knowledge.Class({
     },
 
     _get_wrapper_js_files: function () {
-        return [
+        const js_files = [
             'jquery-min.js',
             'clipboard-manager.js',
             'crosslink.js',
@@ -93,6 +93,16 @@ var ArticleHTMLRenderer = new Knowledge.Class({
             'share-actions.js',
             'nav-content.js',
         ];
+
+        if (this.enable_scroll_manager) {
+            js_files.push('scroll-manager.js');
+        }
+
+        if (!this.show_title) {
+            js_files.push('title-hider.js');
+        }
+
+        return js_files;
     },
 
     _get_crosslink_data: function (model) {

--- a/js/framework/modules/view/document.js
+++ b/js/framework/modules/view/document.js
@@ -266,7 +266,7 @@ var Document = new Module.Class({
     _get_webview: function () {
         let webview = this._create_webview();
 
-        webview.renderer.enable_scroll_manager = true;
+        webview.renderer.enable_scroll_manager = this.toc.visible;
         webview.renderer.show_title = !this.show_toc;
         if (this.custom_css)
             webview.renderer.set_custom_css_files([this.custom_css]);


### PR DESCRIPTION
…cuments

These options were only supported by the legacy rendering (used in
Wiki based apps). Now we are stopping to use the legacy rendering by
porting the Wikipedia based apps to a libingester based ingestion
pipeline, so we need to support these to options in non-legacy
documents.

https://phabricator.endlessm.com/T24162