### PR TITLE
Check that GdkWindow exists before using it

### DIFF
--- a/js/framework/utils.js
+++ b/js/framework/utils.js
@@ -41,11 +41,13 @@ function set_hand_cursor_on_widget(widget) {
 
     let enter_id = widget.connect('enter-notify-event', function (widget) {
         let cursor = Gdk.Cursor.new_from_name(widget.get_display(), "pointer");
-        widget.window.set_cursor(cursor);
+        if (widget.window)
+            widget.window.set_cursor(cursor);
         return Gdk.EVENT_PROPAGATE;
     });
     let leave_id = widget.connect('leave-notify-event', function (widget) {
-        widget.window.set_cursor(null);
+        if (widget.window)
+            widget.window.set_cursor(null);
         return Gdk.EVENT_PROPAGATE;
     });
 

--- a/lib/eosknowledgeprivate/EknMediaBin.ui
+++ b/lib/eosknowledgeprivate/EknMediaBin.ui
@@ -36,6 +36,7 @@
     <property name="can_focus">True</property>
     <property name="orientation">vertical</property>
     <signal name="realize" handler="on_ekn_media_bin_realize" swapped="no"/>
+    <signal name="unrealize" handler="on_ekn_media_bin_unrealize" swapped="no"/>
     <child>
       <object class="GtkStack" id="stack">
         <property name="visible">True</property>


### PR DESCRIPTION
This branch fixes several small problems with the MediaBin widget which may have contributed to instability we observed after playing videos.

https://phabricator.endlessm.com/T26126