### PR TITLE
Consistently set GTypeName for GObject interfaces

### DIFF
--- a/js/framework/interfaces/filter.js
+++ b/js/framework/interfaces/filter.js
@@ -26,6 +26,7 @@ const Module = imports.framework.interfaces.module;
  */
 var Filter = new Lang.Interface({
     Name: 'Filter',
+    GTypeName: 'EknFilter',
     Requires: [ Module.Module ],
 
     Properties: {

--- a/js/framework/interfaces/module.js
+++ b/js/framework/interfaces/module.js
@@ -106,6 +106,7 @@ function _freeze_recurse(o) {
  */
 var Module = new Lang.Interface({
     Name: 'Module',
+    GTypeName: 'EknModule',
     Requires: [ GObject.Object ],
 
     Properties: {

--- a/js/framework/interfaces/order.js
+++ b/js/framework/interfaces/order.js
@@ -23,6 +23,7 @@ const Module = imports.framework.interfaces.module;
  */
 var Order = new Lang.Interface({
     Name: 'Order',
+    GTypeName: 'EknOrder',
     Requires: [ Module.Module ],
 
     Properties: {

--- a/tests/js/framework/interfaces/testModule.js
+++ b/tests/js/framework/interfaces/testModule.js
@@ -93,6 +93,7 @@ describe('Module metaclass', function () {
     it('pulls in slots from implemented interfaces', function () {
         const MySlotInterface = new Lang.Interface({
             Name: 'MySlotInterface',
+            GTypeName: 'MySlotInterface',
             Requires: [Module.Module],
             Slots: {
                 'interface-slot': {},

--- a/tests/js/framework/testKnowledge.js
+++ b/tests/js/framework/testKnowledge.js
@@ -42,6 +42,7 @@ describe('Syntactic sugar metaclass', function () {
     it('overrides properties automatically (this test should not warn)', function () {
         const MyGObjectInterface = new Lang.Interface({
             Name: 'MyGObjectInterface',
+            GTypeName: 'MyGObjectInterface',
             Requires: [GObject.Object],
             Properties: {
                 'foo': GObject.ParamSpec.boolean('foo', '', '',
@@ -140,6 +141,7 @@ describe('Syntactic sugar metaclass', function () {
     });
     const MyInitGObjectInterface = new Lang.Interface({
         Name: 'MyInitGObjectInterface',
+        GTypeName: 'MyInitGObjectInterface',
         Requires: [GObject.Object],
         _interface_init: function () {
             this.my_gobject_interface_inited = true;


### PR DESCRIPTION
This is a workaround for an issue where gjs on aarch64 crashes creating
a GObject interface without GTypeName:
<https://gitlab.gnome.org/GNOME/gjs/issues/307>