### PR TITLE
Replace deprecated GdkScreen get_width in PDFView

### DIFF
--- a/js/framework/widgets/PDFView.js
+++ b/js/framework/widgets/PDFView.js
@@ -391,9 +391,12 @@ var PDFView = new Knowledge.Class({
     },
 
     vfunc_get_preferred_width: function () {
-        let width = this.get_screen().get_width();
         let [minimal, ] = this.parent();
-        return [minimal, width];
+
+        let gdk_window = this.get_window();
+        let gdk_monitor = gdk_window.get_display().get_monitor_at_window(gdk_window);
+        let natural = gdk_monitor.get_geometry().width;
+
+        return [minimal, natural];
     }
 });
-


### PR DESCRIPTION
Instead of gdk_screen_get_width, we should use gdk_monitor_get_geometry.

https://phabricator.endlessm.com/T28284