### PR TITLE
Remove hard-coded icon theme setting

### DIFF
--- a/js/framework/application.js
+++ b/js/framework/application.js
@@ -347,9 +347,6 @@ var Application = new Knowledge.Class({
         }
 
         this._initialize_set_map();
-
-        let screen = Gdk.Screen.get_default();
-        Gtk.Settings.get_for_screen(screen).gtk_icon_theme_name = 'EndlessOS';
     },
 
     LoadItem: function (id, search_terms, timestamp) {

--- a/js/framework/articleHTMLRenderer.js
+++ b/js/framework/articleHTMLRenderer.js
@@ -187,7 +187,7 @@ var ArticleHTMLRenderer = new Knowledge.Class({
         }
 
         function get_button_markup (network) {
-            let markup = get_svg(`file:///usr/share/runtime/share/icons/EndlessOS/scalable/apps/${network}-symbolic.svg`);
+            let markup = get_svg(`file:///run/host/share/icons/EndlessOS/scalable/apps/${network}-symbolic.svg`);
 
             if (!markup)
                 markup = get_svg(`resource:///com/endlessm/knowledge/data/icons/scalable/apps/${network}-symbolic.svg`);

--- a/tools/picard.js
+++ b/tools/picard.js
@@ -101,7 +101,6 @@ function main () {
         Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION);
 
     Gtk.IconTheme.get_default().add_resource_path('/com/endlessm/knowledge/data/icons');
-    Gtk.Settings.get_for_screen(Gdk.Screen.get_default()).gtk_icon_theme_name = 'EndlessOS';
 
     build_ui();
     load_arrangement(widgets.arrangement_combo_box.get_active_text(), widgets.card_combo_box.get_active_text());


### PR DESCRIPTION
Now that we have removed a lot of custom CSS from the chrome around knowledge applications, I think it is reasonable to always use the system icon theme. As far as I can tell, there are no special EndlessOS-specific icons being used here, and I haven't noticed any problems with icons using the Adwaita theme. On Endless OS, applications will continue to use the system icon theme so this change won't have any effect.

https://phabricator.endlessm.com/T30537