### PR TITLE
Allow navigate to same page anchor links for non declared sections

### DIFF
--- a/js/framework/modules/view/document.js
+++ b/js/framework/modules/view/document.js
@@ -302,9 +302,12 @@ var Document = new Module.Class({
 
                 if (hash && !hash.startsWith(SCROLLED_PAST_PREFIX)) {
                     let index = this._find_section_index(hash);
-                    if (index !== -1)
+                    if (index !== -1) {
                         this._scroll_to_section(index);
-                    decision.ignore();
+                        decision.ignore();
+                    } else {
+                        decision.use();
+                    }
                 } else {
                     decision.use();
                 }


### PR DESCRIPTION
This allow same page anchor links (e.g. ending with #the-section) to
work even if the section is not declared in the article table of
content.

This is particularly useful for Wikipedia OpenZIM articles that
preserves references links and the references section of articles.