### PR TITLE
replace deprecated cdn domain

### DIFF
--- a/docs/framework/tutorial/shard.md
+++ b/docs/framework/tutorial/shard.md
@@ -110,7 +110,7 @@ The raw HTML for the paragraph with the missing image looks like this:
 ```html
 <p>
   <a href="https://www.eff.org/copyrightweek">
-    <img data-image-title="copyright_week_2018" data-image-description="" src="https://d15omoko64skxi.cloudfront.net/wp-content/uploads/2018/01/copyright_week_2018-1024x512.png" alt="" width="840" height="420" sizes="(max-width: 709px) 85vw, (max-width: 909px) 67vw, (max-width: 1362px) 62vw, 840px">
+    <img data-image-title="copyright_week_2018" data-image-description="" src="https://creativecommons.org/wp-content/uploads/2018/01/copyright_week_2018-1024x512.png" alt="" width="840" height="420" sizes="(max-width: 709px) 85vw, (max-width: 909px) 67vw, (max-width: 1362px) 62vw, 840px">
   </a>
   <i>
     <span>We’re taking part in </span>


### PR DESCRIPTION
Replace deprecated CDN domain (~~`d15omoko64skxi.cloudfront.net`~~) with correct domain (`creativecommons.org`)

Resulting URL works as expected:
```shell
curl -i 'https://creativecommons.org/wp-content/uploads/2018/01/copyright_week_2018-1024x512.png'
```
```
HTTP/2 200 
date: Mon, 23 May 2022 14:54:26 GMT
content-type: image/png
content-length: 33036
vary: Accept-Encoding
last-modified: Sat, 13 Jan 2018 01:01:05 GMT
etag: "e3c0a-810c-5629dea5e7640"
referrer-policy: 
x-varnish: 198920
age: 178
via: 1.1 varnish (Varnish/5.0)
strict-transport-security: max-age=15768000
x-content-type-options: nosniff
x-frame-options: deny
x-xss-protection: 1; mode=block
cache-control: max-age=432000
cf-cache-status: HIT
accept-ranges: bytes
expect-ct: max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
server: cloudflare
cf-ray: 70fea074bbee7a9f-LAX
```